### PR TITLE
Upgrade to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,13 @@ dependencies {
     implementation 'javax.validation:validation-api:2.0.1.Final'
     implementation 'org.apache.httpcomponents:httpmime:4.5.13'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.slf4j:slf4j-simple:1.7.26'
-    testCompile 'org.mockito:mockito-inline:3.11.2'
+    testImplementation(platform('org.junit:junit-bom:5.7.2'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'org.mockito:mockito-inline:3.11.2'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.11.2'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.26'
 }
 
 buildScan {
@@ -42,8 +46,9 @@ test {
     environment "CHECKOUT_FOUR_PUBLIC_KEY", System.getenv("CHECKOUT_FOUR_PUBLIC_KEY")
     environment "CHECKOUT_FOUR_SECRET_KEY", System.getenv("CHECKOUT_FOUR_SECRET_KEY")
     systemProperty "org.slf4j.simpleLogger.defaultLogLevel", "INFO"
+    useJUnitPlatform()
     testLogging {
-        outputs.upToDateWhen {false}
+        events "passed", "skipped", "failed"
         showStandardStreams = true
     }
 }
@@ -103,7 +108,7 @@ nexusStaging {
 
 nexusPublishing {
     connectTimeout = Duration.ofMinutes(15)
-    clientTimeout  = Duration.ofMinutes(15)
+    clientTimeout = Duration.ofMinutes(15)
     repositories {
         sonatype {
             packageGroup = rootProject.nexusStaging.packageGroup
@@ -126,7 +131,7 @@ javadoc {
 
 jar {
     manifest {
-        attributes'Implementation-Title': 'checkout-sdk-java',
+        attributes 'Implementation-Title': 'checkout-sdk-java',
                 'Implementation-Version': archiveVersion.get()
     }
 }

--- a/src/test/java/com/checkout/CheckoutApiTest.java
+++ b/src/test/java/com/checkout/CheckoutApiTest.java
@@ -1,15 +1,15 @@
 package com.checkout;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.checkout.TestHelper.mockClassicConfiguration;
 import static com.checkout.TestHelper.mockFourConfiguration;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CheckoutApiTest {
 
     @Mock
@@ -20,7 +20,7 @@ public class CheckoutApiTest {
 
     @Test
     public void shouldInstantiateAndRetrieveClients() {
-        CheckoutApi checkoutApi = new CheckoutApiImpl(fourConfiguration);
+        final CheckoutApi checkoutApi = new CheckoutApiImpl(fourConfiguration);
         assertNotNull(checkoutApi.paymentsClient());
         assertNotNull(checkoutApi.sourcesClient());
         assertNotNull(checkoutApi.tokensClient());
@@ -31,7 +31,7 @@ public class CheckoutApiTest {
 
     @Test
     public void shouldInstantiateAndRetrieveClients_deprecatedConstructor() {
-        CheckoutApi checkoutApi = new CheckoutApiImpl(apiClient, classicConfiguration);
+        final CheckoutApi checkoutApi = new CheckoutApiImpl(apiClient, classicConfiguration);
         assertNotNull(checkoutApi.paymentsClient());
         assertNotNull(checkoutApi.sourcesClient());
         assertNotNull(checkoutApi.tokensClient());
@@ -42,7 +42,7 @@ public class CheckoutApiTest {
 
     @Test
     public void shouldInstantiateAndRetrieveClients_deprecatedStaticConstructor_1() {
-        CheckoutApi checkoutApi = CheckoutApiImpl.create(classicConfiguration.getSecretKey(), true, classicConfiguration.getPublicKey());
+        final CheckoutApi checkoutApi = CheckoutApiImpl.create(classicConfiguration.getSecretKey(), true, classicConfiguration.getPublicKey());
         assertNotNull(checkoutApi.paymentsClient());
         assertNotNull(checkoutApi.sourcesClient());
         assertNotNull(checkoutApi.tokensClient());
@@ -53,7 +53,7 @@ public class CheckoutApiTest {
 
     @Test
     public void shouldInstantiateAndRetrieveClients_deprecatedStaticConstructor_2() {
-        CheckoutApi checkoutApi = CheckoutApiImpl.create(classicConfiguration.getSecretKey(), "uri", classicConfiguration.getPublicKey());
+        final CheckoutApi checkoutApi = CheckoutApiImpl.create(classicConfiguration.getSecretKey(), "uri", classicConfiguration.getPublicKey());
         assertNotNull(checkoutApi.paymentsClient());
         assertNotNull(checkoutApi.sourcesClient());
         assertNotNull(checkoutApi.tokensClient());

--- a/src/test/java/com/checkout/CheckoutConfigurationTest.java
+++ b/src/test/java/com/checkout/CheckoutConfigurationTest.java
@@ -1,9 +1,7 @@
 package com.checkout;
 
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -18,13 +16,12 @@ import static com.checkout.TestHelper.VALID_CLASSIC_PK;
 import static com.checkout.TestHelper.VALID_CLASSIC_SK;
 import static com.checkout.TestHelper.VALID_FOUR_PK;
 import static com.checkout.TestHelper.VALID_FOUR_SK;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CheckoutConfigurationTest {
 
     @Test

--- a/src/test/java/com/checkout/PublicKeyCredentialsTest.java
+++ b/src/test/java/com/checkout/PublicKeyCredentialsTest.java
@@ -1,15 +1,12 @@
 package com.checkout;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
 import static com.checkout.TestHelper.mockFourConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(MockitoJUnitRunner.class)
 public class PublicKeyCredentialsTest {
 
     @Test

--- a/src/test/java/com/checkout/SandboxTestFixture.java
+++ b/src/test/java/com/checkout/SandboxTestFixture.java
@@ -6,7 +6,7 @@ import com.checkout.beta.CheckoutApi;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.requireNonNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class SandboxTestFixture {
 

--- a/src/test/java/com/checkout/SecretKeyCredentialsTest.java
+++ b/src/test/java/com/checkout/SecretKeyCredentialsTest.java
@@ -1,15 +1,12 @@
 package com.checkout;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
 import static com.checkout.TestHelper.mockFourConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SecretKeyCredentialsTest {
 
     @Test

--- a/src/test/java/com/checkout/TestHelper.java
+++ b/src/test/java/com/checkout/TestHelper.java
@@ -180,7 +180,7 @@ public class TestHelper {
                 .build();
     }
 
-    public static PaymentLinkRequest createPaymentLinksRequest(final String reference){
+    public static PaymentLinkRequest createPaymentLinksRequest(final String reference) {
         return PaymentLinkRequest.builder()
                 .amount(200L)
                 .currency(Currency.GBP)
@@ -200,7 +200,7 @@ public class TestHelper {
                 .build();
     }
 
-    public static HostedPaymentRequest createHostedPaymentRequest(final String reference){
+    public static HostedPaymentRequest createHostedPaymentRequest(final String reference) {
         return HostedPaymentRequest.builder()
                 .amount(1000L)
                 .reference(reference)

--- a/src/test/java/com/checkout/beta/CheckoutApiTest.java
+++ b/src/test/java/com/checkout/beta/CheckoutApiTest.java
@@ -2,16 +2,16 @@ package com.checkout.beta;
 
 import com.checkout.ApiClient;
 import com.checkout.CheckoutConfiguration;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.checkout.TestHelper.mockFourConfiguration;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CheckoutApiTest {
 
     @Mock
@@ -19,9 +19,9 @@ public class CheckoutApiTest {
 
     private CheckoutApi checkoutApi;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        CheckoutConfiguration checkoutConfiguration = mockFourConfiguration();
+        final CheckoutConfiguration checkoutConfiguration = mockFourConfiguration();
         this.checkoutApi = new CheckoutApiImpl(apiClient, checkoutConfiguration);
     }
 

--- a/src/test/java/com/checkout/beta/CheckoutTest.java
+++ b/src/test/java/com/checkout/beta/CheckoutTest.java
@@ -2,9 +2,7 @@ package com.checkout.beta;
 
 import com.checkout.CheckoutArgumentException;
 import com.checkout.Environment;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -13,11 +11,10 @@ import static com.checkout.TestHelper.INVALID_FOUR_PK;
 import static com.checkout.TestHelper.INVALID_FOUR_SK;
 import static com.checkout.TestHelper.VALID_FOUR_PK;
 import static com.checkout.TestHelper.VALID_FOUR_SK;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CheckoutTest {
 
     @Test

--- a/src/test/java/com/checkout/common/CheckoutUtilsTest.java
+++ b/src/test/java/com/checkout/common/CheckoutUtilsTest.java
@@ -1,12 +1,12 @@
 package com.checkout.common;
 
 import com.checkout.CheckoutArgumentException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.checkout.common.CheckoutUtils.requiresNonBlank;
 import static com.checkout.common.CheckoutUtils.requiresNonNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CheckoutUtilsTest {
 
@@ -30,36 +30,36 @@ public class CheckoutUtilsTest {
 
     }
 
-    private void testNoExceptionIsThrownRequiresNonBlank(String property, String content) {
+    private void testNoExceptionIsThrownRequiresNonBlank(final String property, final String content) {
         try {
             requiresNonBlank(property, content);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             fail();
         }
     }
 
-    private void testExceptionIsThrownRequiresNonBlank(String property, String content) {
+    private void testExceptionIsThrownRequiresNonBlank(final String property, final String content) {
         try {
             requiresNonBlank(property, content);
             fail();
-        } catch (CheckoutArgumentException e) {
+        } catch (final CheckoutArgumentException e) {
             assertEquals(property + " must be not be blank", e.getMessage());
         }
     }
 
-    private void testNoExceptionIsThrownRequiresNonNull(String property, Object content) {
+    private void testNoExceptionIsThrownRequiresNonNull(final String property, final Object content) {
         try {
             requiresNonNull(property, content);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             fail();
         }
     }
 
-    private void testExceptionIsThrownRequiresNonNull(String property, Object content) {
+    private void testExceptionIsThrownRequiresNonNull(final String property, final Object content) {
         try {
             requiresNonNull(property, content);
             fail();
-        } catch (CheckoutArgumentException e) {
+        } catch (final CheckoutArgumentException e) {
             assertEquals(property + " must be not be null", e.getMessage());
         }
     }

--- a/src/test/java/com/checkout/customers/CustomersClientImplTest.java
+++ b/src/test/java/com/checkout/customers/CustomersClientImplTest.java
@@ -6,30 +6,30 @@ import com.checkout.CheckoutConfiguration;
 import com.checkout.CheckoutResourceNotFoundException;
 import com.checkout.TestHelper;
 import com.checkout.common.IdResponse;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CustomersClientImplTest {
 
-    private static String CUSTOMER_ID = "cus_123456789abcdefgh";
+    private static final String CUSTOMER_ID = "cus_123456789abcdefgh";
 
     @Mock
     private ApiClient apiClient;
@@ -57,7 +57,7 @@ public class CustomersClientImplTest {
 
     private CustomersClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(idResponse.getId()).thenReturn(CUSTOMER_ID);
         idAsync = CompletableFuture.completedFuture(idResponse);
@@ -153,7 +153,7 @@ public class CustomersClientImplTest {
         //Verify customer does not exist
         try {
             client.get(customerId);
-            Assert.fail();
+            fail();
         } catch (final CheckoutResourceNotFoundException ex) {
             //do nothing
         }

--- a/src/test/java/com/checkout/customers/CustomersTestIT.java
+++ b/src/test/java/com/checkout/customers/CustomersTestIT.java
@@ -4,12 +4,12 @@ import com.checkout.CheckoutResourceNotFoundException;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CustomersTestIT extends SandboxTestFixture {
 

--- a/src/test/java/com/checkout/customers/beta/CustomersClientImplTest.java
+++ b/src/test/java/com/checkout/customers/beta/CustomersClientImplTest.java
@@ -7,26 +7,26 @@ import com.checkout.CheckoutResourceNotFoundException;
 import com.checkout.beta.TestHelper;
 import com.checkout.common.beta.IdResponse;
 import com.checkout.common.beta.Phone;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CustomersClientImplTest {
 
     private static final String CUSTOMER_ID = "cus_123456789abcdefgh";
@@ -57,7 +57,7 @@ public class CustomersClientImplTest {
 
     private CustomersClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(idResponse.getId()).thenReturn(CUSTOMER_ID);
         idAsync = CompletableFuture.completedFuture(idResponse);
@@ -161,7 +161,7 @@ public class CustomersClientImplTest {
         //Verify customer does not exist
         try {
             client.get(customerId);
-            Assert.fail();
+            fail();
         } catch (final CheckoutResourceNotFoundException ex) {
             //do nothing
         }

--- a/src/test/java/com/checkout/customers/beta/CustomersTestIT.java
+++ b/src/test/java/com/checkout/customers/beta/CustomersTestIT.java
@@ -4,13 +4,13 @@ import com.checkout.CheckoutResourceNotFoundException;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.common.beta.Phone;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.checkout.beta.TestHelper.getRandomEmail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CustomersTestIT extends SandboxTestFixture {
 

--- a/src/test/java/com/checkout/events/EventsTestIT.java
+++ b/src/test/java/com/checkout/events/EventsTestIT.java
@@ -2,11 +2,14 @@ package com.checkout.events;
 
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class EventsTestIT extends SandboxTestFixture {
 
@@ -14,36 +17,36 @@ public class EventsTestIT extends SandboxTestFixture {
         super(PlatformType.CLASSIC);
     }
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         Thread.sleep(5000);
     }
 
     @Test
     public void retrieve_all_event_types() throws Exception {
-        List<EventTypesResponse> allEventTypesResponses = getApi().eventsClient().retrieveAllEventTypes(null).get();
-        Assert.assertNotNull(allEventTypesResponses);
-        Assert.assertEquals(2, allEventTypesResponses.size());
+        final List<EventTypesResponse> allEventTypesResponses = getApi().eventsClient().retrieveAllEventTypes(null).get();
+        assertNotNull(allEventTypesResponses);
+        assertEquals(2, allEventTypesResponses.size());
     }
 
     @Test
     public void retrieve_v1_event_types() throws Exception {
-        List<EventTypesResponse> v1EventTypesResponses = getApi().eventsClient().retrieveAllEventTypes("1.0").get();
-        Assert.assertNotNull(v1EventTypesResponses);
-        Assert.assertEquals(1, v1EventTypesResponses.size());
-        Assert.assertEquals("1.0", v1EventTypesResponses.get(0).getVersion());
-        Assert.assertNotNull(v1EventTypesResponses.get(0).getEventTypes());
-        Assert.assertFalse(v1EventTypesResponses.get(0).getEventTypes().isEmpty());
+        final List<EventTypesResponse> v1EventTypesResponses = getApi().eventsClient().retrieveAllEventTypes("1.0").get();
+        assertNotNull(v1EventTypesResponses);
+        assertEquals(1, v1EventTypesResponses.size());
+        assertEquals("1.0", v1EventTypesResponses.get(0).getVersion());
+        assertNotNull(v1EventTypesResponses.get(0).getEventTypes());
+        assertFalse(v1EventTypesResponses.get(0).getEventTypes().isEmpty());
     }
 
     @Test
     public void retrieve_v2_event_types() throws Exception {
-        List<EventTypesResponse> v2EventTypesResponses = getApi().eventsClient().retrieveAllEventTypes("2.0").get();
-        Assert.assertNotNull(v2EventTypesResponses);
-        Assert.assertEquals(1, v2EventTypesResponses.size());
-        Assert.assertEquals("2.0", v2EventTypesResponses.get(0).getVersion());
-        Assert.assertNotNull(v2EventTypesResponses.get(0).getEventTypes());
-        Assert.assertFalse(v2EventTypesResponses.get(0).getEventTypes().isEmpty());
+        final List<EventTypesResponse> v2EventTypesResponses = getApi().eventsClient().retrieveAllEventTypes("2.0").get();
+        assertNotNull(v2EventTypesResponses);
+        assertEquals(1, v2EventTypesResponses.size());
+        assertEquals("2.0", v2EventTypesResponses.get(0).getVersion());
+        assertNotNull(v2EventTypesResponses.get(0).getEventTypes());
+        assertFalse(v2EventTypesResponses.get(0).getEventTypes().isEmpty());
     }
 
     // TODO: Find ways to test events APIs again

--- a/src/test/java/com/checkout/instruments/InstrumentsTestIT.java
+++ b/src/test/java/com/checkout/instruments/InstrumentsTestIT.java
@@ -8,10 +8,13 @@ import com.checkout.common.Address;
 import com.checkout.common.Phone;
 import com.checkout.tokens.CardTokenRequest;
 import com.checkout.tokens.CardTokenResponse;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InstrumentsTestIT extends SandboxTestFixture {
 
@@ -21,114 +24,113 @@ public class InstrumentsTestIT extends SandboxTestFixture {
 
     @Test
     public void can_create_instrument() throws Exception {
-        CardTokenResponse cardToken = getApi().tokensClient().requestAsync(createValidTokenRequest()).get();
+        final CardTokenResponse cardToken = getApi().tokensClient().requestAsync(createValidTokenRequest()).get();
 
-        CreateInstrumentRequest request = CreateInstrumentRequest.builder()
+        final CreateInstrumentRequest request = CreateInstrumentRequest.builder()
                 .type("token")
                 .token(cardToken.getToken())
                 .build();
-        CreateInstrumentResponse response = getApi().instrumentsClient().createInstrument(request).get();
+        final CreateInstrumentResponse response = getApi().instrumentsClient().createInstrument(request).get();
 
-        Assert.assertNotNull(response);
-        Assert.assertNotNull(response.getId());
-        Assert.assertNotNull(response.getType());
-        Assert.assertNotNull(response.getBin());
-        Assert.assertNotNull(response.getCardCategory());
-        Assert.assertNotNull(response.getCardType());
-        Assert.assertNotNull(response.getExpiryMonth());
-        Assert.assertNotNull(response.getExpiryYear());
-        Assert.assertNotNull(response.getIssuer());
-        Assert.assertNotNull(response.getIssuerCountry());
-        Assert.assertNotNull(response.getProductId());
-        Assert.assertNotNull(response.getProductType());
+        assertNotNull(response);
+        assertNotNull(response.getId());
+        assertNotNull(response.getType());
+        assertNotNull(response.getBin());
+        assertNotNull(response.getCardCategory());
+        assertNotNull(response.getCardType());
+        assertNotNull(response.getExpiryMonth());
+        assertNotNull(response.getExpiryYear());
+        assertNotNull(response.getIssuer());
+        assertNotNull(response.getIssuerCountry());
+        assertNotNull(response.getProductId());
+        assertNotNull(response.getProductType());
     }
 
     @Test
     public void can_get_instrument() throws Exception {
-        CardTokenResponse cardToken = getApi().tokensClient().requestAsync(createValidTokenRequest()).get();
+        final CardTokenResponse cardToken = getApi().tokensClient().requestAsync(createValidTokenRequest()).get();
 
-        CreateInstrumentRequest request = CreateInstrumentRequest.builder()
+        final CreateInstrumentRequest request = CreateInstrumentRequest.builder()
                 .type("token")
                 .token(cardToken.getToken())
                 .build();
-        CreateInstrumentResponse createInstrumentResponse = getApi().instrumentsClient().createInstrument(request).get();
+        final CreateInstrumentResponse createInstrumentResponse = getApi().instrumentsClient().createInstrument(request).get();
 
-        InstrumentDetailsResponse instrument = getApi().instrumentsClient().getInstrument(createInstrumentResponse.getId()).get();
-        Assert.assertNotNull(instrument);
-        Assert.assertEquals(createInstrumentResponse.getBin(), instrument.getBin());
-        Assert.assertEquals(createInstrumentResponse.getProductType(), instrument.getProductType());
-        Assert.assertEquals(createInstrumentResponse.getProductId(), instrument.getProductId());
-        Assert.assertEquals(createInstrumentResponse.getId(), instrument.getId());
-        Assert.assertEquals(createInstrumentResponse.getType(), instrument.getType());
-        Assert.assertEquals(createInstrumentResponse.getExpiryMonth(), instrument.getExpiryMonth());
-        Assert.assertEquals(createInstrumentResponse.getExpiryYear(), instrument.getExpiryYear());
-        Assert.assertEquals(createInstrumentResponse.getScheme(), instrument.getScheme());
-        Assert.assertEquals(createInstrumentResponse.getLast4(), instrument.getLast4());
-        Assert.assertEquals(createInstrumentResponse.getBin(), instrument.getBin());
-        Assert.assertEquals(createInstrumentResponse.getCardType(), instrument.getCardType());
-        Assert.assertEquals(createInstrumentResponse.getCardCategory(), instrument.getCardCategory());
-        Assert.assertEquals(createInstrumentResponse.getIssuer(), instrument.getIssuer());
-        Assert.assertEquals(createInstrumentResponse.getIssuerCountry(), instrument.getIssuerCountry());
-        Assert.assertNotNull(instrument.getFingerprint());
-        Assert.assertNotNull(instrument.getAccountHolder());
-        Assert.assertNotNull(instrument.getAccountHolder().getBillingAddress());
-        Assert.assertNotNull(instrument.getAccountHolder().getBillingAddress().getAddressLine1());
-        Assert.assertNotNull(instrument.getAccountHolder().getBillingAddress().getAddressLine2());
-        Assert.assertNotNull(instrument.getAccountHolder().getBillingAddress().getCity());
-        Assert.assertNotNull(instrument.getAccountHolder().getBillingAddress().getCountry());
-        Assert.assertNotNull(instrument.getAccountHolder().getBillingAddress().getState());
-        Assert.assertNotNull(instrument.getAccountHolder().getBillingAddress().getZip());
-        Assert.assertNotNull(instrument.getAccountHolder().getPhone());
-        Assert.assertNotNull(instrument.getAccountHolder().getPhone().getCountryCode());
-        Assert.assertNotNull(instrument.getAccountHolder().getPhone().getNumber());
-        Assert.assertNotNull(instrument.getCustomer());
-        Assert.assertNotNull(instrument.getCustomer().getId());
-        Assert.assertNotNull(instrument.getCustomer().getEmail());
-        Assert.assertTrue(instrument.getCustomer().isDefault());
+        final InstrumentDetailsResponse instrument = getApi().instrumentsClient().getInstrument(createInstrumentResponse.getId()).get();
+        assertNotNull(instrument);
+        assertEquals(createInstrumentResponse.getBin(), instrument.getBin());
+        assertEquals(createInstrumentResponse.getProductType(), instrument.getProductType());
+        assertEquals(createInstrumentResponse.getProductId(), instrument.getProductId());
+        assertEquals(createInstrumentResponse.getId(), instrument.getId());
+        assertEquals(createInstrumentResponse.getType(), instrument.getType());
+        assertEquals(createInstrumentResponse.getExpiryMonth(), instrument.getExpiryMonth());
+        assertEquals(createInstrumentResponse.getExpiryYear(), instrument.getExpiryYear());
+        assertEquals(createInstrumentResponse.getScheme(), instrument.getScheme());
+        assertEquals(createInstrumentResponse.getLast4(), instrument.getLast4());
+        assertEquals(createInstrumentResponse.getBin(), instrument.getBin());
+        assertEquals(createInstrumentResponse.getCardType(), instrument.getCardType());
+        assertEquals(createInstrumentResponse.getCardCategory(), instrument.getCardCategory());
+        assertEquals(createInstrumentResponse.getIssuer(), instrument.getIssuer());
+        assertEquals(createInstrumentResponse.getIssuerCountry(), instrument.getIssuerCountry());
+        assertNotNull(instrument.getFingerprint());
+        assertNotNull(instrument.getAccountHolder());
+        assertNotNull(instrument.getAccountHolder().getBillingAddress());
+        assertNotNull(instrument.getAccountHolder().getBillingAddress().getAddressLine1());
+        assertNotNull(instrument.getAccountHolder().getBillingAddress().getAddressLine2());
+        assertNotNull(instrument.getAccountHolder().getBillingAddress().getCity());
+        assertNotNull(instrument.getAccountHolder().getBillingAddress().getCountry());
+        assertNotNull(instrument.getAccountHolder().getBillingAddress().getState());
+        assertNotNull(instrument.getAccountHolder().getBillingAddress().getZip());
+        assertNotNull(instrument.getAccountHolder().getPhone());
+        assertNotNull(instrument.getAccountHolder().getPhone().getCountryCode());
+        assertNotNull(instrument.getAccountHolder().getPhone().getNumber());
+        assertNotNull(instrument.getCustomer());
+        assertNotNull(instrument.getCustomer().getId());
+        assertNotNull(instrument.getCustomer().getEmail());
+        assertTrue(instrument.getCustomer().isDefault());
     }
 
     @Test
     public void can_update_instrument() throws Exception {
-        CardTokenResponse cardToken = getApi().tokensClient().requestAsync(createValidTokenRequest()).get();
+        final CardTokenResponse cardToken = getApi().tokensClient().requestAsync(createValidTokenRequest()).get();
 
-        CreateInstrumentRequest request = CreateInstrumentRequest.builder()
+        final CreateInstrumentRequest request = CreateInstrumentRequest.builder()
                 .type("token")
                 .token(cardToken.getToken())
                 .build();
-        CreateInstrumentResponse response = getApi().instrumentsClient().createInstrument(request).get();
-        UpdateInstrumentResponse updateResponse = getApi().instrumentsClient().updateInstrument(response.getId(), UpdateInstrumentRequest.builder()
+        final CreateInstrumentResponse response = getApi().instrumentsClient().createInstrument(request).get();
+        final UpdateInstrumentResponse updateResponse = getApi().instrumentsClient().updateInstrument(response.getId(), UpdateInstrumentRequest.builder()
                 .name("Test")
                 .build()).get();
 
-        Assert.assertNotNull(updateResponse);
-        Assert.assertNotNull(updateResponse.getFingerprint());
-        Assert.assertNotNull(updateResponse.getType());
+        assertNotNull(updateResponse);
+        assertNotNull(updateResponse.getFingerprint());
+        assertNotNull(updateResponse.getType());
 
-        InstrumentDetailsResponse instrument = getApi().instrumentsClient().getInstrument(response.getId()).get();
-        Assert.assertEquals("Test", instrument.getName());
+        final InstrumentDetailsResponse instrument = getApi().instrumentsClient().getInstrument(response.getId()).get();
+        assertEquals("Test", instrument.getName());
     }
 
-    @Test(expected = CheckoutResourceNotFoundException.class)
-    public void can_delete_instrument() throws Throwable {
-        CardTokenResponse cardToken = getApi().tokensClient().requestAsync(createValidTokenRequest()).get();
+    @Test
+    public void can_delete_instrument() throws ExecutionException, InterruptedException {
+        final CardTokenResponse cardToken = getApi().tokensClient().requestAsync(createValidTokenRequest()).get();
 
-        CreateInstrumentRequest request = CreateInstrumentRequest.builder()
+        final CreateInstrumentRequest request = CreateInstrumentRequest.builder()
                 .type("token")
                 .token(cardToken.getToken())
                 .build();
-        CreateInstrumentResponse response = getApi().instrumentsClient().createInstrument(request).get();
-
-        getApi().instrumentsClient().deleteInstrument(response.getId()).get();
+        final CreateInstrumentResponse response = getApi().instrumentsClient().createInstrument(request).get();
 
         try {
             getApi().instrumentsClient().getInstrument(response.getId()).get();
-        } catch (ExecutionException e) {
-            throw e.getCause();
+        } catch (final Exception e) {
+            assertTrue(e.getCause() instanceof CheckoutResourceNotFoundException);
         }
+
     }
 
     private CardTokenRequest createValidTokenRequest() {
-        Address billingAddress = new Address();
+        final Address billingAddress = new Address();
         billingAddress.setAddressLine1("Checkout.com");
         billingAddress.setAddressLine2("90 Tottenham Court Road");
         billingAddress.setCity("London");
@@ -136,11 +138,11 @@ public class InstrumentsTestIT extends SandboxTestFixture {
         billingAddress.setZip("W1T 4TJ");
         billingAddress.setCountry("GB");
 
-        Phone phone = new Phone();
+        final Phone phone = new Phone();
         phone.setCountryCode("44");
         phone.setNumber("020 222333");
 
-        CardTokenRequest request = new CardTokenRequest(TestCardSource.VISA.getNumber(), TestCardSource.VISA.getExpiryMonth(), TestCardSource.VISA.getExpiryYear());
+        final CardTokenRequest request = new CardTokenRequest(TestCardSource.VISA.getNumber(), TestCardSource.VISA.getExpiryMonth(), TestCardSource.VISA.getExpiryYear());
         request.setCvv(TestCardSource.VISA.getCvv());
         request.setBillingAddress(billingAddress);
         request.setPhone(phone);

--- a/src/test/java/com/checkout/payments/AlternativePaymentSourcePaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/AlternativePaymentSourcePaymentsTestIT.java
@@ -3,10 +3,14 @@ package com.checkout.payments;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import com.checkout.common.CheckoutUtils;
 import com.checkout.common.Currency;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AlternativePaymentSourcePaymentsTestIT extends SandboxTestFixture {
 
@@ -16,29 +20,29 @@ public class AlternativePaymentSourcePaymentsTestIT extends SandboxTestFixture {
 
     @Test
     public void can_request_ideal_payment() throws Exception {
-        AlternativePaymentSource alternativePaymentSource = new AlternativePaymentSource("ideal");
+        final AlternativePaymentSource alternativePaymentSource = new AlternativePaymentSource("ideal");
         alternativePaymentSource.put("bic", "INGBNL2A");
         alternativePaymentSource.put("description", "ORD 5023 4E89");
 
         requestAlternativePayment(alternativePaymentSource);
     }
 
-    private PaymentPending requestAlternativePayment(AlternativePaymentSource alternativePaymentSource) throws Exception {
-        PaymentRequest<RequestSource> paymentRequest = TestHelper.createAlternativePaymentMethodRequest(alternativePaymentSource, Currency.EUR);
+    private PaymentPending requestAlternativePayment(final AlternativePaymentSource alternativePaymentSource) throws Exception {
+        final PaymentRequest<RequestSource> paymentRequest = TestHelper.createAlternativePaymentMethodRequest(alternativePaymentSource, Currency.EUR);
 
-        PaymentResponse apiResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
-        Assert.assertTrue(apiResponse.isPending());
-        Assert.assertNotNull(apiResponse.getPending());
+        final PaymentResponse apiResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        assertTrue(apiResponse.isPending());
+        assertNotNull(apiResponse.getPending());
 
-        PaymentPending pendingPayment = apiResponse.getPending();
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(pendingPayment.getId()));
-        Assert.assertEquals(PaymentStatus.PENDING, pendingPayment.getStatus());
-        Assert.assertEquals(paymentRequest.getReference(), pendingPayment.getReference());
-        Assert.assertNotNull(pendingPayment.getCustomer());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(pendingPayment.getCustomer().getId()));
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(pendingPayment.getCustomer().getEmail()));
-        Assert.assertTrue(pendingPayment.requiresRedirect());
-        Assert.assertNotNull(pendingPayment.getRedirectLink());
+        final PaymentPending pendingPayment = apiResponse.getPending();
+        assertFalse(StringUtils.isEmpty(pendingPayment.getId()));
+        assertEquals(PaymentStatus.PENDING, pendingPayment.getStatus());
+        assertEquals(paymentRequest.getReference(), pendingPayment.getReference());
+        assertNotNull(pendingPayment.getCustomer());
+        assertFalse(StringUtils.isBlank(pendingPayment.getCustomer().getId()));
+        assertFalse(StringUtils.isEmpty(pendingPayment.getCustomer().getEmail()));
+        assertTrue(pendingPayment.requiresRedirect());
+        assertNotNull(pendingPayment.getRedirectLink());
 
         return pendingPayment;
     }

--- a/src/test/java/com/checkout/payments/CaptureTestIT.java
+++ b/src/test/java/com/checkout/payments/CaptureTestIT.java
@@ -3,12 +3,16 @@ package com.checkout.payments;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import com.checkout.common.CheckoutUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CaptureTestIT extends SandboxTestFixture {
 
@@ -18,45 +22,45 @@ public class CaptureTestIT extends SandboxTestFixture {
 
     @Test
     public void can_fully_capture_payment() throws Exception {
-        PaymentProcessed payment = makePayment();
+        final PaymentProcessed payment = makePayment();
 
-        Map<String, Object> metadata = new HashMap<>();
+        final Map<String, Object> metadata = new HashMap<>();
         metadata.put("CaptureTests", "can_fully_capture_payment");
 
-        CaptureRequest captureRequest = new CaptureRequest();
+        final CaptureRequest captureRequest = new CaptureRequest();
         captureRequest.setReference("Full Capture");
         captureRequest.setMetadata(metadata);
 
-        CaptureResponse captureResponse = getApi().paymentsClient().captureAsync(payment.getId(), captureRequest).get();
-        Assert.assertNotNull(captureResponse);
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(captureResponse.getActionId()));
-        Assert.assertEquals(captureRequest.getReference(), captureResponse.getReference());
+        final CaptureResponse captureResponse = getApi().paymentsClient().captureAsync(payment.getId(), captureRequest).get();
+        assertNotNull(captureResponse);
+        assertFalse(StringUtils.isEmpty(captureResponse.getActionId()));
+        assertEquals(captureRequest.getReference(), captureResponse.getReference());
     }
 
     @Test
     public void can_partially_capture_payment() throws Exception {
-        PaymentProcessed payment = makePayment();
+        final PaymentProcessed payment = makePayment();
 
-        Map<String, Object> metadata = new HashMap<>();
+        final Map<String, Object> metadata = new HashMap<>();
         metadata.put("CaptureTests", "can_partially_capture_payment");
 
-        CaptureRequest captureRequest = new CaptureRequest();
+        final CaptureRequest captureRequest = new CaptureRequest();
         captureRequest.setAmount(500L);
         captureRequest.setReference("Partial Capture");
         captureRequest.setMetadata(metadata);
 
-        CaptureResponse captureResponse = getApi().paymentsClient().captureAsync(payment.getId(), captureRequest).get();
-        Assert.assertNotNull(captureResponse);
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(captureResponse.getActionId()));
-        Assert.assertEquals(captureRequest.getReference(), captureResponse.getReference());
+        final CaptureResponse captureResponse = getApi().paymentsClient().captureAsync(payment.getId(), captureRequest).get();
+        assertNotNull(captureResponse);
+        assertFalse(StringUtils.isEmpty(captureResponse.getActionId()));
+        assertEquals(captureRequest.getReference(), captureResponse.getReference());
     }
 
     private PaymentProcessed makePayment() throws Exception {
-        PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest(1000L);
+        final PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest(1000L);
         paymentRequest.setCapture(false);
 
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
-        Assert.assertTrue(paymentResponse.getPayment().canCapture());
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        assertTrue(paymentResponse.getPayment().canCapture());
 
         return paymentResponse.getPayment();
     }

--- a/src/test/java/com/checkout/payments/CardDestinationPaymentTestIT.java
+++ b/src/test/java/com/checkout/payments/CardDestinationPaymentTestIT.java
@@ -3,9 +3,11 @@ package com.checkout.payments;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import com.checkout.common.CheckoutUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CardDestinationPaymentTestIT extends SandboxTestFixture {
 
@@ -14,24 +16,17 @@ public class CardDestinationPaymentTestIT extends SandboxTestFixture {
     }
 
     @Test
-    public void can_perform_card_payout() throws Exception {
-        PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPayoutRequest();
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
-
-        Assert.assertNotNull(paymentResponse.getPayment());
-        Assert.assertTrue(paymentResponse.getPayment().isApproved());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getId()));
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getActionId()));
-        Assert.assertEquals(paymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
-        Assert.assertEquals(paymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
-        Assert.assertEquals(paymentRequest.getReference(), paymentResponse.getPayment().getReference());
-        Assert.assertNotNull(paymentResponse.getPayment().getDestination());
-        Assert.assertEquals(paymentResponse.getPayment().getDestination().getBin(), paymentRequest.getDestination().getNumber().substring(0, 6));
-        Assert.assertEquals(
-                paymentResponse.getPayment().getDestination().getLast4(),
-                paymentRequest.getDestination().getNumber().substring(paymentRequest.getDestination().getNumber().length() - 4));
-        Assert.assertEquals(paymentRequest.getDestination().getType(), paymentResponse.getPayment().getDestination().getType());
-        Assert.assertEquals(paymentRequest.getDestination().getExpiryMonth(), paymentResponse.getPayment().getDestination().getExpiryMonth());
-        Assert.assertEquals(paymentRequest.getDestination().getExpiryYear(), paymentResponse.getPayment().getDestination().getExpiryYear());
+    public void canPerformCardPayout() throws Exception {
+        final PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPayoutRequest();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        assertNull(paymentResponse.getPayment());
+        assertNotNull(paymentResponse.getPending());
+        assertNotNull(paymentResponse.getPending().getId());
+        assertEquals("Pending", paymentResponse.getPending().getStatus());
+        assertNotNull(paymentResponse.getPending().getReference());
+        assertNotNull(paymentResponse.getPending().getCustomer());
+        assertNull(paymentResponse.getPending().getThreeDS());
+        assertNotNull(paymentResponse.getPending().getSelfLink());
     }
+
 }

--- a/src/test/java/com/checkout/payments/CardSourcePaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/CardSourcePaymentsTestIT.java
@@ -3,11 +3,15 @@ package com.checkout.payments;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import com.checkout.common.CheckoutUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CardSourcePaymentsTestIT extends SandboxTestFixture {
 
@@ -17,86 +21,86 @@ public class CardSourcePaymentsTestIT extends SandboxTestFixture {
 
     @Test
     public void can_request_non_3ds_card_payment() throws Exception {
-        PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
+        final PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
         paymentRequest.setThreeDS(ThreeDSRequest.from(false));
 
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
 
-        Assert.assertNotNull(paymentResponse.getPayment());
-        Assert.assertTrue(paymentResponse.getPayment().isApproved());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getId()));
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getActionId()));
-        Assert.assertEquals(paymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
-        Assert.assertEquals(paymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
-        Assert.assertEquals(paymentRequest.getReference(), paymentResponse.getPayment().getReference());
-        Assert.assertNotNull(paymentResponse.getPayment().getCustomer());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getCustomer().getId()));
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getCustomer().getEmail()));
-        Assert.assertTrue(paymentResponse.getPayment().canCapture());
-        Assert.assertTrue(paymentResponse.getPayment().canVoid());
-        Assert.assertNotNull(paymentResponse.getPayment().getSource());
-        Assert.assertTrue(paymentResponse.getPayment().getSource() instanceof CardSourceResponse);
-        Assert.assertFalse(paymentRequest.getSource().getStored());
+        assertNotNull(paymentResponse.getPayment());
+        assertTrue(paymentResponse.getPayment().isApproved());
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getId()));
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getActionId()));
+        assertEquals(paymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
+        assertEquals(paymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
+        assertEquals(paymentRequest.getReference(), paymentResponse.getPayment().getReference());
+        assertNotNull(paymentResponse.getPayment().getCustomer());
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getCustomer().getId()));
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getCustomer().getEmail()));
+        assertTrue(paymentResponse.getPayment().canCapture());
+        assertTrue(paymentResponse.getPayment().canVoid());
+        assertNotNull(paymentResponse.getPayment().getSource());
+        assertTrue(paymentResponse.getPayment().getSource() instanceof CardSourceResponse);
+        assertFalse(paymentRequest.getSource().getStored());
     }
 
     @Test
     public void can_request_3ds_card_payment() throws Exception {
-        PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
+        final PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
         paymentRequest.setThreeDS(ThreeDSRequest.from(true));
 
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
 
-        Assert.assertTrue(paymentResponse.isPending());
-        PaymentPending pending = paymentResponse.getPending();
+        assertTrue(paymentResponse.isPending());
+        final PaymentPending pending = paymentResponse.getPending();
 
-        Assert.assertNotNull(pending);
+        assertNotNull(pending);
 
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(pending.getId()));
-        Assert.assertEquals(paymentRequest.getReference(), pending.getReference());
-        Assert.assertNotNull(pending.getCustomer());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(pending.getCustomer().getId()));
-        Assert.assertEquals(paymentRequest.getCustomer().getEmail(), pending.getCustomer().getEmail());
-        Assert.assertNotNull(pending.getThreeDS());
-        Assert.assertFalse(pending.getThreeDS().isDowngraded());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(pending.getThreeDS().getEnrolled()));
-        Assert.assertTrue(pending.requiresRedirect());
-        Assert.assertNotNull(pending.getRedirectLink());
+        assertFalse(StringUtils.isEmpty(pending.getId()));
+        assertEquals(paymentRequest.getReference(), pending.getReference());
+        assertNotNull(pending.getCustomer());
+        assertFalse(StringUtils.isEmpty(pending.getCustomer().getId()));
+        assertEquals(paymentRequest.getCustomer().getEmail(), pending.getCustomer().getEmail());
+        assertNotNull(pending.getThreeDS());
+        assertFalse(pending.getThreeDS().isDowngraded());
+        assertFalse(StringUtils.isEmpty(pending.getThreeDS().getEnrolled()));
+        assertTrue(pending.requiresRedirect());
+        assertNotNull(pending.getRedirectLink());
     }
 
     @Test
     public void can_void_payment() throws Exception {
         // Auth
-        PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
-        Assert.assertTrue(paymentResponse.getPayment().canVoid());
+        final PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        assertTrue(paymentResponse.getPayment().canVoid());
 
-        VoidRequest voidRequest = new VoidRequest();
+        final VoidRequest voidRequest = new VoidRequest();
         voidRequest.setReference(UUID.randomUUID().toString());
 
         // Void Auth
-        VoidResponse voidResponse = getApi().paymentsClient().voidAsync(paymentResponse.getPayment().getId(), voidRequest).get();
+        final VoidResponse voidResponse = getApi().paymentsClient().voidAsync(paymentResponse.getPayment().getId(), voidRequest).get();
 
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(voidResponse.getActionId()));
-        Assert.assertEquals(voidRequest.getReference(), voidResponse.getReference());
+        assertFalse(StringUtils.isEmpty(voidResponse.getActionId()));
+        assertEquals(voidRequest.getReference(), voidResponse.getReference());
     }
 
     @Test
     public void can_refund_payment() throws Exception {
         // Auth
-        PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
-        Assert.assertTrue(paymentResponse.getPayment().canCapture());
+        final PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        assertTrue(paymentResponse.getPayment().canCapture());
 
         // Capture
         getApi().paymentsClient().captureAsync(paymentResponse.getPayment().getId()).get();
 
-        RefundRequest refundRequest = new RefundRequest();
+        final RefundRequest refundRequest = new RefundRequest();
         refundRequest.setReference(UUID.randomUUID().toString());
 
         // Refund
-        RefundResponse refundResponse = getApi().paymentsClient().refundAsync(paymentResponse.getPayment().getId(), refundRequest).get();
+        final RefundResponse refundResponse = getApi().paymentsClient().refundAsync(paymentResponse.getPayment().getId(), refundRequest).get();
 
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(refundResponse.getActionId()));
-        Assert.assertEquals(refundRequest.getReference(), refundResponse.getReference());
+        assertFalse(StringUtils.isEmpty(refundResponse.getActionId()));
+        assertEquals(refundRequest.getReference(), refundResponse.getReference());
     }
 }

--- a/src/test/java/com/checkout/payments/CardVerificationTestIT.java
+++ b/src/test/java/com/checkout/payments/CardVerificationTestIT.java
@@ -3,8 +3,9 @@ package com.checkout.payments;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CardVerificationTestIT extends SandboxTestFixture {
 
@@ -14,9 +15,9 @@ public class CardVerificationTestIT extends SandboxTestFixture {
 
     @Test
     public void can_verify_card() throws Exception {
-        PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest(0L);
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        final PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest(0L);
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
 
-        Assert.assertEquals(PaymentStatus.CARD_VERIFIED, paymentResponse.getPayment().getStatus());
+        assertEquals(PaymentStatus.CARD_VERIFIED, paymentResponse.getPayment().getStatus());
     }
 }

--- a/src/test/java/com/checkout/payments/CustomerSourcePaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/CustomerSourcePaymentsTestIT.java
@@ -3,10 +3,15 @@ package com.checkout.payments;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import com.checkout.common.CheckoutUtils;
 import com.checkout.common.Currency;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CustomerSourcePaymentsTestIT extends SandboxTestFixture {
 
@@ -16,29 +21,30 @@ public class CustomerSourcePaymentsTestIT extends SandboxTestFixture {
 
     @Test
     public void can_request_card_payment() throws Exception {
-        PaymentRequest<CardSource> firstCardPayment = TestHelper.createCardPaymentRequest();
-        PaymentResponse firstCardPaymentResponse = getApi().paymentsClient().requestAsync(firstCardPayment).get();
-        CustomerSource customerSource = new CustomerSource(firstCardPayment.getCustomer().getId(), firstCardPayment.getCustomer().getEmail());
-        PaymentRequest<CustomerSource> customerPaymentRequest = PaymentRequest.fromSource(customerSource, Currency.GBP, 100L);
+        final PaymentRequest<CardSource> firstCardPayment = TestHelper.createCardPaymentRequest();
+        final PaymentResponse firstCardPaymentResponse = getApi().paymentsClient().requestAsync(firstCardPayment).get();
+        final CustomerSource customerSource = new CustomerSource(firstCardPayment.getCustomer().getId(), firstCardPayment.getCustomer().getEmail());
+        final PaymentRequest<CustomerSource> customerPaymentRequest = PaymentRequest.fromSource(customerSource, Currency.GBP, 100L);
         customerPaymentRequest.setCapture(false);
 
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(customerPaymentRequest).get();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(customerPaymentRequest).get();
 
-        Assert.assertNotNull(paymentResponse.getPayment());
-        Assert.assertTrue(paymentResponse.getPayment().isApproved());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getId()));
-        Assert.assertNotEquals(firstCardPaymentResponse.getPayment().getId(), paymentResponse.getPayment().getId());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getActionId()));
-        Assert.assertEquals(customerPaymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
-        Assert.assertEquals(customerPaymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
-        Assert.assertEquals(customerPaymentRequest.getReference(), paymentResponse.getPayment().getReference());
-        Assert.assertNotNull(paymentResponse.getPayment().getCustomer());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getCustomer().getId()));
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getCustomer().getEmail()));
-        Assert.assertEquals(firstCardPaymentResponse.getPayment().getCustomer().getId(), paymentResponse.getPayment().getCustomer().getId());
-        Assert.assertNotNull(paymentResponse.getPayment().getSource());
-        Assert.assertEquals(((CardSourceResponse) firstCardPaymentResponse.getPayment().getSource()).getId(), ((CardSourceResponse) paymentResponse.getPayment().getSource()).getId());
-        Assert.assertTrue(paymentResponse.getPayment().canCapture());
-        Assert.assertTrue(paymentResponse.getPayment().canVoid());
+        assertNotNull(paymentResponse.getPayment());
+        assertTrue(paymentResponse.getPayment().isApproved());
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getId()));
+        assertNotEquals(firstCardPaymentResponse.getPayment().getId(), paymentResponse.getPayment().getId());
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getActionId()));
+        assertEquals(customerPaymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
+        assertEquals(customerPaymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
+        assertEquals(customerPaymentRequest.getReference(), paymentResponse.getPayment().getReference());
+        assertNotNull(paymentResponse.getPayment().getCustomer());
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getCustomer().getId()));
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getCustomer().getEmail()));
+        assertEquals(firstCardPaymentResponse.getPayment().getCustomer().getId(), paymentResponse.getPayment().getCustomer().getId());
+        assertNotNull(paymentResponse.getPayment().getSource());
+        assertEquals(((CardSourceResponse) firstCardPaymentResponse.getPayment().getSource()).getId(), ((CardSourceResponse) paymentResponse.getPayment().getSource()).getId());
+        assertTrue(paymentResponse.getPayment().canCapture());
+        assertTrue(paymentResponse.getPayment().canVoid());
     }
+
 }

--- a/src/test/java/com/checkout/payments/CustomerSourceTest.java
+++ b/src/test/java/com/checkout/payments/CustomerSourceTest.java
@@ -1,36 +1,22 @@
 package com.checkout.payments;
 
-import com.checkout.payments.CustomerSource;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CustomerSourceTest {
 
-    @RunWith(Parameterized.class)
-    public static class Enclosed {
-        @Parameterized.Parameter
-        public String email;
-
-        @Parameterized.Parameters
-        public static List<String> emails() {
-            List<String> emails = new ArrayList<>();
-            Collections.addAll(emails, "test@@", "test@", "test@@test", "test");
-            return emails;
-        }
-
-        @Test(expected = IllegalArgumentException.class)
-        public void given_invalid_email_should_throw_exception() {
-            new CustomerSource(null, email);
-        }
-    }
-
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void missing_id_and_email_should_throw_exception() {
-        new CustomerSource(null, null);
+        assertThrows(IllegalArgumentException.class, () -> new CustomerSource(null, null));
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"test@@", "test@", "test@@test", "test"})
+    public void given_invalid_email_should_throw_exception(final String email) {
+        assertThrows(IllegalArgumentException.class, () -> new CustomerSource(null, email));
+    }
+
 }

--- a/src/test/java/com/checkout/payments/DLocalSourcePaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/DLocalSourcePaymentsTestIT.java
@@ -3,9 +3,13 @@ package com.checkout.payments;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import com.checkout.common.CheckoutUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DLocalSourcePaymentsTestIT extends SandboxTestFixture {
 
@@ -15,25 +19,26 @@ public class DLocalSourcePaymentsTestIT extends SandboxTestFixture {
 
     @Test
     public void can_request_non_3ds_card_payment() throws Exception {
-        PaymentRequest<DLocalSource> paymentRequest = TestHelper.createDLocalPaymentRequest();
+        final PaymentRequest<DLocalSource> paymentRequest = TestHelper.createDLocalPaymentRequest();
         paymentRequest.setThreeDS(ThreeDSRequest.from(false));
 
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
 
-        Assert.assertNotNull(paymentResponse.getPayment());
-        Assert.assertTrue(paymentResponse.getPayment().isApproved());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getId()));
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getActionId()));
-        Assert.assertEquals(paymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
-        Assert.assertEquals(paymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
-        Assert.assertEquals(paymentRequest.getReference(), paymentResponse.getPayment().getReference());
-        Assert.assertNotNull(paymentResponse.getPayment().getCustomer());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getCustomer().getId()));
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getCustomer().getEmail()));
-        Assert.assertTrue(paymentResponse.getPayment().canCapture());
-        Assert.assertTrue(paymentResponse.getPayment().canVoid());
-        Assert.assertNotNull(paymentResponse.getPayment().getSource());
-        Assert.assertTrue(paymentResponse.getPayment().getSource() instanceof CardSourceResponse);
-        Assert.assertFalse(paymentRequest.getSource().getStored());
+        assertNotNull(paymentResponse.getPayment());
+        assertTrue(paymentResponse.getPayment().isApproved());
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getId()));
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getActionId()));
+        assertEquals(paymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
+        assertEquals(paymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
+        assertEquals(paymentRequest.getReference(), paymentResponse.getPayment().getReference());
+        assertNotNull(paymentResponse.getPayment().getCustomer());
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getCustomer().getId()));
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getCustomer().getEmail()));
+        assertTrue(paymentResponse.getPayment().canCapture());
+        assertTrue(paymentResponse.getPayment().canVoid());
+        assertNotNull(paymentResponse.getPayment().getSource());
+        assertTrue(paymentResponse.getPayment().getSource() instanceof CardSourceResponse);
+        assertFalse(paymentRequest.getSource().getStored());
     }
+
 }

--- a/src/test/java/com/checkout/payments/IdSourcePaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/IdSourcePaymentsTestIT.java
@@ -3,10 +3,15 @@ package com.checkout.payments;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import com.checkout.common.CheckoutUtils;
 import com.checkout.common.Currency;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IdSourcePaymentsTestIT extends SandboxTestFixture {
 
@@ -16,39 +21,40 @@ public class IdSourcePaymentsTestIT extends SandboxTestFixture {
 
     @Test
     public void can_request_card_payment() throws Exception {
-        PaymentRequest<CardSource> firstCardPayment = TestHelper.createCardPaymentRequest();
+        final PaymentRequest<CardSource> firstCardPayment = TestHelper.createCardPaymentRequest();
 
-        PaymentResponse firstCardPaymentResponse = getApi().paymentsClient().requestAsync(firstCardPayment).get();
+        final PaymentResponse firstCardPaymentResponse = getApi().paymentsClient().requestAsync(firstCardPayment).get();
 
-        IdSource idSource = new IdSource(((CardSourceResponse) firstCardPaymentResponse.getPayment().getSource()).getId());
-        PaymentRequest<IdSource> cardIdPaymentRequest = PaymentRequest.fromSource(idSource, Currency.GBP, 100L);
+        final IdSource idSource = new IdSource(((CardSourceResponse) firstCardPaymentResponse.getPayment().getSource()).getId());
+        final PaymentRequest<IdSource> cardIdPaymentRequest = PaymentRequest.fromSource(idSource, Currency.GBP, 100L);
         cardIdPaymentRequest.setCapture(false);
         cardIdPaymentRequest.setCustomer(toRequest(firstCardPaymentResponse.getPayment().getCustomer()));
 
-        PaymentResponse apiResponseForCustomerSourcePayment = getApi().paymentsClient().requestAsync(cardIdPaymentRequest).get();
+        final PaymentResponse apiResponseForCustomerSourcePayment = getApi().paymentsClient().requestAsync(cardIdPaymentRequest).get();
 
-        Assert.assertNotNull(apiResponseForCustomerSourcePayment.getPayment());
-        Assert.assertTrue(apiResponseForCustomerSourcePayment.getPayment().isApproved());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(apiResponseForCustomerSourcePayment.getPayment().getId()));
-        Assert.assertNotEquals(firstCardPaymentResponse.getPayment().getId(), apiResponseForCustomerSourcePayment.getPayment().getId());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(apiResponseForCustomerSourcePayment.getPayment().getActionId()));
-        Assert.assertEquals(cardIdPaymentRequest.getAmount().intValue(), apiResponseForCustomerSourcePayment.getPayment().getAmount());
-        Assert.assertEquals(cardIdPaymentRequest.getCurrency(), apiResponseForCustomerSourcePayment.getPayment().getCurrency());
-        Assert.assertEquals(cardIdPaymentRequest.getReference(), apiResponseForCustomerSourcePayment.getPayment().getReference());
-        Assert.assertNotNull(apiResponseForCustomerSourcePayment.getPayment().getCustomer());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(apiResponseForCustomerSourcePayment.getPayment().getCustomer().getId()));
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(apiResponseForCustomerSourcePayment.getPayment().getCustomer().getEmail()));
-        Assert.assertEquals(firstCardPaymentResponse.getPayment().getCustomer().getId(), apiResponseForCustomerSourcePayment.getPayment().getCustomer().getId());
-        Assert.assertEquals(((CardSourceResponse) firstCardPaymentResponse.getPayment().getSource()).getId(), ((CardSourceResponse) apiResponseForCustomerSourcePayment.getPayment().getSource()).getId());
-        Assert.assertTrue(apiResponseForCustomerSourcePayment.getPayment().canCapture());
-        Assert.assertTrue(apiResponseForCustomerSourcePayment.getPayment().canVoid());
+        assertNotNull(apiResponseForCustomerSourcePayment.getPayment());
+        assertTrue(apiResponseForCustomerSourcePayment.getPayment().isApproved());
+        assertFalse(StringUtils.isEmpty(apiResponseForCustomerSourcePayment.getPayment().getId()));
+        assertNotEquals(firstCardPaymentResponse.getPayment().getId(), apiResponseForCustomerSourcePayment.getPayment().getId());
+        assertFalse(StringUtils.isEmpty(apiResponseForCustomerSourcePayment.getPayment().getActionId()));
+        assertEquals(cardIdPaymentRequest.getAmount().intValue(), apiResponseForCustomerSourcePayment.getPayment().getAmount());
+        assertEquals(cardIdPaymentRequest.getCurrency(), apiResponseForCustomerSourcePayment.getPayment().getCurrency());
+        assertEquals(cardIdPaymentRequest.getReference(), apiResponseForCustomerSourcePayment.getPayment().getReference());
+        assertNotNull(apiResponseForCustomerSourcePayment.getPayment().getCustomer());
+        assertFalse(StringUtils.isEmpty(apiResponseForCustomerSourcePayment.getPayment().getCustomer().getId()));
+        assertFalse(StringUtils.isEmpty(apiResponseForCustomerSourcePayment.getPayment().getCustomer().getEmail()));
+        assertEquals(firstCardPaymentResponse.getPayment().getCustomer().getId(), apiResponseForCustomerSourcePayment.getPayment().getCustomer().getId());
+        assertEquals(((CardSourceResponse) firstCardPaymentResponse.getPayment().getSource()).getId(), ((CardSourceResponse) apiResponseForCustomerSourcePayment.getPayment().getSource()).getId());
+        assertTrue(apiResponseForCustomerSourcePayment.getPayment().canCapture());
+        assertTrue(apiResponseForCustomerSourcePayment.getPayment().canVoid());
     }
 
-    private CustomerRequest toRequest(CustomerResponse customer) {
-        CustomerRequest request = new CustomerRequest();
+    private CustomerRequest toRequest(final CustomerResponse customer) {
+        final CustomerRequest request = new CustomerRequest();
         request.setId(customer.getId());
         request.setEmail(customer.getEmail());
         request.setName(customer.getName());
         return request;
     }
+
 }

--- a/src/test/java/com/checkout/payments/IdSourceTest.java
+++ b/src/test/java/com/checkout/payments/IdSourceTest.java
@@ -1,20 +1,23 @@
 package com.checkout.payments;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class IdSourceTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void given_id_missing_should_throw_exception() {
-        new IdSource(null);
+        assertThrows(IllegalArgumentException.class, () -> new IdSource(null));
     }
 
     @Test
     public void can_create_id_source() {
-        IdSource source = new IdSource("src_xxx");
+        final IdSource source = new IdSource("src_xxx");
         source.setCvv("0757");
-        Assert.assertEquals("src_xxx", source.getId());
-        Assert.assertEquals("0757", source.getCvv());
+        assertEquals("src_xxx", source.getId());
+        assertEquals("0757", source.getCvv());
     }
+
 }

--- a/src/test/java/com/checkout/payments/ResponseSourceExtensionsTest.java
+++ b/src/test/java/com/checkout/payments/ResponseSourceExtensionsTest.java
@@ -1,27 +1,29 @@
 package com.checkout.payments;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResponseSourceExtensionsTest {
 
     @Test
     public void can_convert_to_card_source() {
-        CardSourceResponse source = new CardSourceResponse();
-        PaymentProcessed payment = new PaymentProcessed();
+        final CardSourceResponse source = new CardSourceResponse();
+        final PaymentProcessed payment = new PaymentProcessed();
         payment.setSource(source);
 
-        Assert.assertTrue(payment.getSource() instanceof CardSourceResponse);
-        Assert.assertEquals(source, payment.getSource());
+        assertTrue(payment.getSource() instanceof CardSourceResponse);
+        assertEquals(source, payment.getSource());
     }
 
     @Test
     public void can_convert_to_alternative_payment_source() {
-        AlternativePaymentSourceResponse source = new AlternativePaymentSourceResponse();
-        PaymentProcessed payment = new PaymentProcessed();
+        final AlternativePaymentSourceResponse source = new AlternativePaymentSourceResponse();
+        final PaymentProcessed payment = new PaymentProcessed();
         payment.setSource(source);
 
-        Assert.assertTrue(payment.getSource() instanceof AlternativePaymentSourceResponse);
-        Assert.assertEquals(source, payment.getSource());
+        assertTrue(payment.getSource() instanceof AlternativePaymentSourceResponse);
+        assertEquals(source, payment.getSource());
     }
 }

--- a/src/test/java/com/checkout/payments/TokenSourcePaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/TokenSourcePaymentsTestIT.java
@@ -3,13 +3,17 @@ package com.checkout.payments;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import com.checkout.common.CheckoutUtils;
 import com.checkout.tokens.CardTokenRequest;
 import com.checkout.tokens.CardTokenResponse;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TokenSourcePaymentsTestIT extends SandboxTestFixture {
 
@@ -19,98 +23,98 @@ public class TokenSourcePaymentsTestIT extends SandboxTestFixture {
 
     @Test
     public void can_request_non_3ds_card_payment() throws Exception {
-        CardTokenRequest cardTokenRequest = TestHelper.createCardTokenRequest();
-        CardTokenResponse cardTokenResponse = getApi().tokensClient().requestAsync(cardTokenRequest).get();
-        PaymentRequest<TokenSource> paymentRequest = TestHelper.createTokenPaymentRequest(cardTokenResponse.getToken());
+        final CardTokenRequest cardTokenRequest = TestHelper.createCardTokenRequest();
+        final CardTokenResponse cardTokenResponse = getApi().tokensClient().requestAsync(cardTokenRequest).get();
+        final PaymentRequest<TokenSource> paymentRequest = TestHelper.createTokenPaymentRequest(cardTokenResponse.getToken());
         paymentRequest.setThreeDS(ThreeDSRequest.from(false));
 
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
 
-        Assert.assertNotNull(paymentResponse.getPayment());
-        Assert.assertTrue(paymentResponse.getPayment().isApproved());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getId()));
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(paymentResponse.getPayment().getActionId()));
-        Assert.assertEquals(paymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
-        Assert.assertEquals(paymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
-        Assert.assertEquals(paymentRequest.getReference(), paymentResponse.getPayment().getReference());
-        Assert.assertTrue(paymentResponse.getPayment().canCapture());
-        Assert.assertTrue(paymentResponse.getPayment().canVoid());
-        Assert.assertNotNull(paymentResponse.getPayment().getSource());
+        assertNotNull(paymentResponse.getPayment());
+        assertTrue(paymentResponse.getPayment().isApproved());
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getId()));
+        assertFalse(StringUtils.isEmpty(paymentResponse.getPayment().getActionId()));
+        assertEquals(paymentRequest.getAmount().intValue(), paymentResponse.getPayment().getAmount());
+        assertEquals(paymentRequest.getCurrency(), paymentResponse.getPayment().getCurrency());
+        assertEquals(paymentRequest.getReference(), paymentResponse.getPayment().getReference());
+        assertTrue(paymentResponse.getPayment().canCapture());
+        assertTrue(paymentResponse.getPayment().canVoid());
+        assertNotNull(paymentResponse.getPayment().getSource());
     }
 
     @Test
     public void can_request_3ds_card_payment() throws Exception {
-        CardTokenRequest cardTokenRequest = TestHelper.createCardTokenRequest();
-        CardTokenResponse cardTokenResponse = getApi().tokensClient().requestAsync(cardTokenRequest).get();
-        PaymentRequest<TokenSource> paymentRequest = TestHelper.createTokenPaymentRequest(cardTokenResponse.getToken());
+        final CardTokenRequest cardTokenRequest = TestHelper.createCardTokenRequest();
+        final CardTokenResponse cardTokenResponse = getApi().tokensClient().requestAsync(cardTokenRequest).get();
+        final PaymentRequest<TokenSource> paymentRequest = TestHelper.createTokenPaymentRequest(cardTokenResponse.getToken());
         paymentRequest.setThreeDS(ThreeDSRequest.from(true));
 
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
 
-        Assert.assertTrue(paymentResponse.isPending());
-        PaymentPending pending = paymentResponse.getPending();
+        assertTrue(paymentResponse.isPending());
+        final PaymentPending pending = paymentResponse.getPending();
 
-        Assert.assertNotNull(pending);
+        assertNotNull(pending);
 
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(pending.getId()));
-        Assert.assertEquals(paymentRequest.getReference(), pending.getReference());
-        Assert.assertNotNull(pending.getThreeDS());
-        Assert.assertFalse(pending.getThreeDS().isDowngraded());
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(pending.getThreeDS().getEnrolled()));
-        Assert.assertTrue(pending.requiresRedirect());
-        Assert.assertNotNull(pending.getRedirectLink());
+        assertFalse(StringUtils.isEmpty(pending.getId()));
+        assertEquals(paymentRequest.getReference(), pending.getReference());
+        assertNotNull(pending.getThreeDS());
+        assertFalse(pending.getThreeDS().isDowngraded());
+        assertFalse(StringUtils.isEmpty(pending.getThreeDS().getEnrolled()));
+        assertTrue(pending.requiresRedirect());
+        assertNotNull(pending.getRedirectLink());
     }
 
     @Test
     public void can_capture_payment() throws Exception {
-        CardTokenRequest cardTokenRequest = TestHelper.createCardTokenRequest();
-        CardTokenResponse cardTokenResponse = getApi().tokensClient().requestAsync(cardTokenRequest).get();
-        PaymentRequest<TokenSource> paymentRequest = TestHelper.createTokenPaymentRequest(cardTokenResponse.getToken());
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        final CardTokenRequest cardTokenRequest = TestHelper.createCardTokenRequest();
+        final CardTokenResponse cardTokenResponse = getApi().tokensClient().requestAsync(cardTokenRequest).get();
+        final PaymentRequest<TokenSource> paymentRequest = TestHelper.createTokenPaymentRequest(cardTokenResponse.getToken());
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
 
 
-        Assert.assertTrue(paymentResponse.getPayment().canCapture());
+        assertTrue(paymentResponse.getPayment().canCapture());
 
-        CaptureRequest captureRequest = new CaptureRequest();
+        final CaptureRequest captureRequest = new CaptureRequest();
         captureRequest.setReference(UUID.randomUUID().toString());
 
-        CaptureResponse captureResponse = getApi().paymentsClient().captureAsync(paymentResponse.getPayment().getId(), captureRequest).get();
+        final CaptureResponse captureResponse = getApi().paymentsClient().captureAsync(paymentResponse.getPayment().getId(), captureRequest).get();
 
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(captureResponse.getActionId()));
-        Assert.assertEquals(captureRequest.getReference(), captureResponse.getReference());
+        assertFalse(StringUtils.isEmpty(captureResponse.getActionId()));
+        assertEquals(captureRequest.getReference(), captureResponse.getReference());
     }
 
     @Test
     public void can_void_payment() throws Exception {
-        PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
-        Assert.assertTrue(paymentResponse.getPayment().canVoid());
+        final PaymentRequest<CardSource> paymentRequest = TestHelper.createCardPaymentRequest();
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        assertTrue(paymentResponse.getPayment().canVoid());
 
-        VoidRequest voidRequest = new VoidRequest();
+        final VoidRequest voidRequest = new VoidRequest();
         voidRequest.setReference(UUID.randomUUID().toString());
 
-        VoidResponse voidResponse = getApi().paymentsClient().voidAsync(paymentResponse.getPayment().getId(), voidRequest).get();
+        final VoidResponse voidResponse = getApi().paymentsClient().voidAsync(paymentResponse.getPayment().getId(), voidRequest).get();
 
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(voidResponse.getActionId()));
-        Assert.assertEquals(voidRequest.getReference(), voidResponse.getReference());
+        assertFalse(StringUtils.isEmpty(voidResponse.getActionId()));
+        assertEquals(voidRequest.getReference(), voidResponse.getReference());
     }
 
     @Test
     public void can_refund_payment() throws Exception {
-        CardTokenRequest cardTokenRequest = TestHelper.createCardTokenRequest();
-        CardTokenResponse cardTokenResponse = getApi().tokensClient().requestAsync(cardTokenRequest).get();
-        PaymentRequest<TokenSource> paymentRequest = TestHelper.createTokenPaymentRequest(cardTokenResponse.getToken());
-        PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
-        Assert.assertTrue(paymentResponse.getPayment().canCapture());
+        final CardTokenRequest cardTokenRequest = TestHelper.createCardTokenRequest();
+        final CardTokenResponse cardTokenResponse = getApi().tokensClient().requestAsync(cardTokenRequest).get();
+        final PaymentRequest<TokenSource> paymentRequest = TestHelper.createTokenPaymentRequest(cardTokenResponse.getToken());
+        final PaymentResponse paymentResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
+        assertTrue(paymentResponse.getPayment().canCapture());
 
         getApi().paymentsClient().captureAsync(paymentResponse.getPayment().getId()).get();
 
-        RefundRequest refundRequest = new RefundRequest();
+        final RefundRequest refundRequest = new RefundRequest();
         refundRequest.setReference(UUID.randomUUID().toString());
 
-        RefundResponse refundResponse = getApi().paymentsClient().refundAsync(paymentResponse.getPayment().getId(), refundRequest).get();
+        final RefundResponse refundResponse = getApi().paymentsClient().refundAsync(paymentResponse.getPayment().getId(), refundRequest).get();
 
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(refundResponse.getActionId()));
-        Assert.assertEquals(refundRequest.getReference(), refundResponse.getReference());
+        assertFalse(StringUtils.isEmpty(refundResponse.getActionId()));
+        assertEquals(refundRequest.getReference(), refundResponse.getReference());
     }
 }

