### PR TITLE
Re-implement customer operations (CS2)

### DIFF
--- a/src/main/java/com/checkout/GsonSerializer.java
+++ b/src/main/java/com/checkout/GsonSerializer.java
@@ -35,6 +35,10 @@ public class GsonSerializer implements Serializer {
                     Instant.parse(json.getAsString()))
             .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(ResponseSource.class, "type", true, AlternativePaymentSourceResponse.class)
                     .registerSubtype(CardSourceResponse.class, CardSource.TYPE_NAME))
+            // TODO Re-enable for customer instruments when related functionality is implemented for CS2
+            //.registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(CustomerInstrument.class)
+            //        .registerSubtype(CustomerBankAccountInstrument.class)
+            //        .registerSubtype(CustomerCardInstrument.class))
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .create();
 

--- a/src/main/java/com/checkout/beta/CheckoutApi.java
+++ b/src/main/java/com/checkout/beta/CheckoutApi.java
@@ -1,5 +1,6 @@
 package com.checkout.beta;
 
+import com.checkout.customers.beta.CustomersClient;
 import com.checkout.payments.beta.PaymentsClient;
 import com.checkout.tokens.beta.TokensClient;
 
@@ -8,5 +9,7 @@ public interface CheckoutApi {
     TokensClient tokensClient();
 
     PaymentsClient paymentsClient();
+
+    CustomersClient customersClient();
 
 }

--- a/src/main/java/com/checkout/beta/CheckoutApiImpl.java
+++ b/src/main/java/com/checkout/beta/CheckoutApiImpl.java
@@ -2,6 +2,8 @@ package com.checkout.beta;
 
 import com.checkout.ApiClient;
 import com.checkout.CheckoutConfiguration;
+import com.checkout.customers.beta.CustomersClient;
+import com.checkout.customers.beta.CustomersClientImpl;
 import com.checkout.payments.beta.PaymentsClient;
 import com.checkout.payments.beta.PaymentsClientImpl;
 import com.checkout.tokens.beta.TokensClient;
@@ -11,10 +13,12 @@ public final class CheckoutApiImpl implements CheckoutApi {
 
     private final TokensClient tokensClient;
     private final PaymentsClient paymentsClient;
+    private final CustomersClient customersClient;
 
     public CheckoutApiImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
         this.tokensClient = new TokensClientImpl(apiClient, configuration);
         this.paymentsClient = new PaymentsClientImpl(apiClient, configuration);
+        this.customersClient = new CustomersClientImpl(apiClient, configuration);
     }
 
     @Override
@@ -25,6 +29,11 @@ public final class CheckoutApiImpl implements CheckoutApi {
     @Override
     public PaymentsClient paymentsClient() {
         return paymentsClient;
+    }
+
+    @Override
+    public CustomersClient customersClient() {
+        return customersClient;
     }
 
 }

--- a/src/main/java/com/checkout/common/beta/BankDetails.java
+++ b/src/main/java/com/checkout/common/beta/BankDetails.java
@@ -1,0 +1,14 @@
+package com.checkout.common.beta;
+
+import lombok.Data;
+
+@Data
+public final class BankDetails {
+
+    private String name;
+
+    private String branch;
+
+    private Address address;
+
+}

--- a/src/main/java/com/checkout/common/beta/IdResponse.java
+++ b/src/main/java/com/checkout/common/beta/IdResponse.java
@@ -1,0 +1,10 @@
+package com.checkout.common.beta;
+
+import lombok.Data;
+
+@Data
+public final class IdResponse {
+
+    private String id;
+
+}

--- a/src/main/java/com/checkout/customers/beta/CustomerRequest.java
+++ b/src/main/java/com/checkout/customers/beta/CustomerRequest.java
@@ -1,0 +1,26 @@
+package com.checkout.customers.beta;
+
+import com.checkout.common.beta.Phone;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+public final class CustomerRequest {
+
+    @NotEmpty
+    private String email;
+
+    private String name;
+
+    private Phone phone;
+
+    private Map<String, Object> metadata;
+
+    private List<String> instruments;
+
+}

--- a/src/main/java/com/checkout/customers/beta/CustomerResponse.java
+++ b/src/main/java/com/checkout/customers/beta/CustomerResponse.java
@@ -1,0 +1,27 @@
+package com.checkout.customers.beta;
+
+import com.checkout.common.beta.Phone;
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@Builder
+public final class CustomerResponse {
+
+    private String id;
+
+    private String email;
+
+    @SerializedName("default")
+    private String defaultId;
+
+    private String name;
+
+    private Phone phone;
+
+    private Map<String, Object> metadata;
+
+}

