### PR TITLE
Add support for Baloto, Boleto, Fawry and Giropay APMs (CS1)

### DIFF
--- a/documentation/docs/api/alternative-payments/_category_.json
+++ b/documentation/docs/api/alternative-payments/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Alternative Payments",
+  "position": 9
+}

--- a/documentation/docs/api/alternative-payments/baloto.md
+++ b/documentation/docs/api/alternative-payments/baloto.md
@@ -1,0 +1,36 @@
+---
+id: baloto
+title: Baloto
+sidebar_position: 1
+---
+
+More information on this topic can be found in the [official docs](https://docs.checkout.com/payments/payment-methods/cash-and-atm-payment/via-baloto).
+
+## Request a Baloto payment
+
+```java
+BalotoSource balotoSource = BalotoSource.builder()
+        .country("CO")
+        .description("simulate Via Baloto Demo Payment")
+        .payer(BalotoSource.Payer.builder()
+               .email("bruce@wayne-enterprises.com")
+               .name("Bruce Wayne")
+               .build())
+        .build();
+
+PaymentRequest<BalotoSource> request = PaymentRequest.baloto(balotoSource, com.checkout.common.beta.Currency.COP, 100000L);
+
+PaymentResponse response = api.paymentsClient().requestAsync(request).get();
+```
+## Succeed a Baloto payment
+
+```java
+api.balotoClient().succeed(paymentId).get();
+```
+
+## Expire a Baloto payment
+
+```java
+api.balotoClient().expire(paymentId).get();
+```
+

--- a/documentation/docs/api/alternative-payments/boleto.md
+++ b/documentation/docs/api/alternative-payments/boleto.md
@@ -1,0 +1,45 @@
+---
+id: boleto
+title: Boleto
+sidebar_position: 2
+---
+
+More information on this topic can be found in the [official docs](https://docs.checkout.com/payments/payment-methods/cash-and-atm-payment/boleto-bancario).
+
+## Request a "Redirect" Baloto payment
+
+```java
+BoletoSource boletoSource = BoletoSource.builder()
+        .country("BR")
+        .description("boleto payment")
+        .integrationType(IntegrationType.REDIRECT)
+        .payer(BoletoSource.Payer.builder()
+                    .email("john@doe-enterprises.com")
+                    .name("John Doe")
+                    .document("53033315550").build())
+        .build();
+
+PaymentRequest<BoletoSource> request = PaymentRequest.boleto(boletoSource, com.checkout.common.beta.Currency.BRL, 100L);
+
+PaymentResponse response = api.paymentsClient().requestAsync(request).get();
+
+String redirectURL = response.getPending().getRedirectLink().getHref()
+```
+
+## Request a "Direct" Baloto payment
+
+```java
+BoletoSource boletoSource = BoletoSource.builder()
+        .country("BR")
+        .description("boleto payment")
+        .integrationType(IntegrationType.DIRECT)
+        .payer(BoletoSource.Payer.builder()
+                    .email("john@doe-enterprises.com")
+                    .name("John Doe")
+                    .document("53033315550").build())
+        .build();
+
+PaymentRequest<BoletoSource> request = PaymentRequest.boleto(boletoSource, com.checkout.common.beta.Currency.BRL, 100L);
+
+PaymentResponse response = api.paymentsClient().requestAsync(request).get();
+```

--- a/documentation/docs/api/alternative-payments/fawry.md
+++ b/documentation/docs/api/alternative-payments/fawry.md
@@ -1,0 +1,43 @@
+---
+id: fawry
+title: Fawry
+sidebar_position: 3
+---
+
+More information on this topic can be found in the [official docs](https://docs.checkout.com/payments/payment-methods/cash-and-atm-payment/fawry).
+
+## Request a Fawry payment
+
+```java
+FawrySource fawrySource = FawrySource.builder()
+        .description("Fawry Demo Payment")
+        .customerEmail("bruce@wayne-enterprises.com")
+        .customerMobile("01058375055")
+        .products(Collections.singletonList(
+                FawrySource.Product.builder()
+                        .id("0123456789")
+                        .description("Fawry Demo Product")
+                        .price(1000L)
+                        .quantity(1L)
+                        .build()
+        ))
+        .build();
+
+PaymentRequest<FawrySource> request = PaymentRequest.fawry(fawrySource, com.checkout.common.beta.Currency.EGP, 1000L);
+
+PaymentResponse response = api.paymentsClient().requestAsync(request).get();
+
+String approvalURL = response.getPending().getLink("approve").getHref();
+String cancellationURL = response.getPending().getLink("cancel").getHref();
+```
+## Approve a Fawry payment
+
+```java
+api.fawryClient().approve(paymentReference).get();
+```
+
+## Expire a Fawry payment
+
+```java
+api.fawryClient().cancel(paymentReference).get();
+```

--- a/documentation/docs/api/alternative-payments/giropay.md
+++ b/documentation/docs/api/alternative-payments/giropay.md
@@ -1,0 +1,33 @@
+---
+id: giropay
+title: Giropay
+sidebar_position: 4
+---
+
+More information on this topic can be found in the [official docs](https://docs.checkout.com/payments/payment-methods/bank-transfers/giropay).
+
+## Request a Giropay payment
+
+```java
+GiropaySource giropaySource = GiropaySource.builder()
+        .bic("TESTDETT421")
+        .purpose("CKO Giropay test")
+        .build();
+
+PaymentRequest<GiropaySource> request = PaymentRequest.giropay(giropaySource, com.checkout.common.beta.Currency.EUR, 1000L);
+
+PaymentResponse response = api.paymentsClient().requestAsync(request).get();
+
+redirectURL = response.getPending().getRedirectLink().getHref()
+```
+## Get Giropay list of supported Banks
+
+```java
+BanksResponse banksResponse = api.giropayClient().getBanks().get();
+```
+
+## Get Giropay list of supported EPS Banks
+
+```java
+BanksResponse banksResponse = api.giropayClient().getEpsBanks().get();
+```

--- a/documentation/docs/api/payments.md
+++ b/documentation/docs/api/payments.md
@@ -104,52 +104,6 @@ paymentRequest.setReference("ORD-456");
 PaymentResponse response = api.paymentsClient().requestAsync(paymentRequest).get();
 ```
 
-## Request a payment for a <Highlight color="#25c2a0">local payment method</Highlight>
-
-The [API Reference](https://api-reference.checkout.com/#tag/Payments/paths/~1payments/post) contains a list of local payment options that you can use, as well as the other information required in the payment source (if required).
-
-This is an example of a payment request for [Giropay](https://docs.checkout.com/payment-methods/bank-transfers/giropay):
-
-```java
-AlternativePaymentSource alternativePaymentSource =
-  new AlternativePaymentSource("giropay");
-alternativePaymentSource.put("bic", "TESTDETT421");
-alternativePaymentSource.put("purpose", "CKO Giropay test");
-
-PaymentRequest<RequestSource> paymentRequest =
-  PaymentRequest.fromSource(alternativePaymentSource, Currency.EUR, 1000); //cents
-
-PaymentResponse response = api.paymentsClient().requestAsync(paymentRequest).get();
-```
-
-This request is meant to return a redirection URL, so you can let the customer complete the transaction on the local payment method's website. Normally a successful response would look like this:
-
-```json
-{
-  "id": "pay_d3ohhwwu3qderfjlzitknc26sq",
-  "status": "Pending",
-  "customer": {
-    "id": "cus_hfgq4ctsnr6e3cfhq5ctwb5gtu"
-  },
-  "_links": {
-    "self": {
-      "href": "https://api.sandbox.checkout.com/payments/pay_d3ohhwwu3qderfjlzitknc26sq"
-    },
-    "redirect": {
-      "href": "https://ftg-customer-integration.giropay.de/ftgbank/b/bankselection/219499703994809788;jsessionid=8ECFE1809F9BAB6635EC9D37D98A1CAE.sf-testapp01tom21?op=001"
-    }
-  }
-}
-```
-
-You can access the redirection URL via the SDK like so:
-
-```java
-PaymentPending pendingPayment = response.getPending();
-// Your redirect link
-pendingPayment.getRedirectLink();
-```
-
 ## Request a <Highlight color="#25c2a0">3D Secure payment</Highlight>
 
 You have the ability to authenticate with 3DS in a payment request. The request body is similar to normal card payments, but with some additional parameters. [Read more about 3DS](https://docs.checkout.com/docs/3d-secure-payments)

--- a/src/main/java/com/checkout/AbstractCheckoutApmApi.java
+++ b/src/main/java/com/checkout/AbstractCheckoutApmApi.java
@@ -1,0 +1,38 @@
+package com.checkout;
+
+import com.checkout.apm.baloto.BalotoClient;
+import com.checkout.apm.baloto.BalotoClientImpl;
+import com.checkout.apm.fawry.FawryClient;
+import com.checkout.apm.fawry.FawryClientImpl;
+import com.checkout.apm.giropay.GiropayClient;
+import com.checkout.apm.giropay.GiropayClientImpl;
+
+public abstract class AbstractCheckoutApmApi {
+
+    protected final ApiClient apiClient;
+
+    private final BalotoClient balotoClient;
+    private final FawryClient fawryClient;
+    private final GiropayClient giropayClient;
+
+    protected AbstractCheckoutApmApi(final ApiClient apiClient,
+                                     final CheckoutConfiguration configuration) {
+        this.apiClient = apiClient;
+        this.balotoClient = new BalotoClientImpl(apiClient, configuration);
+        this.fawryClient = new FawryClientImpl(apiClient, configuration);
+        this.giropayClient = new GiropayClientImpl(apiClient, configuration);
+    }
+
+    public BalotoClient balotoClient() {
+        return balotoClient;
+    }
+
+    public FawryClient fawryClient() {
+        return fawryClient;
+    }
+
+    public GiropayClient giropayClient() {
+        return giropayClient;
+    }
+
+}

--- a/src/main/java/com/checkout/AbstractClient.java
+++ b/src/main/java/com/checkout/AbstractClient.java
@@ -1,8 +1,5 @@
 package com.checkout;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static com.checkout.common.CheckoutUtils.requiresNonNull;
 
 public abstract class AbstractClient {
@@ -18,8 +15,7 @@ public abstract class AbstractClient {
     }
 
     protected static String constructApiPath(final String... pathParams) {
-        return Stream.of(pathParams)
-                .collect(Collectors.joining("/"));
+        return String.join("/", pathParams);
     }
 
 }

--- a/src/main/java/com/checkout/CheckoutApi.java
+++ b/src/main/java/com/checkout/CheckoutApi.java
@@ -12,7 +12,8 @@ import com.checkout.sources.SourcesClient;
 import com.checkout.tokens.TokensClient;
 import com.checkout.webhooks.WebhooksClient;
 
-public interface CheckoutApi {
+public interface CheckoutApi extends CheckoutApmApi {
+
     PaymentsClient paymentsClient();
 
     SourcesClient sourcesClient();
@@ -34,4 +35,5 @@ public interface CheckoutApi {
     DisputesClient disputesClient();
 
     ReconciliationClient reconciliationClient();
+
 }

--- a/src/main/java/com/checkout/CheckoutApiImpl.java
+++ b/src/main/java/com/checkout/CheckoutApiImpl.java
@@ -23,7 +23,7 @@ import com.checkout.tokens.TokensClientImpl;
 import com.checkout.webhooks.WebhooksClient;
 import com.checkout.webhooks.WebhooksClientImpl;
 
-public final class CheckoutApiImpl implements CheckoutApi {
+public final class CheckoutApiImpl extends AbstractCheckoutApmApi implements CheckoutApi {
 
     private final PaymentsClient paymentsClient;
     private final SourcesClient sourcesClient;
@@ -38,7 +38,7 @@ public final class CheckoutApiImpl implements CheckoutApi {
     private final ReconciliationClient reconciliationClient;
 
     public CheckoutApiImpl(final CheckoutConfiguration configuration) {
-        final ApiClient apiClient = new ApiClientImpl(configuration);
+        super(new ApiClientImpl(configuration), configuration);
         this.paymentsClient = new PaymentsClientImpl(apiClient, configuration);
         this.sourcesClient = new SourcesClientImpl(apiClient, configuration);
         this.tokensClient = new TokensClientImpl(apiClient, configuration);
@@ -53,6 +53,7 @@ public final class CheckoutApiImpl implements CheckoutApi {
     }
 
     public CheckoutApiImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
+        super(apiClient, configuration);
         this.paymentsClient = new PaymentsClientImpl(apiClient, configuration);
         this.sourcesClient = new SourcesClientImpl(apiClient, configuration);
         this.tokensClient = new TokensClientImpl(apiClient, configuration);

--- a/src/main/java/com/checkout/CheckoutApmApi.java
+++ b/src/main/java/com/checkout/CheckoutApmApi.java
@@ -1,0 +1,15 @@
+package com.checkout;
+
+import com.checkout.apm.baloto.BalotoClient;
+import com.checkout.apm.fawry.FawryClient;
+import com.checkout.apm.giropay.GiropayClient;
+
+public interface CheckoutApmApi {
+
+    BalotoClient balotoClient();
+
+    FawryClient fawryClient();
+
+    GiropayClient giropayClient();
+
+}

--- a/src/main/java/com/checkout/apm/baloto/BalotoClient.java
+++ b/src/main/java/com/checkout/apm/baloto/BalotoClient.java
@@ -1,0 +1,11 @@
+package com.checkout.apm.baloto;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface BalotoClient {
+
+    CompletableFuture<Void> succeed(String id);
+
+    CompletableFuture<Void> expire(String id);
+
+}

--- a/src/main/java/com/checkout/apm/baloto/BalotoClientImpl.java
+++ b/src/main/java/com/checkout/apm/baloto/BalotoClientImpl.java
@@ -1,0 +1,28 @@
+package com.checkout.apm.baloto;
+
+import com.checkout.AbstractClient;
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SecretKeyCredentials;
+
+import java.util.concurrent.CompletableFuture;
+
+public class BalotoClientImpl extends AbstractClient implements BalotoClient {
+
+    private static final String BALOTO_PATH = "/apms/baloto/payments";
+
+    public BalotoClientImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
+        super(apiClient, SecretKeyCredentials.fromConfiguration(configuration));
+    }
+
+    @Override
+    public CompletableFuture<Void> succeed(final String paymentId) {
+        return apiClient.postAsync(constructApiPath(BALOTO_PATH, paymentId, "succeed"), apiCredentials, Void.class, null, null);
+    }
+
+    @Override
+    public CompletableFuture<Void> expire(final String paymentId) {
+        return apiClient.postAsync(constructApiPath(BALOTO_PATH, paymentId, "expire"), apiCredentials, Void.class, null, null);
+    }
+
+}

--- a/src/main/java/com/checkout/apm/fawry/FawryClient.java
+++ b/src/main/java/com/checkout/apm/fawry/FawryClient.java
@@ -1,0 +1,11 @@
+package com.checkout.apm.fawry;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface FawryClient {
+
+    CompletableFuture<Void> approve(String reference);
+
+    CompletableFuture<Void> cancel(String reference);
+
+}

--- a/src/main/java/com/checkout/apm/fawry/FawryClientImpl.java
+++ b/src/main/java/com/checkout/apm/fawry/FawryClientImpl.java
@@ -1,0 +1,28 @@
+package com.checkout.apm.fawry;
+
+import com.checkout.AbstractClient;
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SecretKeyCredentials;
+
+import java.util.concurrent.CompletableFuture;
+
+public class FawryClientImpl extends AbstractClient implements FawryClient {
+
+    private static final String FAWRY_PATH = "/fawry/payments";
+
+    public FawryClientImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
+        super(apiClient, SecretKeyCredentials.fromConfiguration(configuration));
+    }
+
+    @Override
+    public CompletableFuture<Void> approve(final String reference) {
+        return apiClient.putAsync(constructApiPath(FAWRY_PATH, reference, "approval"), apiCredentials, Void.class, null);
+    }
+
+    @Override
+    public CompletableFuture<Void> cancel(final String reference) {
+        return apiClient.putAsync(constructApiPath(FAWRY_PATH, reference, "cancellation"), apiCredentials, Void.class, null);
+    }
+
+}

--- a/src/main/java/com/checkout/apm/giropay/BanksResponse.java
+++ b/src/main/java/com/checkout/apm/giropay/BanksResponse.java
@@ -1,0 +1,17 @@
+package com.checkout.apm.giropay;
+
+import com.checkout.common.Resource;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class BanksResponse extends Resource {
+
+    private final Map<String, String> banks;
+
+}

--- a/src/main/java/com/checkout/apm/giropay/GiropayClient.java
+++ b/src/main/java/com/checkout/apm/giropay/GiropayClient.java
@@ -1,0 +1,11 @@
+package com.checkout.apm.giropay;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface GiropayClient {
+
+    CompletableFuture<BanksResponse> getEpsBanks();
+
+    CompletableFuture<BanksResponse> getBanks();
+
+}

--- a/src/main/java/com/checkout/apm/giropay/GiropayClientImpl.java
+++ b/src/main/java/com/checkout/apm/giropay/GiropayClientImpl.java
@@ -1,0 +1,28 @@
+package com.checkout.apm.giropay;
+
+import com.checkout.AbstractClient;
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SecretKeyCredentials;
+
+import java.util.concurrent.CompletableFuture;
+
+public class GiropayClientImpl extends AbstractClient implements GiropayClient {
+
+    private static final String GIROPAY_PATH = "/giropay";
+
+    public GiropayClientImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
+        super(apiClient, SecretKeyCredentials.fromConfiguration(configuration));
+    }
+
+    @Override
+    public CompletableFuture<BanksResponse> getBanks() {
+        return apiClient.getAsync(constructApiPath(GIROPAY_PATH, "banks"), apiCredentials, BanksResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<BanksResponse> getEpsBanks() {
+        return apiClient.getAsync(constructApiPath(GIROPAY_PATH, "eps", "banks"), apiCredentials, BanksResponse.class);
+    }
+
+}

--- a/src/main/java/com/checkout/payments/AlternativePaymentSource.java
+++ b/src/main/java/com/checkout/payments/AlternativePaymentSource.java
@@ -6,12 +6,16 @@ import lombok.ToString;
 
 import java.util.HashMap;
 
+/**
+ * @deprecated Use a specific payment source at {@link com.checkout.payments.apm}
+ */
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@Deprecated
 public class AlternativePaymentSource extends HashMap<String, Object> implements RequestSource {
     private static final String TYPE_FIELD = "type";
 
-    public AlternativePaymentSource(String type) {
+    public AlternativePaymentSource(final String type) {
         if (CheckoutUtils.isNullOrWhitespace(type)) {
             throw new IllegalArgumentException("The alternative payment source type is required.");
         }
@@ -23,7 +27,7 @@ public class AlternativePaymentSource extends HashMap<String, Object> implements
         return get(TYPE_FIELD).toString();
     }
 
-    public void setType(String type) {
+    public void setType(final String type) {
         put(TYPE_FIELD, type);
     }
 }

--- a/src/main/java/com/checkout/payments/PaymentRequest.java
+++ b/src/main/java/com/checkout/payments/PaymentRequest.java
@@ -1,6 +1,10 @@
 package com.checkout.payments;
 
-import com.checkout.common.CheckoutUtils;
+import com.checkout.common.beta.Currency;
+import com.checkout.payments.apm.BalotoSource;
+import com.checkout.payments.apm.BoletoSource;
+import com.checkout.payments.apm.FawrySource;
+import com.checkout.payments.apm.GiropaySource;
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +14,9 @@ import lombok.NonNull;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+
+import static com.checkout.common.CheckoutUtils.requiresNonBlank;
+import static com.checkout.common.CheckoutUtils.requiresNonNull;
 
 @Data
 @Builder
@@ -45,16 +52,14 @@ public class PaymentRequest<T extends RequestSource> {
     private AuthorizationType authorizationType;
     private MarketplaceData marketplace;
 
-    private PaymentRequest(T sourceOrDestination, String currency, Long amount, boolean isSource) {
-        if (sourceOrDestination == null) {
-            throw new IllegalArgumentException(String.format("The payment %s is required.", isSource ? "source" : "destination"));
-        }
-        if (CheckoutUtils.isNullOrWhitespace(currency)) {
-            throw new IllegalArgumentException("The currency is required.");
-        }
-        if (amount != null && amount < 0) {
-            throw new IllegalArgumentException("The amount cannot be negative");
-        }
+    /**
+     * @deprecated Please use {@link PaymentRequest} constructor with {@link Currency} parameter enum type.
+     */
+    @Deprecated
+    private PaymentRequest(final T sourceOrDestination, final String currency, final Long amount, final boolean isSource) {
+        requiresNonNull("sourceOrDestination", sourceOrDestination);
+        requiresNonBlank("currency", currency);
+        requiresNonNull("amount", amount);
         this.source = isSource ? sourceOrDestination : null;
         this.destination = isSource ? null : sourceOrDestination;
         this.amount = amount;
@@ -62,11 +67,40 @@ public class PaymentRequest<T extends RequestSource> {
         this.metadata = new HashMap<>();
     }
 
-    public static <T extends RequestSource> PaymentRequest<T> fromSource(T source, String currency, Long amount) {
+    private PaymentRequest(final T sourceOrDestination, final Currency currency, final Long amount, final boolean isSource) {
+        requiresNonNull("sourceOrDestination", sourceOrDestination);
+        requiresNonNull("currency", currency);
+        requiresNonNull("amount", amount);
+        this.source = isSource ? sourceOrDestination : null;
+        this.destination = isSource ? null : sourceOrDestination;
+        this.amount = amount;
+        this.currency = currency.name();
+        this.metadata = new HashMap<>();
+    }
+
+
+    public static <T extends RequestSource> PaymentRequest<T> fromSource(final T source, final String currency, final Long amount) {
         return new PaymentRequest<>(source, currency, amount, true);
     }
 
-    public static <T extends RequestSource> PaymentRequest<T> fromDestination(T destination, String currency, Long amount) {
+    public static <T extends RequestSource> PaymentRequest<T> fromDestination(final T destination, final String currency, final Long amount) {
         return new PaymentRequest<>(destination, currency, amount, false);
     }
+
+    public static PaymentRequest<BalotoSource> baloto(final BalotoSource balotoSource, final Currency currency, final Long amount) {
+        return new PaymentRequest<>(balotoSource, currency, amount, true);
+    }
+
+    public static PaymentRequest<BoletoSource> boleto(final BoletoSource balotoSource, final Currency currency, final Long amount) {
+        return new PaymentRequest<>(balotoSource, currency, amount, true);
+    }
+
+    public static PaymentRequest<FawrySource> fawry(final FawrySource fawrySource, final Currency currency, final Long amount) {
+        return new PaymentRequest<>(fawrySource, currency, amount, true);
+    }
+
+    public static PaymentRequest<GiropaySource> giropay(final GiropaySource giropaySource, final Currency currency, final Long amount) {
+        return new PaymentRequest<>(giropaySource, currency, amount, true);
+    }
+
 }

--- a/src/main/java/com/checkout/payments/apm/BalotoSource.java
+++ b/src/main/java/com/checkout/payments/apm/BalotoSource.java
@@ -1,0 +1,39 @@
+package com.checkout.payments.apm;
+
+import com.checkout.payments.RequestSource;
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+public final class BalotoSource implements RequestSource {
+
+    private final String type = "baloto";
+
+    @SerializedName("integration_type")
+    private final IntegrationType integrationType = IntegrationType.REDIRECT;
+
+    private final String country;
+
+    private final Payer payer;
+
+    private final String description;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Payer {
+        private String name;
+        private String email;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+}

--- a/src/main/java/com/checkout/payments/apm/BoletoSource.java
+++ b/src/main/java/com/checkout/payments/apm/BoletoSource.java
@@ -1,0 +1,40 @@
+package com.checkout.payments.apm;
+
+import com.checkout.payments.RequestSource;
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+public final class BoletoSource implements RequestSource {
+
+    private final String type = "boleto";
+
+    @SerializedName("integration_type")
+    private final IntegrationType integrationType;
+
+    private final String country;
+
+    private final Payer payer;
+
+    private final String description;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Payer {
+        private String name;
+        private String email;
+        private String document;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+}

--- a/src/main/java/com/checkout/payments/apm/FawrySource.java
+++ b/src/main/java/com/checkout/payments/apm/FawrySource.java
@@ -1,0 +1,50 @@
+package com.checkout.payments.apm;
+
+import com.checkout.payments.RequestSource;
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+public final class FawrySource implements RequestSource {
+
+    private final String type = "fawry";
+
+    private final String description;
+
+    @SerializedName("customer_mobile")
+    private final String customerMobile;
+
+    @SerializedName("customer_email")
+    private final String customerEmail;
+
+    private final List<Product> products;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Product {
+
+        @SerializedName("product_id")
+        private String id;
+
+        private Long quantity;
+
+        private Long price;
+
+        private String description;
+
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+}

--- a/src/main/java/com/checkout/payments/apm/GiropaySource.java
+++ b/src/main/java/com/checkout/payments/apm/GiropaySource.java
@@ -1,0 +1,22 @@
+package com.checkout.payments.apm;
+
+import com.checkout.payments.RequestSource;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public final class GiropaySource implements RequestSource {
+
+    private final String type = "giropay";
+
+    private final String bic;
+
+    private final String purpose;
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+}

--- a/src/main/java/com/checkout/payments/apm/IntegrationType.java
+++ b/src/main/java/com/checkout/payments/apm/IntegrationType.java
@@ -1,0 +1,12 @@
+package com.checkout.payments.apm;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum IntegrationType {
+
+    @SerializedName("direct")
+    DIRECT,
+    @SerializedName("redirect")
+    REDIRECT
+
+}

--- a/src/test/java/com/checkout/SandboxTestFixture.java
+++ b/src/test/java/com/checkout/SandboxTestFixture.java
@@ -4,6 +4,7 @@ import com.checkout.beta.Checkout;
 import com.checkout.beta.CheckoutApi;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -47,6 +48,17 @@ public abstract class SandboxTestFixture {
             fail(e.getMessage());
         }
         return null;
+    }
+
+    /**
+     * Take a Nap
+     */
+    protected void nap() {
+        try {
+            TimeUnit.SECONDS.sleep(2);
+        } catch (final InterruptedException ignore) {
+            fail();
+        }
     }
 
     public com.checkout.CheckoutApi getApi() {

--- a/src/test/java/com/checkout/apm/BalotoPaymentsTestIT.java
+++ b/src/test/java/com/checkout/apm/BalotoPaymentsTestIT.java
@@ -1,0 +1,96 @@
+package com.checkout.apm;
+
+import com.checkout.PlatformType;
+import com.checkout.SandboxTestFixture;
+import com.checkout.payments.AlternativePaymentSourceResponse;
+import com.checkout.payments.GetPaymentResponse;
+import com.checkout.payments.PaymentPending;
+import com.checkout.payments.PaymentRequest;
+import com.checkout.payments.PaymentResponse;
+import com.checkout.payments.apm.BalotoSource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BalotoPaymentsTestIT extends SandboxTestFixture {
+
+    public BalotoPaymentsTestIT() {
+        super(PlatformType.CLASSIC);
+    }
+
+    @Test
+    public void shouldSucceedBalotoPayment() {
+
+        final String paymentId = makeBaletoPayment();
+
+        blocking(getApi().balotoClient().succeed(paymentId));
+
+        final GetPaymentResponse response = blocking(getApi().paymentsClient().getAsync(paymentId));
+
+        assertNotNull(response);
+        assertEquals("Captured", response.getStatus());
+
+        assertNotNull(response.getSource());
+        assertTrue(response.getSource() instanceof AlternativePaymentSourceResponse);
+        final AlternativePaymentSourceResponse source = (AlternativePaymentSourceResponse) response.getSource();
+        assertEquals("baloto", source.getType());
+        assertEquals("redirect", source.get("integration_type"));
+        assertNotNull(source.get("dlocal_order_id"));
+        assertNotNull(source.get("dlocal_payment_id"));
+        assertEquals("simulate Via Baloto Demo Payment", source.get("description"));
+
+    }
+
+    @Test
+    public void shouldExpireBalotoPayment() {
+
+        final String paymentId = makeBaletoPayment();
+
+        blocking(getApi().balotoClient().expire(paymentId));
+
+        final GetPaymentResponse response = blocking(getApi().paymentsClient().getAsync(paymentId));
+
+        assertNotNull(response);
+        assertEquals("Expired", response.getStatus());
+
+        assertNotNull(response.getSource());
+        assertTrue(response.getSource() instanceof AlternativePaymentSourceResponse);
+        final AlternativePaymentSourceResponse source = (AlternativePaymentSourceResponse) response.getSource();
+        assertEquals("baloto", source.getType());
+        assertEquals("redirect", source.get("integration_type"));
+        assertNotNull(source.get("dlocal_order_id"));
+        assertNotNull(source.get("dlocal_payment_id"));
+        assertEquals("simulate Via Baloto Demo Payment", source.get("description"));
+
+    }
+
+    private String makeBaletoPayment() {
+
+        final BalotoSource balotoSource = BalotoSource.builder()
+                .country("CO")
+                .description("simulate Via Baloto Demo Payment")
+                .payer(BalotoSource.Payer.builder().email("bruce@wayne-enterprises.com").name("Bruce Wayne").build())
+                .build();
+
+        final PaymentRequest<BalotoSource> request = PaymentRequest.baloto(balotoSource, com.checkout.common.beta.Currency.COP, 100000L);
+
+        final PaymentResponse response = blocking(getApi().paymentsClient().requestAsync(request));
+
+        assertNotNull(response);
+
+        final PaymentPending paymentPending = response.getPending();
+        assertNotNull(paymentPending);
+        assertEquals("Pending", paymentPending.getStatus());
+
+        assertTrue(paymentPending.hasLink("self"));
+        assertTrue(paymentPending.hasLink("redirect"));
+        assertTrue(paymentPending.hasLink("simulator:payment-succeed"));
+        assertTrue(paymentPending.hasLink("simulator:payment-expire"));
+
+        return paymentPending.getId();
+
+    }
+
+}

--- a/src/test/java/com/checkout/apm/BoletoPaymentsTestIT.java
+++ b/src/test/java/com/checkout/apm/BoletoPaymentsTestIT.java
@@ -1,0 +1,107 @@
+package com.checkout.apm;
+
+import com.checkout.PlatformType;
+import com.checkout.SandboxTestFixture;
+import com.checkout.payments.AlternativePaymentSourceResponse;
+import com.checkout.payments.GetPaymentResponse;
+import com.checkout.payments.PaymentPending;
+import com.checkout.payments.PaymentProcessed;
+import com.checkout.payments.PaymentRequest;
+import com.checkout.payments.PaymentResponse;
+import com.checkout.payments.apm.BoletoSource;
+import com.checkout.payments.apm.IntegrationType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BoletoPaymentsTestIT extends SandboxTestFixture {
+
+    public BoletoPaymentsTestIT() {
+        super(PlatformType.CLASSIC);
+    }
+
+    @Test
+    public void shouldSucceedBoletoRedirectPayment() {
+
+        final BoletoSource boletoSource = BoletoSource.builder()
+                .country("BR")
+                .description("boleto payment")
+                .integrationType(IntegrationType.REDIRECT)
+                .payer(BoletoSource.Payer.builder().email("john@doe-enterprises.com").name("John Doe").document("53033315550").build())
+                .build();
+
+        final PaymentRequest<BoletoSource> request = PaymentRequest.boleto(boletoSource, com.checkout.common.beta.Currency.BRL, 100L);
+
+        final PaymentResponse response = blocking(getApi().paymentsClient().requestAsync(request));
+
+        assertNotNull(response);
+
+        final PaymentPending paymentPending = response.getPending();
+        assertNotNull(paymentPending);
+        assertEquals("Pending", paymentPending.getStatus());
+
+        assertTrue(paymentPending.hasLink("self"));
+        assertTrue(paymentPending.hasLink("redirect"));
+
+        // Get payment
+
+        final GetPaymentResponse getPaymentResponse = blocking(getApi().paymentsClient().getAsync(paymentPending.getId()));
+
+        assertNotNull(response);
+        assertEquals("Pending", getPaymentResponse.getStatus());
+
+        assertNotNull(getPaymentResponse.getSource());
+        assertTrue(getPaymentResponse.getSource() instanceof AlternativePaymentSourceResponse);
+        final AlternativePaymentSourceResponse source = (AlternativePaymentSourceResponse) getPaymentResponse.getSource();
+        assertEquals("boleto", source.getType());
+        assertEquals("redirect", source.get("integration_type"));
+        assertNotNull(source.get("dlocal_order_id"));
+        assertNotNull(source.get("dlocal_payment_id"));
+        assertEquals("boleto payment", source.get("description"));
+
+    }
+
+    @Test
+    public void shouldMakeBoletoDirectPayment_thirdPartyRejection() {
+
+        final BoletoSource boletoSource = BoletoSource.builder()
+                .country("BR")
+                .description("boleto payment")
+                .integrationType(IntegrationType.DIRECT)
+                .payer(BoletoSource.Payer.builder().email("john@doe-enterprises.com").name("John Doe").document("53033315550").build())
+                .build();
+
+        final PaymentRequest<BoletoSource> request = PaymentRequest.boleto(boletoSource, com.checkout.common.beta.Currency.BRL, 100L);
+
+        final PaymentResponse response = blocking(getApi().paymentsClient().requestAsync(request));
+
+        assertNotNull(response);
+
+        final PaymentProcessed paymentProcessed = response.getPayment();
+        assertNotNull(paymentProcessed);
+        assertEquals("Declined", paymentProcessed.getStatus());
+        assertEquals("Rejected", paymentProcessed.getResponseSummary());
+        assertTrue(paymentProcessed.hasLink("self"));
+        assertTrue(paymentProcessed.hasLink("actions"));
+
+        // Get payment
+
+        final GetPaymentResponse getPaymentResponse = blocking(getApi().paymentsClient().getAsync(paymentProcessed.getId()));
+
+        assertNotNull(response);
+        assertEquals("Declined", getPaymentResponse.getStatus());
+
+        assertNotNull(getPaymentResponse.getSource());
+        assertTrue(getPaymentResponse.getSource() instanceof AlternativePaymentSourceResponse);
+        final AlternativePaymentSourceResponse source = (AlternativePaymentSourceResponse) getPaymentResponse.getSource();
+        assertEquals("boleto", source.getType());
+        assertEquals("direct", source.get("integration_type"));
+        assertEquals("third_party_rejected", source.get("failure_code"));
+        assertNotNull(source.get("dlocal_order_id"));
+        assertEquals("boleto payment", source.get("description"));
+
+    }
+
+}

--- a/src/test/java/com/checkout/apm/FawryPaymentsTestIT.java
+++ b/src/test/java/com/checkout/apm/FawryPaymentsTestIT.java
@@ -1,0 +1,126 @@
+package com.checkout.apm;
+
+import com.checkout.PlatformType;
+import com.checkout.SandboxTestFixture;
+import com.checkout.payments.AlternativePaymentSourceResponse;
+import com.checkout.payments.GetPaymentResponse;
+import com.checkout.payments.PaymentPending;
+import com.checkout.payments.PaymentRequest;
+import com.checkout.payments.PaymentResponse;
+import com.checkout.payments.apm.FawrySource;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FawryPaymentsTestIT extends SandboxTestFixture {
+
+    public FawryPaymentsTestIT() {
+        super(PlatformType.CLASSIC);
+    }
+
+    @Test
+    public void shouldApproveFawryPayment() {
+
+        final String paymentId = makeFawryPayment();
+
+        final String paymentReference = validatePaymentPending(paymentId);
+
+        // Approve payment
+        blocking(getApi().fawryClient().approve(paymentReference));
+
+        nap();
+
+        final GetPaymentResponse paymentApproved = blocking(getApi().paymentsClient().getAsync(paymentId));
+        assertNotNull(paymentApproved);
+        assertEquals("Captured", paymentApproved.getStatus());
+        assertNotNull(paymentApproved.getSource());
+        assertTrue(paymentApproved.getSource() instanceof AlternativePaymentSourceResponse);
+
+        final AlternativePaymentSourceResponse approvedSource = (AlternativePaymentSourceResponse) paymentApproved.getSource();
+        assertEquals("fawry", approvedSource.getType());
+        assertNotNull(approvedSource.get("reference_number"));
+        assertEquals("Fawry Demo Payment", approvedSource.get("description"));
+
+    }
+
+    @Test
+    public void shouldCancelFawryPayment() {
+
+        final String paymentId = makeFawryPayment();
+
+        final String paymentReference = validatePaymentPending(paymentId);
+
+        // Cancel payment
+        blocking(getApi().fawryClient().cancel(paymentReference));
+
+        nap();
+
+        final GetPaymentResponse paymentCanceled = blocking(getApi().paymentsClient().getAsync(paymentId));
+        assertNotNull(paymentCanceled);
+        assertEquals("Canceled", paymentCanceled.getStatus());
+        assertNotNull(paymentCanceled.getSource());
+        assertTrue(paymentCanceled.getSource() instanceof AlternativePaymentSourceResponse);
+
+        final AlternativePaymentSourceResponse approvedSource = (AlternativePaymentSourceResponse) paymentCanceled.getSource();
+        assertEquals("fawry", approvedSource.getType());
+        assertNotNull(approvedSource.get("reference_number"));
+        assertEquals("Fawry Demo Payment", approvedSource.get("description"));
+
+    }
+
+    private String makeFawryPayment() {
+
+        final FawrySource fawrySource = FawrySource.builder()
+                .description("Fawry Demo Payment")
+                .customerEmail("bruce@wayne-enterprises.com")
+                .customerMobile("01058375055")
+                .products(Collections.singletonList(
+                        FawrySource.Product.builder()
+                                .id("0123456789")
+                                .description("Fawry Demo Product")
+                                .price(1000L)
+                                .quantity(1L)
+                                .build()
+                ))
+                .build();
+
+        final PaymentRequest<FawrySource> request = PaymentRequest.fawry(fawrySource, com.checkout.common.beta.Currency.EGP, 1000L);
+
+        final PaymentResponse response = blocking(getApi().paymentsClient().requestAsync(request));
+
+        assertNotNull(response);
+
+        final PaymentPending paymentPending = response.getPending();
+        assertNotNull(paymentPending);
+        assertEquals("Pending", paymentPending.getStatus());
+
+        assertTrue(paymentPending.hasLink("self"));
+        assertTrue(paymentPending.hasLink("approve"));
+        assertTrue(paymentPending.hasLink("cancel"));
+
+        return paymentPending.getId();
+
+    }
+
+    private String validatePaymentPending(final String paymentId) {
+
+        final GetPaymentResponse pendingPayment = blocking(getApi().paymentsClient().getAsync(paymentId));
+        assertNotNull(pendingPayment);
+        assertEquals("Pending", pendingPayment.getStatus());
+        assertNotNull(pendingPayment.getSource());
+        assertTrue(pendingPayment.getSource() instanceof AlternativePaymentSourceResponse);
+
+        final AlternativePaymentSourceResponse source = (AlternativePaymentSourceResponse) pendingPayment.getSource();
+        assertEquals("fawry", source.getType());
+        assertNotNull(source.get("reference_number"));
+        assertEquals("Fawry Demo Payment", source.get("description"));
+
+        return (String) source.get("reference_number");
+
+    }
+
+}

--- a/src/test/java/com/checkout/apm/GiropayPaymentsTestIT.java
+++ b/src/test/java/com/checkout/apm/GiropayPaymentsTestIT.java
@@ -1,0 +1,70 @@
+package com.checkout.apm;
+
+import com.checkout.PlatformType;
+import com.checkout.SandboxTestFixture;
+import com.checkout.apm.giropay.BanksResponse;
+import com.checkout.payments.PaymentPending;
+import com.checkout.payments.PaymentRequest;
+import com.checkout.payments.PaymentResponse;
+import com.checkout.payments.apm.GiropaySource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GiropayPaymentsTestIT extends SandboxTestFixture {
+
+    public GiropayPaymentsTestIT() {
+        super(PlatformType.CLASSIC);
+    }
+
+    @Test
+    public void shouldMakeGiropayPayment() {
+
+        final GiropaySource giropaySource = GiropaySource.builder()
+                .bic("TESTDETT421")
+                .purpose("CKO Giropay test")
+                .build();
+
+        final PaymentRequest<GiropaySource> request = PaymentRequest.giropay(giropaySource, com.checkout.common.beta.Currency.EUR, 1000L);
+
+        final PaymentResponse response = blocking(getApi().paymentsClient().requestAsync(request));
+
+        assertNotNull(response);
+
+        final PaymentPending paymentPending = response.getPending();
+        assertNotNull(paymentPending);
+        assertEquals("Pending", paymentPending.getStatus());
+
+        assertTrue(paymentPending.hasLink("self"));
+        assertTrue(paymentPending.hasLink("redirect"));
+
+    }
+
+    @Test
+    public void shouldGetBanks() {
+
+        final BanksResponse banksResponse = blocking(getApi().giropayClient().getBanks());
+
+        assertNotNull(banksResponse);
+        assertNotNull(banksResponse.getSelfLink());
+        assertNotNull(banksResponse.getBanks());
+        assertFalse(banksResponse.getBanks().isEmpty());
+
+    }
+
+    @Test
+    public void shouldGetEpsBanks() {
+
+        final BanksResponse banksResponse = blocking(getApi().giropayClient().getEpsBanks());
+
+        assertNotNull(banksResponse);
+        assertNotNull(banksResponse.getSelfLink());
+        assertNotNull(banksResponse.getBanks());
+        assertFalse(banksResponse.getBanks().isEmpty());
+
+    }
+
+}

--- a/src/test/java/com/checkout/apm/baloto/BalotoClientTest.java
+++ b/src/test/java/com/checkout/apm/baloto/BalotoClientTest.java
@@ -1,0 +1,67 @@
+package com.checkout.apm.baloto;
+
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SecretKeyCredentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class BalotoClientTest {
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private CheckoutConfiguration checkoutConfiguration;
+
+    @Mock
+    private Void voidResponse;
+
+    private BalotoClient balotoClient;
+
+    @BeforeEach
+    public void setUp() {
+        this.balotoClient = new BalotoClientImpl(apiClient, checkoutConfiguration);
+    }
+
+    @Test
+    public void shouldSucceedPayment() throws ExecutionException, InterruptedException {
+
+        when(apiClient.postAsync(eq("/apms/baloto/payments/payment_id/succeed"), any(SecretKeyCredentials.class), eq(Void.class), isNull(), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(voidResponse));
+
+        final CompletableFuture<Void> future = balotoClient.succeed("payment_id");
+
+        assertNotNull(future.get());
+        assertEquals(voidResponse, future.get());
+
+    }
+
+    @Test
+    public void shouldExpirePayment() throws ExecutionException, InterruptedException {
+
+        when(apiClient.postAsync(eq("/apms/baloto/payments/payment_id/expire"), any(SecretKeyCredentials.class), eq(Void.class), isNull(), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(voidResponse));
+
+        final CompletableFuture<Void> future = balotoClient.expire("payment_id");
+
+        assertNotNull(future.get());
+        assertEquals(voidResponse, future.get());
+
+    }
+
+}

--- a/src/test/java/com/checkout/apm/baloto/FawryClientTest.java
+++ b/src/test/java/com/checkout/apm/baloto/FawryClientTest.java
@@ -1,0 +1,69 @@
+package com.checkout.apm.baloto;
+
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SecretKeyCredentials;
+import com.checkout.apm.fawry.FawryClient;
+import com.checkout.apm.fawry.FawryClientImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FawryClientTest {
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private CheckoutConfiguration checkoutConfiguration;
+
+    @Mock
+    private Void voidResponse;
+
+    private FawryClient fawryClient;
+
+    @BeforeEach
+    public void setUp() {
+        this.fawryClient = new FawryClientImpl(apiClient, checkoutConfiguration);
+    }
+
+    @Test
+    public void shouldApprovePayment() throws ExecutionException, InterruptedException {
+
+        when(apiClient.putAsync(eq("/fawry/payments/reference/approval"), any(SecretKeyCredentials.class), eq(Void.class), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(voidResponse));
+
+        final CompletableFuture<Void> future = fawryClient.approve("reference");
+
+        assertNotNull(future.get());
+        assertEquals(voidResponse, future.get());
+
+    }
+
+    @Test
+    public void shouldCancelPayment() throws ExecutionException, InterruptedException {
+
+        when(apiClient.putAsync(eq("/fawry/payments/reference/cancellation"), any(SecretKeyCredentials.class), eq(Void.class), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(voidResponse));
+
+        final CompletableFuture<Void> future = fawryClient.cancel("reference");
+
+        assertNotNull(future.get());
+        assertEquals(voidResponse, future.get());
+
+    }
+
+}

--- a/src/test/java/com/checkout/apm/baloto/GiropayClientTest.java
+++ b/src/test/java/com/checkout/apm/baloto/GiropayClientTest.java
@@ -1,0 +1,69 @@
+package com.checkout.apm.baloto;
+
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SecretKeyCredentials;
+import com.checkout.apm.giropay.BanksResponse;
+import com.checkout.apm.giropay.GiropayClient;
+import com.checkout.apm.giropay.GiropayClientImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class GiropayClientTest {
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private CheckoutConfiguration checkoutConfiguration;
+
+    @Mock
+    private BanksResponse banksResponse;
+
+    private GiropayClient giropayClient;
+
+    @BeforeEach
+    public void setUp() {
+        this.giropayClient = new GiropayClientImpl(apiClient, checkoutConfiguration);
+    }
+
+    @Test
+    public void shouldGetBanks() throws ExecutionException, InterruptedException {
+
+        when(apiClient.getAsync(eq("/giropay/banks"), any(SecretKeyCredentials.class), eq(BanksResponse.class)))
+                .thenReturn(CompletableFuture.completedFuture(banksResponse));
+
+        final CompletableFuture<BanksResponse> future = giropayClient.getBanks();
+
+        assertNotNull(future.get());
+        assertEquals(banksResponse, future.get());
+
+    }
+
+    @Test
+    public void shouldGetEpsBanks() throws ExecutionException, InterruptedException {
+
+        when(apiClient.getAsync(eq("/giropay/eps/banks"), any(SecretKeyCredentials.class), eq(BanksResponse.class)))
+                .thenReturn(CompletableFuture.completedFuture(banksResponse));
+
+        final CompletableFuture<BanksResponse> future = giropayClient.getEpsBanks();
+
+        assertNotNull(future.get());
+        assertEquals(banksResponse, future.get());
+
+    }
+
+}

--- a/src/test/java/com/checkout/payments/AlternativePaymentSourcePaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/AlternativePaymentSourcePaymentsTestIT.java
@@ -27,7 +27,7 @@ public class AlternativePaymentSourcePaymentsTestIT extends SandboxTestFixture {
         requestAlternativePayment(alternativePaymentSource);
     }
 
-    private PaymentPending requestAlternativePayment(final AlternativePaymentSource alternativePaymentSource) throws Exception {
+    private void requestAlternativePayment(final AlternativePaymentSource alternativePaymentSource) throws Exception {
         final PaymentRequest<RequestSource> paymentRequest = TestHelper.createAlternativePaymentMethodRequest(alternativePaymentSource, Currency.EUR);
 
         final PaymentResponse apiResponse = getApi().paymentsClient().requestAsync(paymentRequest).get();
@@ -44,6 +44,5 @@ public class AlternativePaymentSourcePaymentsTestIT extends SandboxTestFixture {
         assertTrue(pendingPayment.requiresRedirect());
         assertNotNull(pendingPayment.getRedirectLink());
 
-        return pendingPayment;
     }
 }

--- a/src/test/java/com/checkout/payments/beta/AbstractPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/AbstractPaymentsTestIT.java
@@ -28,7 +28,6 @@ import static com.checkout.payments.beta.CardSourceHelper.getCorporateSender;
 import static com.checkout.payments.beta.CardSourceHelper.getIndividualSender;
 import static com.checkout.payments.beta.CardSourceHelper.getRequestCardSource;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractPaymentsTestIT extends SandboxTestFixture {
 
@@ -136,14 +135,6 @@ public abstract class AbstractPaymentsTestIT extends SandboxTestFixture {
                 .expiryYear(CardSourceHelper.Visa.EXPIRY_YEAR)
                 .build();
         return blocking(tokensClient.requestAsync(request));
-    }
-
-    protected void waitForIt() {
-        try {
-            Thread.sleep(2000);
-        } catch (final InterruptedException ignore) {
-            fail();
-        }
     }
 
 }

--- a/src/test/java/com/checkout/payments/beta/GetPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/GetPaymentsTestIT.java
@@ -261,7 +261,7 @@ public class GetPaymentsTestIT extends AbstractPaymentsTestIT {
 
         final CaptureResponse captureResponse = capturePayment(payment.getId(), captureRequest);
 
-        waitForIt();
+        nap();
 
         // capture
 

--- a/src/test/java/com/checkout/payments/beta/RefundPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/RefundPaymentsTestIT.java
@@ -34,7 +34,7 @@ public class RefundPaymentsTestIT extends AbstractPaymentsTestIT {
         // capture
         capturePayment(paymentResponse.getId());
 
-        waitForIt();
+        nap();
 
         // refund
         final RefundRequest refundRequest = RefundRequest.builder()
@@ -60,7 +60,7 @@ public class RefundPaymentsTestIT extends AbstractPaymentsTestIT {
         // Capture Payment
         capturePayment(paymentResponse.getId());
 
-        waitForIt();
+        nap();
 
         // Refund
         final RefundRequest refundRequest = RefundRequest.builder()


### PR DESCRIPTION
Alternative payments support for `Baloto`, `Boleto`, `Fawry` and `Giropay`
types. Specific payment sources were created for these payment methods,
and `AlternativePaymentSource` was marked as deprecated (in favor of
specific types). The SDK supports now the following new clients:

- `BalotoClient` with functionality to `succeed` and `expire` baloto
payments
- `FawryClient` with functionality to `approve` and `cancel` fawry
payments
- `GiropayClient` with functionality to get non & eps banks