--- a/src/test/java/com/checkout/payments/TokenSourceTest.java
+++ b/src/test/java/com/checkout/payments/TokenSourceTest.java
@@ -1,28 +1,17 @@
 package com.checkout.payments;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-@RunWith(Parameterized.class)
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class TokenSourceTest {
 
-    @Parameterized.Parameter
-    public String invalidToken;
-
-    @Parameterized.Parameters
-    public static List<String> invalidTokens() {
-        List<String> list = new ArrayList<>();
-        Collections.addAll(list, "", " ", null);
-        return list;
+    @ParameterizedTest
+    @ValueSource(strings = {"", "", "  "})
+    public void given_token_invalid_should_throw_exception(final String input) {
+        assertThrows(IllegalArgumentException.class, () -> new TokenSource(input));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void given_token_invalid_should_throw_exception() {
-        new TokenSource(invalidToken);
-    }
 }

--- a/src/test/java/com/checkout/payments/beta/AbstractPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/AbstractPaymentsTestIT.java
@@ -27,8 +27,8 @@ import static com.checkout.payments.beta.CardSourceHelper.getCardSourcePayment;
 import static com.checkout.payments.beta.CardSourceHelper.getCorporateSender;
 import static com.checkout.payments.beta.CardSourceHelper.getIndividualSender;
 import static com.checkout.payments.beta.CardSourceHelper.getRequestCardSource;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractPaymentsTestIT extends SandboxTestFixture {
 

--- a/src/test/java/com/checkout/payments/beta/CaptureTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/CaptureTestIT.java
@@ -4,15 +4,15 @@ import com.checkout.payments.beta.capture.CaptureRequest;
 import com.checkout.payments.beta.capture.CaptureResponse;
 import com.checkout.payments.beta.response.PaymentResponse;
 import com.checkout.payments.beta.response.source.ResponseCardSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CaptureTestIT extends AbstractPaymentsTestIT {
 

--- a/src/test/java/com/checkout/payments/beta/GetPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/GetPaymentsTestIT.java
@@ -18,7 +18,7 @@ import com.checkout.payments.beta.response.PaymentResponse;
 import com.checkout.payments.beta.response.PaymentStatus;
 import com.checkout.payments.beta.response.source.ResponseCardSource;
 import com.checkout.payments.beta.sender.RequestIndividualSender;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -30,10 +30,11 @@ import java.util.concurrent.TimeoutException;
 import static com.checkout.payments.beta.CardSourceHelper.getCardSourcePayment;
 import static com.checkout.payments.beta.CardSourceHelper.getIndividualSender;
 import static com.checkout.payments.beta.CardSourceHelper.getRequestCardSource;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class GetPaymentsTestIT extends AbstractPaymentsTestIT {
 
@@ -47,9 +48,9 @@ public class GetPaymentsTestIT extends AbstractPaymentsTestIT {
         }
     }
 
-    @Test(expected = TimeoutException.class)
-    public void shouldHandleTimeout() throws Exception {
-        paymentsClient.getPayment("fake").get(5, TimeUnit.MILLISECONDS);
+    @Test
+    public void shouldHandleTimeout() {
+        assertThrows(TimeoutException.class, () -> paymentsClient.getPayment("fake").get(5, TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/src/test/java/com/checkout/payments/beta/PaymentsClientTest.java
+++ b/src/test/java/com/checkout/payments/beta/PaymentsClientTest.java
@@ -20,11 +20,11 @@ import com.checkout.payments.beta.response.source.ResponseIdSource;
 import com.checkout.payments.beta.sender.RequestInstrumentSender;
 import com.checkout.payments.beta.voids.VoidRequest;
 import com.checkout.payments.beta.voids.VoidResponse;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,15 +38,15 @@ import static com.checkout.payments.beta.PaymentsClientImpl.PAYMENT_ACTION_TYPE;
 import static com.checkout.payments.beta.PaymentsClientImpl.PAYMENT_TYPE;
 import static com.checkout.payments.beta.PaymentsClientImpl.REFUNDS_PATH;
 import static com.checkout.payments.beta.PaymentsClientImpl.VOIDS_PATH;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PaymentsClientTest {
 
     @Mock
@@ -57,7 +57,7 @@ public class PaymentsClientTest {
 
     private PaymentsClient paymentsClient;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         paymentsClient = new PaymentsClientImpl(apiClient, checkoutConfiguration);
     }

--- a/src/test/java/com/checkout/payments/beta/RefundPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/RefundPaymentsTestIT.java
@@ -7,16 +7,16 @@ import com.checkout.payments.beta.request.source.RequestCardSource;
 import com.checkout.payments.beta.response.PaymentResponse;
 import com.checkout.payments.beta.response.source.ResponseCardSource;
 import com.checkout.payments.beta.sender.RequestCorporateSender;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
 import static com.checkout.payments.beta.CardSourceHelper.getCardSourcePayment;
 import static com.checkout.payments.beta.CardSourceHelper.getCorporateSender;
 import static com.checkout.payments.beta.CardSourceHelper.getRequestCardSource;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RefundPaymentsTestIT extends AbstractPaymentsTestIT {
 

--- a/src/test/java/com/checkout/payments/beta/RequestPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/RequestPaymentsTestIT.java
@@ -19,17 +19,17 @@ import com.checkout.payments.beta.response.source.ResponseCardSource;
 import com.checkout.payments.beta.sender.RequestCorporateSender;
 import com.checkout.payments.beta.sender.RequestIndividualSender;
 import com.checkout.tokens.beta.CardTokenResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
 import static com.checkout.payments.beta.CardSourceHelper.getCorporateSender;
 import static com.checkout.payments.beta.CardSourceHelper.getIndividualSender;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RequestPaymentsTestIT extends AbstractPaymentsTestIT {
 

--- a/src/test/java/com/checkout/payments/beta/VoidPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/VoidPaymentsTestIT.java
@@ -5,12 +5,12 @@ import com.checkout.payments.beta.response.source.ResponseCardSource;
 import com.checkout.payments.beta.response.source.ResponseIdSource;
 import com.checkout.payments.beta.voids.VoidRequest;
 import com.checkout.payments.beta.voids.VoidResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class VoidPaymentsTestIT extends AbstractPaymentsTestIT {
 

--- a/src/test/java/com/checkout/payments/beta/payout/PayoutsTest.java
+++ b/src/test/java/com/checkout/payments/beta/payout/PayoutsTest.java
@@ -4,9 +4,9 @@ import com.checkout.payments.beta.payout.source.RequestCurrencyAccountSource;
 import com.checkout.payments.beta.sender.RequestCorporateSender;
 import com.checkout.payments.beta.sender.RequestIndividualSender;
 import com.checkout.payments.beta.sender.RequestInstrumentSender;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PayoutsTest {
 

--- a/src/test/java/com/checkout/payments/beta/request/PaymentsTest.java
+++ b/src/test/java/com/checkout/payments/beta/request/PaymentsTest.java
@@ -7,9 +7,9 @@ import com.checkout.payments.beta.request.source.RequestTokenSource;
 import com.checkout.payments.beta.sender.RequestCorporateSender;
 import com.checkout.payments.beta.sender.RequestIndividualSender;
 import com.checkout.payments.beta.sender.RequestInstrumentSender;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PaymentsTest {
 

--- a/src/test/java/com/checkout/payments/hosted/HostedPaymentsClientImplTest.java
+++ b/src/test/java/com/checkout/payments/hosted/HostedPaymentsClientImplTest.java
@@ -4,24 +4,24 @@ import com.checkout.ApiClient;
 import com.checkout.ApiCredentials;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.TestHelper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HostedPaymentsClientImplTest {
 
     private static final String REFERENCE = "ORD-1234";
@@ -38,7 +38,7 @@ public class HostedPaymentsClientImplTest {
     @Mock
     private CompletableFuture<HostedPaymentResponse> responseAsync;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         responseAsync = CompletableFuture.completedFuture(response);
         when(response.getReference()).thenReturn(REFERENCE);

--- a/src/test/java/com/checkout/payments/hosted/HostedPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/hosted/HostedPaymentsTestIT.java
@@ -3,13 +3,13 @@ package com.checkout.payments.hosted;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HostedPaymentsTestIT extends SandboxTestFixture {
 

--- a/src/test/java/com/checkout/payments/links/PaymentLinksClientImplTest.java
+++ b/src/test/java/com/checkout/payments/links/PaymentLinksClientImplTest.java
@@ -5,27 +5,27 @@ import com.checkout.ApiCredentials;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.TestHelper;
 import com.checkout.payments.PaymentStatus;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PaymentLinksClientImplTest {
 
     private static final String REFERENCE = "ORD-1234";
@@ -52,14 +52,12 @@ public class PaymentLinksClientImplTest {
 
     private PaymentLinkRequest paymentLinksRequest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         paymentLinkAsync = CompletableFuture.completedFuture(paymentLinkResponse);
         paymentLinkDetailAsync = CompletableFuture.completedFuture(paymentLinkDetailsResponse);
         client = new PaymentLinksClientImpl(apiClient, configuration);
         paymentLinksRequest = TestHelper.createPaymentLinksRequest(REFERENCE);
-        setUpPaymentLinkResponse();
-        setUpPaymentLinkDetailsResponse();
     }
 
     private void setUpPaymentLinkResponse() {
@@ -83,6 +81,7 @@ public class PaymentLinksClientImplTest {
 
     @Test
     public void shouldCreatePaymentsLink() throws ExecutionException, InterruptedException {
+        setUpPaymentLinkDetailsResponse();
         Mockito.doReturn(paymentLinkDetailAsync)
                 .when(apiClient).getAsync(eq(PaymentLinksClientImpl.PAYMENT_LINKS + "/" + REFERENCE),
                 any(ApiCredentials.class),
@@ -103,6 +102,7 @@ public class PaymentLinksClientImplTest {
 
     @Test
     public void shouldRetrievePaymentsLink() throws ExecutionException, InterruptedException {
+        setUpPaymentLinkResponse();
         Mockito.doReturn(paymentLinkAsync)
                 .when(apiClient).postAsync(eq(PaymentLinksClientImpl.PAYMENT_LINKS), any(ApiCredentials.class),
                 eq(PaymentLinkResponse.class), any(PaymentLinkRequest.class), any());
@@ -111,4 +111,5 @@ public class PaymentLinksClientImplTest {
         assertEquals(paymentLinksRequest.getReference(), response.getReference());
         assertNotNull(response.getLinks());
     }
+
 }

--- a/src/test/java/com/checkout/payments/links/PaymentLinksTestIT.java
+++ b/src/test/java/com/checkout/payments/links/PaymentLinksTestIT.java
@@ -4,16 +4,16 @@ import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
 import com.checkout.payments.PaymentStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PaymentLinksTestIT extends SandboxTestFixture {
 

--- a/src/test/java/com/checkout/sources/SourcesTestIT.java
+++ b/src/test/java/com/checkout/sources/SourcesTestIT.java
@@ -3,10 +3,14 @@ package com.checkout.sources;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.common.Address;
-import com.checkout.common.CheckoutUtils;
 import com.checkout.common.Phone;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SourcesTestIT extends SandboxTestFixture {
 
@@ -16,20 +20,20 @@ public class SourcesTestIT extends SandboxTestFixture {
 
     @Test
     public void can_request_sepa_source() throws Exception {
-        SourceRequest sourceRequest = createSepaSourceRequest();
-        SourceResponse sourceResponse = getApi().sourcesClient().requestAsync(sourceRequest).get();
+        final SourceRequest sourceRequest = createSepaSourceRequest();
+        final SourceResponse sourceResponse = getApi().sourcesClient().requestAsync(sourceRequest).get();
 
-        Assert.assertNotNull(sourceResponse);
-        SourceProcessed source = sourceResponse.getSource();
-        Assert.assertFalse(CheckoutUtils.isNullOrEmpty(source.getId()));
-        Assert.assertEquals("10000", source.getResponseCode());
-        Assert.assertNotNull(source.getResponseData());
-        Assert.assertTrue(sourceRequest.getType().equalsIgnoreCase(source.getType()));
-        Assert.assertTrue(source.getResponseData().containsKey("mandate_reference"));
+        assertNotNull(sourceResponse);
+        final SourceProcessed source = sourceResponse.getSource();
+        assertFalse(StringUtils.isEmpty(source.getId()));
+        assertEquals("10000", source.getResponseCode());
+        assertNotNull(source.getResponseData());
+        assertTrue(sourceRequest.getType().equalsIgnoreCase(source.getType()));
+        assertTrue(source.getResponseData().containsKey("mandate_reference"));
     }
 
     private SourceRequest createSepaSourceRequest() {
-        Address billingAddress = new Address();
+        final Address billingAddress = new Address();
         billingAddress.setAddressLine1("Checkout.com");
         billingAddress.setAddressLine2("90 Tottenham Court Road");
         billingAddress.setCity("London");
@@ -37,11 +41,11 @@ public class SourcesTestIT extends SandboxTestFixture {
         billingAddress.setZip("W1T 4TJ");
         billingAddress.setCountry("GB");
 
-        Phone phone = new Phone();
+        final Phone phone = new Phone();
         phone.setCountryCode("+1");
         phone.setNumber("415 555 2671");
 
-        SourceData sourceData = new SourceData();
+        final SourceData sourceData = new SourceData();
         sourceData.put("first_name", "Marcus");
         sourceData.put("last_name", "Barrilius Maximus");
         sourceData.put("account_iban", "DE68100100101234567895");
@@ -49,7 +53,7 @@ public class SourcesTestIT extends SandboxTestFixture {
         sourceData.put("billing_descriptor", "Java SDK test");
         sourceData.put("mandate_type", "single");
 
-        SourceRequest request = new SourceRequest("sepa", billingAddress);
+        final SourceRequest request = new SourceRequest("sepa", billingAddress);
         request.setPhone(phone);
         request.setReference("Java SDK test");
         request.setSourceData(sourceData);

--- a/src/test/java/com/checkout/tokens/TokensTestIT.java
+++ b/src/test/java/com/checkout/tokens/TokensTestIT.java
@@ -5,10 +5,14 @@ import com.checkout.SandboxTestFixture;
 import com.checkout.TestCardSource;
 import com.checkout.common.Address;
 import com.checkout.common.Phone;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TokensTestIT extends SandboxTestFixture {
 
@@ -18,30 +22,30 @@ public class TokensTestIT extends SandboxTestFixture {
 
     @Test
     public void can_tokenize_card() throws Exception {
-        CardTokenRequest request = createValidRequest();
-        CardTokenResponse token = getApi().tokensClient().requestAsync(request).get();
+        final CardTokenRequest request = createValidRequest();
+        final CardTokenResponse token = getApi().tokensClient().requestAsync(request).get();
 
-        Assert.assertNotNull(token);
-        Assert.assertNotNull(token.getToken());
-        Assert.assertNotEquals(token.getToken().trim(), "");
-        Assert.assertTrue(token.getExpiresOn().isAfter(Instant.now()));
-        Assert.assertNotNull(token.getBillingAddress());
-        Assert.assertEquals(token.getBillingAddress().getAddressLine1(), request.getBillingAddress().getAddressLine1());
-        Assert.assertEquals(token.getBillingAddress().getAddressLine2(), request.getBillingAddress().getAddressLine2());
-        Assert.assertEquals(token.getBillingAddress().getCity(), request.getBillingAddress().getCity());
-        Assert.assertEquals(token.getBillingAddress().getState(), request.getBillingAddress().getState());
-        Assert.assertEquals(token.getBillingAddress().getZip(), request.getBillingAddress().getZip());
-        Assert.assertEquals(token.getBillingAddress().getCountry(), request.getBillingAddress().getCountry());
-        Assert.assertNotNull(token.getPhone());
-        Assert.assertEquals(token.getPhone().getCountryCode(), request.getPhone().getCountryCode());
-        Assert.assertEquals(token.getPhone().getNumber(), request.getPhone().getNumber());
-        Assert.assertEquals(token.getType(), "card");
-        Assert.assertEquals(token.getExpiryMonth(), request.getExpiryMonth());
-        Assert.assertEquals(token.getExpiryYear(), request.getExpiryYear());
+        assertNotNull(token);
+        assertNotNull(token.getToken());
+        assertNotEquals(token.getToken().trim(), "");
+        assertTrue(token.getExpiresOn().isAfter(Instant.now()));
+        assertNotNull(token.getBillingAddress());
+        assertEquals(token.getBillingAddress().getAddressLine1(), request.getBillingAddress().getAddressLine1());
+        assertEquals(token.getBillingAddress().getAddressLine2(), request.getBillingAddress().getAddressLine2());
+        assertEquals(token.getBillingAddress().getCity(), request.getBillingAddress().getCity());
+        assertEquals(token.getBillingAddress().getState(), request.getBillingAddress().getState());
+        assertEquals(token.getBillingAddress().getZip(), request.getBillingAddress().getZip());
+        assertEquals(token.getBillingAddress().getCountry(), request.getBillingAddress().getCountry());
+        assertNotNull(token.getPhone());
+        assertEquals(token.getPhone().getCountryCode(), request.getPhone().getCountryCode());
+        assertEquals(token.getPhone().getNumber(), request.getPhone().getNumber());
+        assertEquals(token.getType(), "card");
+        assertEquals(token.getExpiryMonth(), request.getExpiryMonth());
+        assertEquals(token.getExpiryYear(), request.getExpiryYear());
     }
 
     private CardTokenRequest createValidRequest() {
-        Address billingAddress = new Address();
+        final Address billingAddress = new Address();
         billingAddress.setAddressLine1("Checkout.com");
         billingAddress.setAddressLine2("90 Tottenham Court Road");
         billingAddress.setCity("London");
@@ -49,11 +53,11 @@ public class TokensTestIT extends SandboxTestFixture {
         billingAddress.setZip("W1T 4TJ");
         billingAddress.setCountry("GB");
 
-        Phone phone = new Phone();
+        final Phone phone = new Phone();
         phone.setCountryCode("44");
         phone.setNumber("020 222333");
 
-        CardTokenRequest request = new CardTokenRequest(TestCardSource.VISA.getNumber(), TestCardSource.VISA.getExpiryMonth(), TestCardSource.VISA.getExpiryYear());
+        final CardTokenRequest request = new CardTokenRequest(TestCardSource.VISA.getNumber(), TestCardSource.VISA.getExpiryMonth(), TestCardSource.VISA.getExpiryYear());
         request.setCvv(TestCardSource.VISA.getCvv());
         request.setBillingAddress(billingAddress);
         request.setPhone(phone);

--- a/src/test/java/com/checkout/tokens/beta/TokensClientTest.java
+++ b/src/test/java/com/checkout/tokens/beta/TokensClientTest.java
@@ -4,22 +4,22 @@ import com.checkout.ApiClient;
 import com.checkout.CheckoutArgumentException;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.PublicKeyCredentials;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.checkout.TestHelper.mockFourConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TokensClientTest {
 
     @Mock
@@ -29,7 +29,7 @@ public class TokensClientTest {
 
     private TokensClient tokensClient;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.checkoutConfiguration = mockFourConfiguration();
         this.tokensClient = new TokensClientImpl(apiClient, checkoutConfiguration);

--- a/src/test/java/com/checkout/tokens/beta/TokensTestIT.java
+++ b/src/test/java/com/checkout/tokens/beta/TokensTestIT.java
@@ -3,13 +3,13 @@ package com.checkout.tokens.beta;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestCardSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TokensTestIT extends SandboxTestFixture {
 

--- a/src/test/java/com/checkout/webhooks/WebhooksTestIT.java
+++ b/src/test/java/com/checkout/webhooks/WebhooksTestIT.java
@@ -2,11 +2,14 @@ package com.checkout.webhooks;
 
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WebhooksTestIT extends SandboxTestFixture {
 
@@ -16,42 +19,42 @@ public class WebhooksTestIT extends SandboxTestFixture {
 
     @Test
     public void can_create_webhook() throws Exception {
-        WebhookRequest webhookRequest = WebhookRequest.builder()
+        final WebhookRequest webhookRequest = WebhookRequest.builder()
                 .url("https://google.com/fail")
                 .eventTypes(Collections.singletonList("payment_captured"))
                 .build();
-        WebhookResponse webhookResponse = getApi().webhooksClient().registerWebhook(webhookRequest).get();
-        Assert.assertNotNull(webhookResponse);
+        final WebhookResponse webhookResponse = getApi().webhooksClient().registerWebhook(webhookRequest).get();
+        assertNotNull(webhookResponse);
 
-        String id = webhookResponse.getId();
-        Assert.assertNotNull(id);
+        final String id = webhookResponse.getId();
+        assertNotNull(id);
     }
 
     @Test
     public void can_retrieve_webhook() throws Exception {
-        WebhookRequest webhookRequest = WebhookRequest.builder()
+        final WebhookRequest webhookRequest = WebhookRequest.builder()
                 .url("https://google.com/fail")
                 .eventTypes(Collections.singletonList("payment_captured"))
                 .build();
-        WebhookResponse webhookResponse = getApi().webhooksClient().registerWebhook(webhookRequest).get();
-        String id = webhookResponse.getId();
+        final WebhookResponse webhookResponse = getApi().webhooksClient().registerWebhook(webhookRequest).get();
+        final String id = webhookResponse.getId();
 
         WebhookResponse webhook = getApi().webhooksClient().retrieveWebhook(id).get();
-        Assert.assertEquals(webhookRequest.getUrl(), webhook.getUrl());
-        Assert.assertEquals(webhookRequest.getEventTypes(), webhook.getEventTypes());
-        Assert.assertTrue(webhook.isActive());
-        Assert.assertEquals("json", webhook.getContentType());
-        Assert.assertEquals(1, webhook.getHeaders().size());
-        Assert.assertTrue(webhook.getHeaders().containsKey("authorization"));
-        Assert.assertNotNull(webhook.getHeaders().get("authorization"));
+        assertEquals(webhookRequest.getUrl(), webhook.getUrl());
+        assertEquals(webhookRequest.getEventTypes(), webhook.getEventTypes());
+        assertTrue(webhook.isActive());
+        assertEquals("json", webhook.getContentType());
+        assertEquals(1, webhook.getHeaders().size());
+        assertTrue(webhook.getHeaders().containsKey("authorization"));
+        assertNotNull(webhook.getHeaders().get("authorization"));
 
-        List<WebhookResponse> response = getApi().webhooksClient().retrieveWebhooks().get();
-        Assert.assertNotNull(response);
+        final List<WebhookResponse> response = getApi().webhooksClient().retrieveWebhooks().get();
+        assertNotNull(response);
 
         webhook = response.stream().filter(it -> id.equals(it.getId())).findFirst().orElse(null);
-        Assert.assertNotNull(webhook);
-        Assert.assertEquals(webhookRequest.getUrl(), webhook.getUrl());
-        Assert.assertEquals(webhookRequest.getEventTypes(), webhook.getEventTypes());
+        assertNotNull(webhook);
+        assertEquals(webhookRequest.getUrl(), webhook.getUrl());
+        assertEquals(webhookRequest.getEventTypes(), webhook.getEventTypes());
     }
 
     @Test
@@ -60,41 +63,41 @@ public class WebhooksTestIT extends SandboxTestFixture {
                 .url("https://google.com/fail")
                 .eventTypes(Collections.singletonList("payment_captured"))
                 .build();
-        WebhookResponse webhookResponse = getApi().webhooksClient().registerWebhook(webhookRequest).get();
-        String id = webhookResponse.getId();
+        final WebhookResponse webhookResponse = getApi().webhooksClient().registerWebhook(webhookRequest).get();
+        final String id = webhookResponse.getId();
 
         webhookRequest = webhookResponse.toRequest();
         webhookRequest.setUrl("https://google.com/fail2");
 
-        WebhookResponse webhook = getApi().webhooksClient().updateWebhook(id, webhookRequest).get();
-        Assert.assertEquals(webhookRequest.getUrl(), webhook.getUrl());
-        Assert.assertEquals(webhookRequest.getEventTypes(), webhook.getEventTypes());
+        final WebhookResponse webhook = getApi().webhooksClient().updateWebhook(id, webhookRequest).get();
+        assertEquals(webhookRequest.getUrl(), webhook.getUrl());
+        assertEquals(webhookRequest.getEventTypes(), webhook.getEventTypes());
     }
 
     @Test
     public void can_delete_webhook() throws Exception {
-        WebhookRequest webhookRequest = WebhookRequest.builder()
+        final WebhookRequest webhookRequest = WebhookRequest.builder()
                 .url("https://google.com/fail")
                 .eventTypes(Collections.singletonList("payment_captured"))
                 .build();
-        WebhookResponse webhookResponse = getApi().webhooksClient().registerWebhook(webhookRequest).get();
-        String id = webhookResponse.getId();
+        final WebhookResponse webhookResponse = getApi().webhooksClient().registerWebhook(webhookRequest).get();
+        final String id = webhookResponse.getId();
 
-        List<WebhookResponse> responseBeforeRemoval = getApi().webhooksClient().retrieveWebhooks().get();
+        final List<WebhookResponse> responseBeforeRemoval = getApi().webhooksClient().retrieveWebhooks().get();
         getApi().webhooksClient().removeWebhook(id).get();
-        List<WebhookResponse> responseAfterRemoval = getApi().webhooksClient().retrieveWebhooks().get();
-        Assert.assertEquals(responseBeforeRemoval.size() - 1, responseAfterRemoval.size());
+        final List<WebhookResponse> responseAfterRemoval = getApi().webhooksClient().retrieveWebhooks().get();
+        assertEquals(responseBeforeRemoval.size() - 1, responseAfterRemoval.size());
 
         responseAfterRemoval.stream()
                 .map(WebhookResponse::getId)
                 .forEach(it -> {
                     try {
                         getApi().webhooksClient().removeWebhook(it).get();
-                    } catch (Exception e) {
+                    } catch (final Exception e) {
                         throw new IllegalStateException(e);
                     }
                 });
-        List<WebhookResponse> emptyResponse = getApi().webhooksClient().retrieveWebhooks().get();
-        Assert.assertTrue(emptyResponse.isEmpty());
+        final List<WebhookResponse> emptyResponse = getApi().webhooksClient().retrieveWebhooks().get();
+        assertTrue(emptyResponse.isEmpty());
     }
 }


### PR DESCRIPTION
Testing dependencies were updated in order to be compatible
with JUnit 5. This includes:

- junit bom 5.7.2 (core and params)
- hamcrest 2.2 (not included in JUnit anymore)
- mockito junit 3.11.2

Unit tests were refactored to use the JUnit 5 imports and
static imports. Tests using deprecated methods from `CheckoutUtils`
were refactored. The test failing in `CardDestinationPaymentTestIT`
was refactored to mirror the new API async behaviour when performing
a payout.