### PR TITLE
Get the correct version from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ javadoc {
 jar {
     manifest {
         attributes'Implementation-Title': 'checkout-sdk-java',
-                'Implementation-Version': archiveVersion
+                'Implementation-Version': archiveVersion.get()
     }
 }
 

--- a/samples/spring/src/main/java/com/checkout/sample/spring/CheckoutConfig.java
+++ b/samples/spring/src/main/java/com/checkout/sample/spring/CheckoutConfig.java
@@ -3,8 +3,10 @@ package com.checkout.sample.spring;
 import com.checkout.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+@Configuration
 public class CheckoutConfig {
     @Value("checkout.secretKey")
     private String secretKey;

--- a/src/main/java/com/checkout/common/CheckoutUtils.java
+++ b/src/main/java/com/checkout/common/CheckoutUtils.java
@@ -10,7 +10,7 @@ public class CheckoutUtils {
     }
 
     public static String getVersionFromManifest() {
-        return CheckoutUtils.class.getPackage().getSpecificationVersion();
+        return CheckoutUtils.class.getPackage().getImplementationVersion();
     }
 
     public static boolean isSuccessHttpStatusCode(int httpStatusCode) {


### PR DESCRIPTION
This should make sure the jar manifest has the version written into it at build time, and that it is used in the user-agent header to the Checkout APIs.