--- a/src/main/java/com/checkout/customers/beta/CustomersClient.java
+++ b/src/main/java/com/checkout/customers/beta/CustomersClient.java
@@ -1,0 +1,17 @@
+package com.checkout.customers.beta;
+
+import com.checkout.common.beta.IdResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface CustomersClient {
+
+    CompletableFuture<CustomerResponse> get(String customerId);
+
+    CompletableFuture<IdResponse> create(CustomerRequest customerRequest);
+
+    CompletableFuture<Void> update(String customerId, CustomerRequest customerRequest);
+
+    CompletableFuture<Void> delete(String customerId);
+
+}

--- a/src/main/java/com/checkout/customers/beta/CustomersClientImpl.java
+++ b/src/main/java/com/checkout/customers/beta/CustomersClientImpl.java
@@ -1,0 +1,43 @@
+package com.checkout.customers.beta;
+
+import com.checkout.AbstractClient;
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SecretKeyCredentials;
+import com.checkout.common.beta.IdResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+public class CustomersClientImpl extends AbstractClient implements CustomersClient {
+
+    public static final String CUSTOMERS_PATH = "/customers";
+
+    public CustomersClientImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
+        super(apiClient, SecretKeyCredentials.fromConfiguration(configuration));
+    }
+
+    @Override
+    public CompletableFuture<CustomerResponse> get(final String customerId) {
+        return apiClient.getAsync(getCustomersUrl(customerId), apiCredentials, CustomerResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<IdResponse> create(final CustomerRequest customerRequest) {
+        return apiClient.postAsync(CUSTOMERS_PATH, apiCredentials, IdResponse.class, customerRequest, null);
+    }
+
+    @Override
+    public CompletableFuture<Void> update(final String customerId, final CustomerRequest customerRequest) {
+        return apiClient.patchAsync(getCustomersUrl(customerId), apiCredentials, Void.class, customerRequest, null);
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(final String customerId) {
+        return apiClient.deleteAsync(getCustomersUrl(customerId), apiCredentials);
+    }
+
+    private String getCustomersUrl(final String customerId) {
+        return CUSTOMERS_PATH + "/" + customerId;
+    }
+
+}

--- a/src/main/java/com/checkout/customers/beta/instrument/AccountHolder.java
+++ b/src/main/java/com/checkout/customers/beta/instrument/AccountHolder.java
@@ -1,0 +1,20 @@
+package com.checkout.customers.beta.instrument;
+
+import com.checkout.common.beta.Address;
+import com.checkout.common.beta.Phone;
+import com.google.gson.annotations.SerializedName;
+
+public class AccountHolder {
+
+    @SerializedName("first_name")
+    private String firstName;
+
+    @SerializedName("last_name")
+    private String lastName;
+
+    @SerializedName("billing_address")
+    private Address billingAddress;
+
+    private Phone phone;
+
+}

--- a/src/main/java/com/checkout/customers/beta/instrument/AccountType.java
+++ b/src/main/java/com/checkout/customers/beta/instrument/AccountType.java
@@ -1,0 +1,14 @@
+package com.checkout.customers.beta.instrument;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum AccountType {
+
+    @SerializedName("savings")
+    SAVINGS,
+    @SerializedName("current")
+    CURRENT,
+    @SerializedName("cash")
+    CASH
+
+}

--- a/src/main/java/com/checkout/customers/beta/instrument/CustomerBankAccountInstrument.java
+++ b/src/main/java/com/checkout/customers/beta/instrument/CustomerBankAccountInstrument.java
@@ -1,0 +1,47 @@
+package com.checkout.customers.beta.instrument;
+
+import com.checkout.common.beta.BankDetails;
+import com.checkout.common.beta.Currency;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class CustomerBankAccountInstrument extends CustomerInstrument {
+
+    private final String id;
+
+    private final String fingerprint;
+
+    @SerializedName("account_type")
+    private final AccountType accountType;
+
+    @SerializedName("account_number")
+    private final String accountNumber;
+
+    @SerializedName("bank_code")
+    private final String bankCode;
+
+    @SerializedName("branch_code")
+    private final String branchCode;
+
+    private final String iban;
+
+    private final String bban;
+
+    @SerializedName("swift_bic")
+    private final String swiftBic;
+
+    private final Currency currency;
+
+    private final String country;
+
+    @SerializedName("account_holder")
+    private final AccountHolder accountHolder;
+
+    private final BankDetails bank;
+
+}

--- a/src/main/java/com/checkout/customers/beta/instrument/CustomerCardInstrument.java
+++ b/src/main/java/com/checkout/customers/beta/instrument/CustomerCardInstrument.java
@@ -1,0 +1,50 @@
+package com.checkout.customers.beta.instrument;
+
+import com.checkout.common.beta.CardCategory;
+import com.checkout.common.beta.CardType;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class CustomerCardInstrument extends CustomerInstrument {
+
+    private final String id;
+
+    private final String fingerprint;
+
+    @SerializedName("expiry_month")
+    private final Integer expiryMonth;
+
+    @SerializedName("expiry_year")
+    private final Integer expiryYear;
+
+    private final String scheme;
+
+    private final String last4;
+
+    private final String bin;
+
+    @SerializedName("card_type")
+    private final CardType cardType;
+
+    @SerializedName("card_category")
+    private final CardCategory cardCategory;
+
+    private final String issuer;
+
+    @SerializedName("issuer_country")
+    private final String issuerCountry;
+
+    @SerializedName("product_id")
+    private final String productId;
+
+    @SerializedName("product_type")
+    private final String productType;
+
+    private final AccountHolder accountHolder;
+
+}

--- a/src/main/java/com/checkout/customers/beta/instrument/CustomerInstrument.java
+++ b/src/main/java/com/checkout/customers/beta/instrument/CustomerInstrument.java
@@ -1,0 +1,10 @@
+package com.checkout.customers.beta.instrument;
+
+import lombok.Data;
+
+@Data
+public class CustomerInstrument {
+
+    private CustomerInstrumentType type;
+
+}

--- a/src/main/java/com/checkout/customers/beta/instrument/CustomerInstrumentType.java
+++ b/src/main/java/com/checkout/customers/beta/instrument/CustomerInstrumentType.java
@@ -1,0 +1,12 @@
+package com.checkout.customers.beta.instrument;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum CustomerInstrumentType {
+
+    @SerializedName("card")
+    CARD,
+    @SerializedName("bank_account")
+    BANK_ACCOUNT,
+
+}

--- a/src/test/java/com/checkout/beta/TestHelper.java
+++ b/src/test/java/com/checkout/beta/TestHelper.java
@@ -3,6 +3,8 @@ package com.checkout.beta;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.Environment;
 
+import java.util.UUID;
+
 public class TestHelper {
 
     public static final String VALID_CLASSIC_SK = "sk_test_fde517a8-3f01-41ef-b4bd-4282384b0a64";
@@ -20,6 +22,10 @@ public class TestHelper {
 
     public static CheckoutConfiguration mockFourConfiguration() {
         return new CheckoutConfiguration(VALID_FOUR_PK, VALID_FOUR_SK, Environment.SANDBOX);
+    }
+
+    public static String getRandomEmail() {
+        return UUID.randomUUID().toString() + "@checkout-sdk-java.com";
     }
 
 }

--- a/src/test/java/com/checkout/customers/beta/CustomersClientImplTest.java
+++ b/src/test/java/com/checkout/customers/beta/CustomersClientImplTest.java
@@ -1,0 +1,169 @@
+package com.checkout.customers.beta;
+
+import com.checkout.ApiClient;
+import com.checkout.ApiCredentials;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.CheckoutResourceNotFoundException;
+import com.checkout.beta.TestHelper;
+import com.checkout.common.beta.IdResponse;
+import com.checkout.common.beta.Phone;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CustomersClientImplTest {
+
+    private static final String CUSTOMER_ID = "cus_123456789abcdefgh";
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private CheckoutConfiguration configuration;
+
+    @Mock
+    private CustomerResponse customerResponse;
+
+    @Mock
+    private IdResponse idResponse;
+
+    @Mock
+    private Void voidResponse;
+
+    @Mock
+    private CompletableFuture<CustomerResponse> customerResponseAsync;
+
+    @Mock
+    private CompletableFuture<IdResponse> idAsync;
+
+    @Mock
+    private CompletableFuture<Void> voidAsync;
+
+    private CustomersClient client;
+
+    @Before
+    public void setUp() {
+        when(idResponse.getId()).thenReturn(CUSTOMER_ID);
+        idAsync = CompletableFuture.completedFuture(idResponse);
+        customerResponseAsync = CompletableFuture.completedFuture(customerResponse);
+        voidAsync = CompletableFuture.completedFuture(voidResponse);
+        client = new CustomersClientImpl(apiClient, configuration);
+    }
+
+    @Test
+    public void shouldCreateAndGetCustomer() throws ExecutionException, InterruptedException {
+        doReturn(idAsync)
+                .when(apiClient).postAsync(eq(CustomersClientImpl.CUSTOMERS_PATH), any(ApiCredentials.class),
+                eq(IdResponse.class), any(CustomerRequest.class), any());
+        doReturn(customerResponseAsync)
+                .when(apiClient)
+                .getAsync(eq(CustomersClientImpl.CUSTOMERS_PATH + "/" + CUSTOMER_ID), any(ApiCredentials.class),
+                        eq(CustomerResponse.class));
+        final CustomerRequest customerRequest = CustomerRequest.builder()
+                .email(TestHelper.getRandomEmail())
+                .name("Armando Ibarra")
+                .phone(Phone.builder()
+                        .countryCode("65")
+                        .number("765432323")
+                        .build())
+                .build();
+        when(customerResponse.getEmail()).thenReturn(customerRequest.getEmail());
+        when(customerResponse.getName()).thenReturn(customerRequest.getName());
+        when(customerResponse.getPhone()).thenReturn(customerRequest.getPhone());
+        final String customerId = client.create(customerRequest).get().getId();
+        assertNotNull(customerId);
+        final CustomerResponse customerResponse = client.get(customerId).get();
+        assertNotNull(customerResponse);
+        assertEquals(customerRequest.getEmail(), customerResponse.getEmail());
+        assertEquals(customerRequest.getName(), customerResponse.getName());
+        assertEquals(customerRequest.getPhone(), customerResponse.getPhone());
+        assertNull(customerResponse.getDefaultId());
+    }
+
+    @Test
+    public void shouldCreateAndUpdateCustomer() throws ExecutionException, InterruptedException {
+        doReturn(idAsync)
+                .when(apiClient).postAsync(eq(CustomersClientImpl.CUSTOMERS_PATH), any(ApiCredentials.class),
+                eq(IdResponse.class), any(CustomerRequest.class), any());
+        doReturn(customerResponseAsync)
+                .when(apiClient)
+                .getAsync(eq(CustomersClientImpl.CUSTOMERS_PATH + "/" + CUSTOMER_ID), any(ApiCredentials.class),
+                        eq(CustomerResponse.class));
+        doReturn(voidAsync)
+                .when(apiClient)
+                .patchAsync(eq(CustomersClientImpl.CUSTOMERS_PATH + "/" + CUSTOMER_ID), any(ApiCredentials.class),
+                        eq(Void.class), any(CustomerRequest.class), any());
+        //Create Customer
+        final CustomerRequest customerRequest = CustomerRequest.builder()
+                .email(TestHelper.getRandomEmail())
+                .name("Armando Ibarra")
+                .phone(Phone.builder()
+                        .countryCode("3")
+                        .number("3455235233")
+                        .build())
+                .build();
+        final String customerId = client.create(customerRequest).get().getId();
+        assertNotNull(customerId);
+        //Update Customer
+        customerRequest.setEmail(TestHelper.getRandomEmail());
+        customerRequest.setName("Armando Changed");
+        when(customerResponse.getEmail()).thenReturn(customerRequest.getEmail());
+        when(customerResponse.getName()).thenReturn(customerRequest.getName());
+        client.update(customerId, customerRequest).get();
+        //Verify changes were applied
+        final CustomerResponse customerDetailsResponse = client.get(customerId).get();
+        assertNotNull(customerDetailsResponse);
+        assertEquals(customerRequest.getName(), customerDetailsResponse.getName());
+        assertEquals(customerRequest.getEmail(), customerDetailsResponse.getEmail());
+    }
+
+    @Test
+    public void shouldCreateAndEditCustomer() throws ExecutionException, InterruptedException {
+        doReturn(idAsync)
+                .when(apiClient).postAsync(eq(CustomersClientImpl.CUSTOMERS_PATH), any(ApiCredentials.class),
+                eq(IdResponse.class), any(CustomerRequest.class), any());
+        doThrow(new CheckoutResourceNotFoundException("Customer not found"))
+                .when(apiClient)
+                .getAsync(eq(CustomersClientImpl.CUSTOMERS_PATH + "/" + CUSTOMER_ID), any(ApiCredentials.class),
+                        eq(CustomerResponse.class));
+        doReturn(voidAsync)
+                .when(apiClient)
+                .deleteAsync(eq(CustomersClientImpl.CUSTOMERS_PATH + "/" + CUSTOMER_ID), any(ApiCredentials.class));
+        //Create Customer
+        final CustomerRequest customerRequest = CustomerRequest.builder()
+                .email(TestHelper.getRandomEmail())
+                .name("Armando Ibarra")
+                .phone(Phone.builder()
+                        .countryCode("3")
+                        .number("3455235233")
+                        .build())
+                .build();
+        final String customerId = client.create(customerRequest).get().getId();
+        assertNotNull(customerId);
+        //Delete customer
+        client.delete(customerId).get();
+        //Verify customer does not exist
+        try {
+            client.get(customerId);
+            Assert.fail();
+        } catch (final CheckoutResourceNotFoundException ex) {
+            //do nothing
+        }
+    }
+}

--- a/src/test/java/com/checkout/customers/beta/CustomersTestIT.java
+++ b/src/test/java/com/checkout/customers/beta/CustomersTestIT.java
@@ -1,0 +1,93 @@
+package com.checkout.customers.beta;
+
+import com.checkout.CheckoutResourceNotFoundException;
+import com.checkout.PlatformType;
+import com.checkout.SandboxTestFixture;
+import com.checkout.common.beta.Phone;
+import org.junit.Test;
+
+import static com.checkout.beta.TestHelper.getRandomEmail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CustomersTestIT extends SandboxTestFixture {
+
+    public CustomersTestIT() {
+        super(PlatformType.FOUR);
+    }
+
+    @Test
+    public void shouldCreateAndGetCustomer() {
+
+        final CustomerRequest customerRequest = CustomerRequest.builder()
+                .email(getRandomEmail())
+                .name("Testing")
+                .phone(Phone.builder()
+                        .countryCode("1")
+                        .number("4155552671")
+                        .build())
+                .build();
+
+        final String customerId = blocking(getApiV2().customersClient().create(customerRequest)).getId();
+        assertNotNull(customerId);
+
+        final CustomerResponse customerResponse = blocking(getApiV2().customersClient().get(customerId));
+        assertNotNull(customerResponse);
+        assertEquals(customerRequest.getEmail(), customerResponse.getEmail());
+        assertEquals(customerRequest.getName(), customerResponse.getName());
+        assertEquals(customerRequest.getPhone(), customerResponse.getPhone());
+        assertNull(customerResponse.getDefaultId());
+        // TODO Review customer instruments when related functionality is implemented for CS2
+        //assertTrue(customerResponse.getInstruments().isEmpty());
+
+    }
+
+    @Test
+    public void shouldCreateAndUpdateCustomer() {
+        //Create Customer
+        final CustomerRequest customerRequest = CustomerRequest.builder()
+                .email(getRandomEmail())
+                .name("Testing")
+                .phone(Phone.builder()
+                        .countryCode("1")
+                        .number("4155552671")
+                        .build())
+                .build();
+        final String customerId = blocking(getApiV2().customersClient().create(customerRequest)).getId();
+        assertNotNull(customerId);
+        //Update Customer
+        customerRequest.setEmail(getRandomEmail());
+        customerRequest.setName("Testing New");
+        blocking(getApiV2().customersClient().update(customerId, customerRequest));
+        //Verify changes were applied
+        final CustomerResponse customerResponse = blocking(getApiV2().customersClient().get(customerId));
+        assertNotNull(customerResponse);
+        assertEquals(customerRequest.getName(), customerResponse.getName());
+        assertEquals(customerRequest.getEmail(), customerResponse.getEmail());
+    }
+
+    @Test
+    public void shouldCreateAndEditCustomer() {
+        //Create Customer
+        final CustomerRequest customerRequest = CustomerRequest.builder()
+                .email(getRandomEmail())
+                .name("Testing")
+                .phone(Phone.builder()
+                        .countryCode("1")
+                        .number("4155552671")
+                        .build())
+                .build();
+        final String customerId = blocking(getApiV2().customersClient().create(customerRequest)).getId();
+        assertNotNull(customerId);
+        //Delete customer
+        blocking(getApiV2().customersClient().delete(customerId));
+        //Verify customer does not exist
+        try {
+            getApiV2().customersClient().get(customerId).get();
+        } catch (final Exception e) {
+            assertTrue(e.getCause() instanceof CheckoutResourceNotFoundException);
+        }
+    }
+}


### PR DESCRIPTION
Similar to CS1, this commit contains `customers` related
functionality to `get`, `post`, `patch` and `delete` operations
for CS2 compliant domain. Support for customer instruments was
not added due to missing CS2 instruments functionality, however
`CustomerBankAccountInstrument` and `CustomerCardInstrument` were
already included to be attached to `CustomerResponse` in the future.