### PR TITLE
Added Payout Support in SDK

### DIFF
--- a/src/main/java/com/checkout/payments/CardDestinationResponse.java
+++ b/src/main/java/com/checkout/payments/CardDestinationResponse.java
@@ -1,0 +1,131 @@
+package com.checkout.payments;
+
+public class CardDestinationResponse{
+	private String id;
+	private String type;
+	private String bin;
+	private String last4;
+	private int expiryMonth;
+	private int expiryYear;
+	private String scheme;
+	private String cardCategory;
+	private String cardType;
+	private String issuer;
+	private String issuerCountry;
+	private String productType;
+	private String productId;
+	private String fingerprint;
+
+	public void setLast4(String last4){
+		this.last4 = last4;
+	}
+
+	public String getLast4(){
+		return last4;
+	}
+
+	public void setScheme(String scheme){
+		this.scheme = scheme;
+	}
+
+	public String getScheme(){
+		return scheme;
+	}
+
+	public void setBin(String bin){
+		this.bin = bin;
+	}
+
+	public String getBin(){
+		return bin;
+	}
+
+	public void setCardCategory(String cardCategory){
+		this.cardCategory = cardCategory;
+	}
+
+	public String getCardCategory(){
+		return cardCategory;
+	}
+
+	public void setType(String type){
+		this.type = type;
+	}
+
+	public String getType(){
+		return type;
+	}
+
+	public void setCardType(String cardType){
+		this.cardType = cardType;
+	}
+
+	public String getCardType(){
+		return cardType;
+	}
+
+	public void setExpiryYear(int expiryYear){
+		this.expiryYear = expiryYear;
+	}
+
+	public int getExpiryYear(){
+		return expiryYear;
+	}
+
+	public void setIssuer(String issuer){
+		this.issuer = issuer;
+	}
+
+	public String getIssuer(){
+		return issuer;
+	}
+
+	public void setIssuerCountry(String issuerCountry){
+		this.issuerCountry = issuerCountry;
+	}
+
+	public String getIssuerCountry(){
+		return issuerCountry;
+	}
+
+	public void setExpiryMonth(int expiryMonth){
+		this.expiryMonth = expiryMonth;
+	}
+
+	public int getExpiryMonth(){
+		return expiryMonth;
+	}
+
+	public void setProductType(String productType){
+		this.productType = productType;
+	}
+
+	public String getProductType(){
+		return productType;
+	}
+
+	public void setProductId(String productId){
+		this.productId = productId;
+	}
+
+	public String getProductId(){
+		return productId;
+	}
+
+	public void setFingerprint(String fingerprint){
+		this.fingerprint = fingerprint;
+	}
+
+	public String getFingerprint(){
+		return fingerprint;
+	}
+
+	public void setId(String id){
+		this.id = id;
+	}
+
+	public String getId(){
+		return id;
+	}
+
+}

