### PR TITLE
Add info about 'metadata' to payments.md

### DIFF
--- a/documentation/docs/payments.md
+++ b/documentation/docs/payments.md
@@ -31,6 +31,17 @@ PaymentRequest<TokenSource> paymentRequest =
 paymentRequest.setCustomer(customer);
 paymentRequest.setReference("ORD-123");
 
+// Optionally, pass arbitrary metadata. Checkout will pass that metadata to the `payment_captured` webhook if the payment succeeds.
+HashMap metadata = new HashMap<String, Object>();
+metadata.put("my_custom_key", "my_custom_value"); 
+// .. other custom field you wish to receie in a webhook
+paymentRequest.setMetadata(metadata);
+
+// Optionally, a custom success and failure url can be passed (for cases where 3DS is invoked)
+paymentRequest.setSuccessUrl("https://my-website.com/some-page/success");
+paymentRequest.setFailureUrl("https://my-website.com/some-page/failure");
+
+
 PaymentResponse response = api.paymentsClient().requestAsync(paymentRequest).get();
 ```
 

--- a/documentation/docs/payments.md
+++ b/documentation/docs/payments.md
@@ -211,9 +211,9 @@ try {
 
   if (response.isPending()) {
     // Local/3DS payment. Redirect the customer to payment.getPending().getRedirectLink()
-  } else if (response.getPayment().isApproved() && !response.getPayment().getRisk()) {
+  } else if (response.getPayment().isApproved() && !response.getPayment().getRisk().isFlagged()) {
     // The payment was successful and not flagged by any risk rule
-  } else if (response.getPayment().isApproved() && response.getPayment().getRisk()) {
+  } else if (response.getPayment().isApproved() && response.getPayment().getRisk().isFlagged()) {
     /* The payment was successful but it was flagged by a risk rule;
        this means you need to manually decide if you want to capture it or void it */
   } else if (!response.getPayment().isApproved()) {


### PR DESCRIPTION
Hi all,
I am the CTO of DriveTribe. We started integrating with you last week. I would like to contribute a few bits to your docs I wish existed before we started this.
- The `setMetadata` method in `paymentRequest` is the most important there is and I discovered it by chance looking at the source code. For apps integrating with you, the existence of `setMetadata` means they don't have to cache/store intermediate state to resolve the webhook data to the transaction data. This actually makes a HUGE difference to the architecture. Everyone coming from Stripe will be looking for this.
- Ditto for successUrl and failureUrl. Most apps would like to redirect the user to the same page they were and just ask them to use a different card (rather than the default homepage)

Please let me know if you think this is not useful. 
Thanks