### PR TITLE
Expose the instrument fingerprint in the Create Instrument response

### DIFF
--- a/src/main/java/com/checkout/instruments/CreateInstrumentResponse.java
+++ b/src/main/java/com/checkout/instruments/CreateInstrumentResponse.java
@@ -19,4 +19,5 @@ public class CreateInstrumentResponse {
     private String issuerCountry;
     private String productId;
     private String productType;
+    private String fingerprint;
 }

--- a/src/test/java/com/checkout/instruments/InstrumentsTests.java
+++ b/src/test/java/com/checkout/instruments/InstrumentsTests.java
@@ -36,6 +36,7 @@ public class InstrumentsTests extends SandboxTestFixture {
         Assert.assertNotNull(response.getIssuerCountry());
         Assert.assertNotNull(response.getProductId());
         Assert.assertNotNull(response.getProductType());
+        Assert.assertNotNull(response.getFingerprint());
     }
 
     @Test
@@ -64,6 +65,7 @@ public class InstrumentsTests extends SandboxTestFixture {
         Assert.assertEquals(createInstrumentResponse.getCardCategory(), instrument.getCardCategory());
         Assert.assertEquals(createInstrumentResponse.getIssuer(), instrument.getIssuer());
         Assert.assertEquals(createInstrumentResponse.getIssuerCountry(), instrument.getIssuerCountry());
+        Assert.assertEquals(createInstrumentResponse.getFingerprint(), instrument.getFingerprint());
         Assert.assertNotNull(instrument.getFingerprint());
         Assert.assertNotNull(instrument.getAccountHolder());
         Assert.assertNotNull(instrument.getAccountHolder().getBillingAddress());


### PR DESCRIPTION
I've exposed another bit of information in the Create Instrument response.

Please let me know if this is ok.