--- a/src/main/java/com/checkout/payments/CardSource.java
+++ b/src/main/java/com/checkout/payments/CardSource.java
@@ -10,6 +10,8 @@ public class CardSource implements RequestSource {
     private final int expiryMonth;
     private final int expiryYear;
     private String name;
+    private String firstName;
+    private String lastName;
     private String cvv;
     private Address billingAddress;
     private Phone phone;
@@ -76,5 +78,21 @@ public class CardSource implements RequestSource {
 
     public void setPhone(Phone phone) {
         this.phone = phone;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
     }
 }

--- a/src/main/java/com/checkout/payments/CardSource.java
+++ b/src/main/java/com/checkout/payments/CardSource.java
@@ -52,6 +52,12 @@ public class CardSource implements RequestSource {
         return name;
     }
 
+    /**
+     * Set the full name of a payin card source object.
+     * When using card as a payout destination you should use
+     * {@link #setFirstName(String)} and {@link #setLastName(String)}
+     * @param name the full name of the source card holder
+     */
     public void setName(String name) {
         this.name = name;
     }
@@ -84,6 +90,11 @@ public class CardSource implements RequestSource {
         return firstName;
     }
 
+    /**
+     * Set the first name of a payout card destination object.
+     * When using card as a payin source you should use {@link #setName(String)}
+     * @param firstName the first name of the destination card holder
+     */
     public void setFirstName(String firstName) {
         this.firstName = firstName;
     }
@@ -92,6 +103,11 @@ public class CardSource implements RequestSource {
         return lastName;
     }
 
+    /**
+     * Set the last name of a payout card destination object.
+     * When using card as a payin source you should use {@link #setName(String)}
+     * @param lastName the last name of the destination card holder
+     */
     public void setLastName(String lastName) {
         this.lastName = lastName;
     }

--- a/src/main/java/com/checkout/payments/PaymentProcessed.java
+++ b/src/main/java/com/checkout/payments/PaymentProcessed.java
@@ -20,6 +20,7 @@ public class PaymentProcessed extends Resource {
     private ThreeDSEnrollment threeDS;
     private RiskAssessment risk;
     private ResponseSource source;
+    private CardDestinationResponse destination;
     private CustomerResponse customer;
     private Instant processedOn;
     private String reference;
@@ -171,5 +172,13 @@ public class PaymentProcessed extends Resource {
 
     public Link getVoidLink() {
         return getLink("void");
+    }
+
+    public CardDestinationResponse getDestination() {
+        return destination;
+    }
+
+    public void setDestination(CardDestinationResponse destination) {
+        this.destination = destination;
     }
 }

--- a/src/main/java/com/checkout/payments/PaymentRequest.java
+++ b/src/main/java/com/checkout/payments/PaymentRequest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 public class PaymentRequest<T extends RequestSource> {
     private final T source;
+    private final T destination;
     private final Integer amount;
     private final String currency;
     private String paymentType;
@@ -29,9 +30,14 @@ public class PaymentRequest<T extends RequestSource> {
     private PaymentRecipient recipient;
     private Map<String, Object> metadata = new HashMap<>();
 
+    @Deprecated
     public PaymentRequest(T source, String currency, Integer amount) {
-        if (source == null) {
-            throw new IllegalArgumentException("The payment source is required.");
+        this(source, currency, amount, true);
+    }
+
+    private PaymentRequest(T sourceOrDestination, String currency, Integer amount, boolean isSource) {
+        if (sourceOrDestination == null) {
+            throw new IllegalArgumentException(String.format("The payment %s is required.", isSource ? "source" : "destination"));
         }
         if (CheckoutUtils.isNullOrWhitespace(currency)) {
             throw new IllegalArgumentException("The currency is required.");
@@ -39,13 +45,26 @@ public class PaymentRequest<T extends RequestSource> {
         if (amount != null && amount < 0) {
             throw new IllegalArgumentException("The amount cannot be negative");
         }
-        this.source = source;
+        this.source = isSource? sourceOrDestination : null;
+        this.destination = isSource ? null :  sourceOrDestination;
         this.amount = amount;
         this.currency = currency;
     }
 
+    public static <T extends RequestSource> PaymentRequest<T> fromSource(T source, String currency, Integer amount) {
+        return new PaymentRequest<>(source, currency, amount, true);
+    }
+
+    public static <T extends RequestSource> PaymentRequest<T> fromDestination(T destination, String currency, Integer amount) {
+        return new PaymentRequest<>(destination, currency, amount, false);
+    }
+
     public T getSource() {
         return source;
+    }
+
+    public T getDestination() {
+        return destination;
     }
 
     public Integer getAmount() {

--- a/src/main/java/com/checkout/payments/PaymentRequest.java
+++ b/src/main/java/com/checkout/payments/PaymentRequest.java
@@ -30,11 +30,6 @@ public class PaymentRequest<T extends RequestSource> {
     private PaymentRecipient recipient;
     private Map<String, Object> metadata = new HashMap<>();
 
-    @Deprecated
-    public PaymentRequest(T source, String currency, Integer amount) {
-        this(source, currency, amount, true);
-    }
-
     private PaymentRequest(T sourceOrDestination, String currency, Integer amount, boolean isSource) {
         if (sourceOrDestination == null) {
             throw new IllegalArgumentException(String.format("The payment %s is required.", isSource ? "source" : "destination"));

--- a/src/test/java/com/checkout/TestHelper.java
+++ b/src/test/java/com/checkout/TestHelper.java
@@ -11,6 +11,18 @@ public class TestHelper {
         return createCardPaymentRequest(100);
     }
 
+    public static PaymentRequest<CardSource> createCardPayoutRequest() {
+        CardSource cardSource = new CardSource(TestCardSource.VISA.getNumber(), TestCardSource.VISA.getExpiryMonth(), TestCardSource.VISA.getExpiryYear());
+        cardSource.setFirstName("John");
+        cardSource.setLastName("Doe");
+
+
+        PaymentRequest<CardSource> request = PaymentRequest.fromDestination(cardSource, Currency.GBP, 100);
+        request.setReference(UUID.randomUUID().toString());
+
+        return request;
+    }
+
     public static PaymentRequest<CardSource> createCardPaymentRequest(Integer amount) {
         CardSource cardSource = new CardSource(TestCardSource.VISA.getNumber(), TestCardSource.VISA.getExpiryMonth(), TestCardSource.VISA.getExpiryYear());
         cardSource.setCvv(TestCardSource.VISA.getCvv());
@@ -18,7 +30,7 @@ public class TestHelper {
         CustomerRequest customer = new CustomerRequest();
         customer.setEmail(generateRandomEmail());
 
-        PaymentRequest<CardSource> request = new PaymentRequest<>(cardSource, Currency.GBP, amount);
+        PaymentRequest<CardSource> request = PaymentRequest.fromSource(cardSource, Currency.GBP, amount);
         request.setCapture(false);
         request.setCustomer(customer);
         request.setReference(UUID.randomUUID().toString());
@@ -34,7 +46,7 @@ public class TestHelper {
         CustomerRequest customer = new CustomerRequest();
         customer.setEmail(generateRandomEmail());
 
-        PaymentRequest<RequestSource> request = new PaymentRequest<>(alternativePaymentMethodRequestSource, currency, amount);
+        PaymentRequest<RequestSource> request = PaymentRequest.fromSource(alternativePaymentMethodRequestSource, currency, amount);
         request.setCapture(false);
         request.setReference(UUID.randomUUID().toString());
         request.setCustomer(customer);
@@ -53,7 +65,7 @@ public class TestHelper {
     }
 
     public static PaymentRequest<TokenSource> createTokenPaymentRequest(String token) {
-        PaymentRequest<TokenSource> request = new PaymentRequest<>(new TokenSource(token), Currency.GBP, 100);
+        PaymentRequest<TokenSource> request = PaymentRequest.fromSource(new TokenSource(token), Currency.GBP, 100);
         request.setCapture(false);
         return request;
     }

--- a/src/test/java/com/checkout/payments/AlternativePaymentSourcePaymentsTests.java
+++ b/src/test/java/com/checkout/payments/AlternativePaymentSourcePaymentsTests.java
@@ -79,7 +79,7 @@ public class AlternativePaymentSourcePaymentsTests extends ApiTestFixture {
         alternativePaymentSource.put("billing_address", billingAddress);
         alternativePaymentSource.put("products", products);
 
-        PaymentRequest<AlternativePaymentSource> paymentRequest = new PaymentRequest<>(alternativePaymentSource, Currency.GBP, 1000);
+        PaymentRequest<AlternativePaymentSource> paymentRequest = PaymentRequest.fromSource(alternativePaymentSource, Currency.GBP, 1000);
         paymentRequest.setCapture(false);
         paymentRequest.setThreeDS(ThreeDSRequest.from(false));
         paymentRequest.setReference(UUID.randomUUID().toString());

--- a/src/test/java/com/checkout/payments/CardDestinationPaymentTests.java
+++ b/src/test/java/com/checkout/payments/CardDestinationPaymentTests.java
@@ -1,0 +1,31 @@
+package com.checkout.payments;
+
+import com.checkout.ApiTestFixture;
+import com.checkout.TestHelper;
+import com.checkout.common.CheckoutUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CardDestinationPaymentTests extends ApiTestFixture {
+	@Test
+	public void can_perform_card_payout() throws Exception {
+		PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPayoutRequest();
+		PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+
+		Assert.assertNotNull(paymentResponse.getPayment());
+		Assert.assertTrue(paymentResponse.getPayment().isApproved());
+		Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getId()));
+		Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getActionId()));
+		Assert.assertEquals(paymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
+		Assert.assertEquals(paymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
+		Assert.assertEquals(paymentRequest.getReference(), paymentResponse.getPayment().getReference());
+		Assert.assertNotNull(paymentResponse.getPayment().getDestination());
+		Assert.assertEquals(paymentResponse.getPayment().getDestination().getBin(), paymentRequest.getDestination().getNumber().substring(0, 6));
+		Assert.assertEquals(
+				paymentResponse.getPayment().getDestination().getLast4(),
+				paymentRequest.getDestination().getNumber().substring(paymentRequest.getDestination().getNumber().length() - 4));
+		Assert.assertEquals(paymentRequest.getDestination().getType(), paymentResponse.getPayment().getDestination().getType());
+		Assert.assertEquals(paymentRequest.getDestination().getExpiryMonth(), paymentResponse.getPayment().getDestination().getExpiryMonth());
+		Assert.assertEquals(paymentRequest.getDestination().getExpiryYear(), paymentResponse.getPayment().getDestination().getExpiryYear());
+	}
+}

--- a/src/test/java/com/checkout/payments/CustomerSourcePaymentsTests.java
+++ b/src/test/java/com/checkout/payments/CustomerSourcePaymentsTests.java
@@ -14,7 +14,7 @@ public class CustomerSourcePaymentsTests extends ApiTestFixture {
         PaymentRequest<CardSource> firstCardPayment = TestHelper.createCardPaymentRequest();
         PaymentResponse firstCardPaymentResponse = getApi().paymentsClient().requestAsync(firstCardPayment).get();
         CustomerSource customerSource = new CustomerSource(firstCardPayment.getCustomer().getId(), firstCardPayment.getCustomer().getEmail());
-        PaymentRequest<CustomerSource> customerPaymentRequest = new PaymentRequest<>(customerSource, Currency.GBP, 100);
+        PaymentRequest<CustomerSource> customerPaymentRequest = PaymentRequest.fromSource(customerSource, Currency.GBP, 100);
         customerPaymentRequest.setCapture(false);
 
         PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(customerPaymentRequest).get();

--- a/src/test/java/com/checkout/payments/IdSourcePaymentsTests.java
+++ b/src/test/java/com/checkout/payments/IdSourcePaymentsTests.java
@@ -16,7 +16,7 @@ public class IdSourcePaymentsTests extends ApiTestFixture {
         PaymentResponse firstCardPaymentResponse = getApi().paymentsClient().requestAsync(firstCardPayment).get();
 
         IdSource idSource = new IdSource(((CardSourceResponse) firstCardPaymentResponse.getPayment().getSource()).getId());
-        PaymentRequest<IdSource> cardIdPaymentRequest = new PaymentRequest<>(idSource, Currency.GBP, 100);
+        PaymentRequest<IdSource> cardIdPaymentRequest = PaymentRequest.fromSource(idSource, Currency.GBP, 100);
         cardIdPaymentRequest.setCapture(false);
         cardIdPaymentRequest.setCustomer(toRequest(firstCardPaymentResponse.getPayment().getCustomer()));
 


### PR DESCRIPTION
The idea is to add payout support in the SDK.

Making this was pretty simple:
- Changing the `PaymentRequest` class to add a `destination` field. This include changing the constructor and adding some new static builder while deprecating the old public constructor. If you think you want to keep this public constructor, I can still remove the `@Deprecated`
- Adding a new `CardDestinationResponse` POJO. There was no similar existing objects
- Adding this object as `destination` of the `PaymentProcessed` response object
- Adding proper tests for those additions
- Moving the tests using the deprecated constructor to the new static builder.