### PR TITLE
added stored field to support stored card details requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The jar, javadoc, and sources are all available from Maven Central. You can impo
 Gradle
 ```groovy
 dependencies {
-    implementation 'com.checkout:checkout-sdk-java:2.3.1'
+    implementation 'com.checkout:checkout-sdk-java:2.3.2'
 }
 ```
 Maven
@@ -21,7 +21,7 @@ Maven
 <dependency>
     <groupId>com.checkout</groupId>
     <artifactId>checkout-sdk-java</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
 </dependency>
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.checkout
-version=2.3.1-SNAPSHOT
+version=2.3.2-SNAPSHOT
 
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/

--- a/src/main/java/com/checkout/payments/CardSource.java
+++ b/src/main/java/com/checkout/payments/CardSource.java
@@ -22,6 +22,7 @@ public class CardSource implements RequestSource {
     private String cvv;
     private Address billingAddress;
     private Phone phone;
+    private boolean stored;
 
     public CardSource(String number, int expiryMonth, int expiryYear) {
         if (CheckoutUtils.isNullOrWhitespace(number)) {

--- a/src/test/java/com/checkout/payments/CardSourcePaymentsTests.java
+++ b/src/test/java/com/checkout/payments/CardSourcePaymentsTests.java
@@ -29,6 +29,7 @@ public class CardSourcePaymentsTests extends ApiTestFixture {
         Assert.assertTrue(paymentResponse.getPayment().canCapture());
         Assert.assertTrue(paymentResponse.getPayment().canVoid());
         Assert.assertNotNull(paymentResponse.getPayment().getSource());
+        Assert.assertFalse(paymentRequest.getSource().isStored());
     }
 
     @Test


### PR DESCRIPTION
added stored field to support [stored card details](https://docs.checkout.com/quickstart/use-an-existing-card/stored-card-details) requirements