### PR TITLE
Re-implement dispute operations (CS2)

### DIFF
--- a/src/main/java/com/checkout/beta/AbstractClient.java
+++ b/src/main/java/com/checkout/beta/AbstractClient.java
@@ -10,11 +10,15 @@ public abstract class AbstractClient {
     protected final ApiClient apiClient;
     protected final ApiCredentials apiCredentials;
 
-    public AbstractClient(final ApiClient apiClient, final ApiCredentials apiCredentials) {
+    protected AbstractClient(final ApiClient apiClient, final ApiCredentials apiCredentials) {
         requiresNonNull("apiClient", apiClient);
         requiresNonNull("apiCredentials", apiCredentials);
         this.apiClient = apiClient;
         this.apiCredentials = apiCredentials;
+    }
+
+    protected static String buildPath(final String... pathParams) {
+        return String.join("/", pathParams);
     }
 
 }

--- a/src/main/java/com/checkout/beta/CheckoutApi.java
+++ b/src/main/java/com/checkout/beta/CheckoutApi.java
@@ -1,6 +1,7 @@
 package com.checkout.beta;
 
 import com.checkout.customers.beta.CustomersClient;
+import com.checkout.disputes.beta.DisputesClient;
 import com.checkout.payments.beta.PaymentsClient;
 import com.checkout.tokens.beta.TokensClient;
 
@@ -11,5 +12,7 @@ public interface CheckoutApi {
     PaymentsClient paymentsClient();
 
     CustomersClient customersClient();
+
+    DisputesClient disputesClient();
 
 }

--- a/src/main/java/com/checkout/beta/CheckoutApiImpl.java
+++ b/src/main/java/com/checkout/beta/CheckoutApiImpl.java
@@ -4,6 +4,8 @@ import com.checkout.ApiClient;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.customers.beta.CustomersClient;
 import com.checkout.customers.beta.CustomersClientImpl;
+import com.checkout.disputes.beta.DisputesClient;
+import com.checkout.disputes.beta.DisputesClientImpl;
 import com.checkout.payments.beta.PaymentsClient;
 import com.checkout.payments.beta.PaymentsClientImpl;
 import com.checkout.tokens.beta.TokensClient;
@@ -14,11 +16,13 @@ public final class CheckoutApiImpl implements CheckoutApi {
     private final TokensClient tokensClient;
     private final PaymentsClient paymentsClient;
     private final CustomersClient customersClient;
+    private final DisputesClient disputesClient;
 
     public CheckoutApiImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
         this.tokensClient = new TokensClientImpl(apiClient, configuration);
         this.paymentsClient = new PaymentsClientImpl(apiClient, configuration);
         this.customersClient = new CustomersClientImpl(apiClient, configuration);
+        this.disputesClient = new DisputesClientImpl(apiClient, configuration);
     }
 
     @Override
@@ -34,6 +38,11 @@ public final class CheckoutApiImpl implements CheckoutApi {
     @Override
     public CustomersClient customersClient() {
         return customersClient;
+    }
+
+    @Override
+    public DisputesClient disputesClient() {
+        return disputesClient;
     }
 
 }

--- a/src/main/java/com/checkout/common/beta/ThreeDSEnrollmentStatus.java
+++ b/src/main/java/com/checkout/common/beta/ThreeDSEnrollmentStatus.java
@@ -1,4 +1,4 @@
-package com.checkout.payments.beta.response;
+package com.checkout.common.beta;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/src/main/java/com/checkout/disputes/beta/Dispute.java
+++ b/src/main/java/com/checkout/disputes/beta/Dispute.java
@@ -1,0 +1,64 @@
+package com.checkout.disputes.beta;
+
+import com.checkout.common.beta.Resource;
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class Dispute extends Resource {
+
+    private String id;
+
+    @SerializedName("entity_id")
+    private String entityId;
+
+    @SerializedName("sub_entity_id")
+    private String subEntityId;
+
+    private DisputeCategory category;
+
+    private DisputeStatus status;
+
+    private Long amount;
+
+    private String currency;
+
+    @SerializedName("reason_code")
+    private String reasonCode;
+
+    @SerializedName("payment_id")
+    private String paymentId;
+
+    @SerializedName("payment_action_id")
+    private String paymentActionId;
+
+    @SerializedName("payment_reference")
+    private String paymentReference;
+
+    @SerializedName("payment_arn")
+    private String paymentArn;
+
+    @SerializedName("payment_mcc")
+    private String paymentMcc;
+
+    @SerializedName("payment_method")
+    private String paymentMethod;
+
+    @SerializedName("evidence_required_by")
+    private Instant evidenceRequiredBy;
+
+    @SerializedName("received_on")
+    private Instant receivedOn;
+
+    @SerializedName("last_update")
+    private Instant lastUpdate;
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputeCategory.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputeCategory.java
@@ -1,4 +1,4 @@
-package com.checkout.disputes;
+package com.checkout.disputes.beta;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/src/main/java/com/checkout/disputes/beta/DisputeDetailsResponse.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputeDetailsResponse.java
@@ -1,0 +1,51 @@
+package com.checkout.disputes.beta;
+
+import com.checkout.common.beta.Resource;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public final class DisputeDetailsResponse extends Resource {
+
+    private String id;
+
+    @SerializedName("entity_id")
+    private String entityId;
+
+    @SerializedName("sub_entity_id")
+    private String subEntityId;
+
+    private DisputeCategory category;
+
+    private Long amount;
+
+    private String currency;
+
+    @SerializedName("reason_code")
+    private String reasonCode;
+
+    private DisputeStatus status;
+
+    @SerializedName("resolved_reason")
+    private DisputeResolvedReason resolvedReason;
+
+    @SerializedName("relevant_evidence")
+    private List<DisputeRelevantEvidence> relevantEvidence;
+
+    @SerializedName("evidence_required_by")
+    private Instant evidenceRequiredBy;
+
+    @SerializedName("received_on")
+    private Instant receivedOn;
+
+    @SerializedName("last_update")
+    private Instant lastUpdate;
+
+    private PaymentDispute payment;
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputeEvidenceRequest.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputeEvidenceRequest.java
@@ -1,0 +1,73 @@
+package com.checkout.disputes.beta;
+
+import com.checkout.common.Link;
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.Size;
+import java.util.Map;
+
+@Data
+@Builder
+public final class DisputeEvidenceRequest {
+
+    @SerializedName("proof_of_delivery_or_service_file")
+    private String proofOfDeliveryOrServiceFile;
+
+    @Size(max = 500)
+    @SerializedName("proof_of_delivery_or_service_text")
+    private String proofOfDeliveryOrServiceText;
+
+    @SerializedName("invoice_or_receipt_file")
+    private String invoiceOrReceiptFile;
+
+    @SerializedName("invoice_or_receipt_text")
+    private String invoiceOrReceiptText;
+
+    @SerializedName("invoice_showing_distinct_transactions_file")
+    private String invoiceShowingDistinctTransactionsFile;
+
+    @Size(max = 500)
+    @SerializedName("invoice_showing_distinct_transactions_text")
+    private String invoiceShowingDistinctTransactionsText;
+
+    @SerializedName("customer_communication_file")
+    private String customerCommunicationFile;
+
+    @Size(max = 500)
+    @SerializedName("customer_communication_text")
+    private String customerCommunicationText;
+
+    @SerializedName("refund_or_cancellation_policy_file")
+    private String refundOrCancellationPolicyFile;
+
+    @Size(max = 500)
+    @SerializedName("refund_or_cancellation_policy_text")
+    private String refundOrCancellationPolicyText;
+
+    @SerializedName("recurring_transaction_agreement_file")
+    private String recurringTransactionAgreementFile;
+
+    @Size(max = 500)
+    @SerializedName("recurring_transaction_agreement_text")
+    private String recurringTransactionAgreementText;
+
+    @SerializedName("additional_evidence_file")
+    private String additionalEvidenceFile;
+
+    @Size(max = 500)
+    @SerializedName("additional_evidence_text")
+    private String additionalEvidenceText;
+
+    @SerializedName("proof_of_delivery_or_service_date_file")
+    private String proofOfDeliveryOrServiceDateFile;
+
+    @Size(max = 500)
+    @SerializedName("proof_of_delivery_or_service_date_text")
+    private String proofOfDeliveryOrServiceDateText;
+
+    @SerializedName("_links")
+    private Map<String, Link> links;
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputeEvidenceResponse.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputeEvidenceResponse.java
@@ -1,0 +1,64 @@
+package com.checkout.disputes.beta;
+
+import com.checkout.common.beta.Resource;
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@Builder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class DisputeEvidenceResponse extends Resource {
+
+    @SerializedName("proof_of_delivery_or_service_file")
+    private String proofOfDeliveryOrServiceFile;
+
+    @SerializedName("proof_of_delivery_or_service_text")
+    private String proofOfDeliveryOrServiceText;
+
+    @SerializedName("invoice_or_receipt_file")
+    private String invoiceOrReceiptFile;
+
+    @SerializedName("invoice_or_receipt_text")
+    private String invoiceOrReceiptText;
+
+    @SerializedName("invoice_showing_distinct_transactions_file")
+    private String invoiceShowingDistinctTransactionsFile;
+
+    @SerializedName("invoice_showing_distinct_transactions_text")
+    private String invoiceShowingDistinctTransactionsText;
+
+    @SerializedName("customer_communication_file")
+    private String customerCommunicationFile;
+
+    @SerializedName("customer_communication_text")
+    private String customerCommunicationText;
+
+    @SerializedName("refund_or_cancellation_policy_file")
+    private String refundOrCancellationPolicyFile;
+
+    @SerializedName("refund_or_cancellation_policy_text")
+    private String refundOrCancellationPolicyText;
+
+    @SerializedName("recurring_transaction_agreement_file")
+    private String recurringTransactionAgreementFile;
+
+    @SerializedName("recurring_transaction_agreement_text")
+    private String recurringTransactionAgreementText;
+
+    @SerializedName("additional_evidence_file")
+    private String additionalEvidenceFile;
+
+    @SerializedName("additional_evidence_text")
+    private String additionalEvidenceText;
+
+    @SerializedName("proof_of_delivery_or_service_date_file")
+    private String proofOfDeliveryOrServiceDateFile;
+
+    @SerializedName("proof_of_delivery_or_service_date_text")
+    private String proofOfDeliveryOrServiceDateText;
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputeRelevantEvidence.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputeRelevantEvidence.java
@@ -1,0 +1,28 @@
+package com.checkout.disputes.beta;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum DisputeRelevantEvidence {
+
+    @SerializedName("proof_of_delivery_or_service")
+    PROOF_OF_DELIVERY_OR_SERVICE,
+
+    @SerializedName("invoice_or_receipt")
+    INVOICE_OR_RECEIPT,
+
+    @SerializedName("invoice_showing_distinct_transactions")
+    INVOICE_SHOWING_DISTINCT_TRANSACTIONS,
+
+    @SerializedName("customer_communication")
+    CUSTOMER_COMMUNICATION,
+
+    @SerializedName("refund_or_cancellation_policy")
+    REFUND_OR_CANCELLATION_POLICY,
+
+    @SerializedName("recurring_transaction_agreement")
+    RECURRING_TRANSACTION_AGREEMENT,
+
+    @SerializedName("additional_evidence")
+    ADDITIONAL_EVIDENCE
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputeResolvedReason.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputeResolvedReason.java
@@ -1,0 +1,16 @@
+package com.checkout.disputes.beta;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum DisputeResolvedReason {
+
+    @SerializedName("rapid_dispute_resolution")
+    RAPID_DISPUTE_RESOLUTION,
+
+    @SerializedName("negative_amount")
+    NEGATIVE_AMOUNT,
+
+    @SerializedName("already_refunded")
+    ALREADY_REFUNDED
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputeStatus.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputeStatus.java
@@ -1,0 +1,40 @@
+package com.checkout.disputes.beta;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum DisputeStatus {
+
+    @SerializedName("won")
+    WON,
+
+    @SerializedName("lost")
+    LOST,
+
+    @SerializedName("expired")
+    EXPIRED,
+
+    @SerializedName("accepted")
+    ACCEPTED,
+
+    @SerializedName("canceled")
+    CANCELED,
+
+    @SerializedName("resolved")
+    RESOLVED,
+
+    @SerializedName("arbitration_won")
+    ARBITRATION_WON,
+
+    @SerializedName("arbitration_lost")
+    ARBITRATION_LOST,
+
+    @SerializedName("evidence_required")
+    EVIDENCE_REQUIRED,
+
+    @SerializedName("evidence_under_review")
+    EVIDENCE_UNDER_REVIEW,
+
+    @SerializedName("arbitration_under_review")
+    ARBITRATION_UNDER_REVIEW
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputesClient.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputesClient.java
@@ -1,0 +1,27 @@
+package com.checkout.disputes.beta;
+
+import com.checkout.common.FileDetailsResponse;
+import com.checkout.common.FileRequest;
+import com.checkout.common.IdResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface DisputesClient {
+
+    CompletableFuture<DisputesQueryResponse> query(DisputesQueryFilter queryFilter);
+
+    CompletableFuture<DisputeDetailsResponse> getDisputeDetails(String disputeId);
+
+    CompletableFuture<Void> accept(String disputeId);
+
+    CompletableFuture<Void> putEvidence(String disputeId, DisputeEvidenceRequest disputeEvidenceRequest);
+
+    CompletableFuture<DisputeEvidenceResponse> getEvidence(String disputeId);
+
+    CompletableFuture<Void> submitEvidence(String disputeId);
+
+    CompletableFuture<IdResponse> uploadFile(FileRequest request);
+
+    CompletableFuture<FileDetailsResponse> getFileDetails(String id);
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputesClientImpl.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputesClientImpl.java
@@ -1,0 +1,64 @@
+package com.checkout.disputes.beta;
+
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SecretKeyCredentials;
+import com.checkout.beta.AbstractClient;
+import com.checkout.common.FileDetailsResponse;
+import com.checkout.common.FileRequest;
+import com.checkout.common.IdResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+public class DisputesClientImpl extends AbstractClient implements DisputesClient {
+
+    private static final String DISPUTES = "disputes";
+    private static final String ACCEPT = "accept";
+    private static final String FILES = "files";
+    private static final String EVIDENCE = "evidence";
+
+    public DisputesClientImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
+        super(apiClient, SecretKeyCredentials.fromConfiguration(configuration));
+    }
+
+    @Override
+    public CompletableFuture<DisputesQueryResponse> query(final DisputesQueryFilter queryFilter) {
+        return apiClient.queryAsync(DISPUTES, apiCredentials, queryFilter, DisputesQueryResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<DisputeDetailsResponse> getDisputeDetails(final String disputeId) {
+        return apiClient.getAsync(buildPath(DISPUTES, disputeId), apiCredentials, DisputeDetailsResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<Void> accept(final String disputeId) {
+        return apiClient.postAsync(buildPath(DISPUTES, disputeId, ACCEPT), apiCredentials, Void.class, null, null);
+    }
+
+    @Override
+    public CompletableFuture<Void> putEvidence(final String id, final DisputeEvidenceRequest disputeEvidence) {
+        return apiClient.putAsync(buildPath(DISPUTES, id, EVIDENCE), apiCredentials, Void.class, disputeEvidence);
+    }
+
+    @Override
+    public CompletableFuture<DisputeEvidenceResponse> getEvidence(final String id) {
+        return apiClient.getAsync(buildPath(DISPUTES, id, EVIDENCE), apiCredentials, DisputeEvidenceResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<Void> submitEvidence(final String id) {
+        return apiClient.postAsync(buildPath(DISPUTES, id, EVIDENCE), apiCredentials, Void.class, null, null);
+    }
+
+    @Override
+    public CompletableFuture<IdResponse> uploadFile(final FileRequest request) {
+        return apiClient.submitFileAsync(FILES, apiCredentials, request, IdResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<FileDetailsResponse> getFileDetails(final String id) {
+        return apiClient.getAsync(buildPath(FILES, id), apiCredentials, FileDetailsResponse.class);
+    }
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputesQueryFilter.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputesQueryFilter.java
@@ -1,0 +1,52 @@
+package com.checkout.disputes.beta;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.Size;
+import java.time.Instant;
+
+@Data
+@Builder
+public final class DisputesQueryFilter {
+
+    @Size(min = 1, max = 250)
+    private Integer limit;
+
+    @Size
+    private Integer skip;
+
+    private Instant from;
+
+    private Instant to;
+
+    private String id;
+
+    /** One or more comma-separated client entities. This works like a logical OR operator */
+    @SerializedName("entity_ids")
+    private String entityIds;
+
+    /** One or more comma-separated sub-entities. This works like a logical OR operator */
+    @SerializedName("sub_entity_ids")
+    private String subEntityIds;
+
+    /** One or more comma-separated statuses. This works like a logical OR operator */
+    private String statuses;
+
+    @SerializedName("payment_id")
+    private String paymentId;
+
+    @SerializedName("payment_reference")
+    private String paymentReference;
+
+    @SerializedName("payment_arn")
+    private String paymentArn;
+
+    @SerializedName("payment_mcc")
+    private String paymentMcc;
+
+    @SerializedName("this_channel_only")
+    private boolean thisChannelOnly;
+
+}

--- a/src/main/java/com/checkout/disputes/beta/DisputesQueryResponse.java
+++ b/src/main/java/com/checkout/disputes/beta/DisputesQueryResponse.java
@@ -1,0 +1,51 @@
+package com.checkout.disputes.beta;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+public final class DisputesQueryResponse {
+
+    private Integer limit;
+
+    private Integer skip;
+
+    private Instant from;
+
+    private Instant to;
+
+    private String id;
+
+    @SerializedName("entity_ids")
+    private String entityIds;
+
+    @SerializedName("sub_entity_ids")
+    private String subEntityIds;
+
+    /** One or more comma-separated statuses. This works like a logical OR operator */
+    private String statuses;
+
+    @SerializedName("payment_id")
+    private String paymentId;
+
+    @SerializedName("payment_reference")
+    private String paymentReference;
+
+    @SerializedName("payment_arn")
+    private String paymentArn;
+
+    @SerializedName("payment_mcc")
+    private String paymentMcc;
+
+    @SerializedName("this_channel_only")
+    private boolean thisChannelOnly;
+
+    @SerializedName("total_count")
+    private Integer totalCount;
+
+    private List<Dispute> data;
+
+}

--- a/src/main/java/com/checkout/disputes/beta/PaymentDispute.java
+++ b/src/main/java/com/checkout/disputes/beta/PaymentDispute.java
@@ -1,0 +1,42 @@
+package com.checkout.disputes.beta;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@Builder
+public class PaymentDispute {
+
+    private String id;
+
+    @SerializedName("action_id")
+    private String actionId;
+
+    @SerializedName("processing_channel_id")
+    private String processingChannelId;
+
+    private Long amount;
+
+    private String currency;
+
+    private String method;
+
+    private String arn;
+
+    private String mcc;
+
+    @SerializedName("3ds")
+    private ThreeDSVersionEnrollment threeDSVersionEnrollment;
+
+    private String eci;
+
+    @SerializedName("has_refund")
+    private boolean hasRefund;
+
+    @SerializedName("processed_on")
+    private Instant processedOn;
+
+}

--- a/src/main/java/com/checkout/disputes/beta/ThreeDSVersionEnrollment.java
+++ b/src/main/java/com/checkout/disputes/beta/ThreeDSVersionEnrollment.java
@@ -1,4 +1,4 @@
-package com.checkout.payments.beta.response;
+package com.checkout.disputes.beta;
 
 import com.checkout.common.beta.ThreeDSEnrollmentStatus;
 import lombok.Builder;
@@ -6,9 +6,9 @@ import lombok.Data;
 
 @Data
 @Builder
-public final class ThreeDSEnrollmentData {
+public final class ThreeDSVersionEnrollment {
 
-    private boolean downgraded;
+    private String version;
 
     private ThreeDSEnrollmentStatus enrolled;
 

--- a/src/test/java/com/checkout/disputes/beta/DisputesClientImplTest.java
+++ b/src/test/java/com/checkout/disputes/beta/DisputesClientImplTest.java
@@ -1,0 +1,219 @@
+package com.checkout.disputes.beta;
+
+import com.checkout.ApiClient;
+import com.checkout.ApiCredentials;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.common.FileDetailsResponse;
+import com.checkout.common.FilePurpose;
+import com.checkout.common.FileRequest;
+import com.checkout.common.IdResponse;
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DisputesClientImplTest {
+
+    private static final String DISPUTES = "disputes";
+    private static final String FILES = "files";
+    private static final String EVIDENCE = "evidence";
+    private static final String REASON_CODE = "10.4";
+    private static final long PAYMENT_AMOUNT = 1040L;
+    private static final String PAYMENT_ARN = "802355416667";
+    private static final String FILE_ID = "file_7kxknf5ftrgurfouydbbs74gvq";
+    private static final String FILE_NAME = "my_evidence.jpg";
+    private static String PAYMENT_ID = "pay_3216549s87jhhjhguyt";
+    private static String DISPUTE_ID = "dsp_9ec11deafd679h77356a";
+    private static String TEXT_MESSAGE = "text_message";
+
+    private DisputesClient client;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private CheckoutConfiguration configuration;
+
+    @Mock
+    private Dispute dispute;
+
+    @Mock
+    private DisputesQueryResponse disputesQueryResponse;
+
+    @Mock
+    private DisputeDetailsResponse disputeDetailsResponse;
+
+    @Mock
+    private DisputeEvidenceResponse evidenceResponse;
+
+    @Mock
+    private IdResponse idResponse;
+
+    @Mock
+    private FileDetailsResponse fileDetailsResponse;
+
+    @Mock
+    private CompletableFuture<DisputesQueryResponse> disputesQueryResponseFuture;
+
+    @Mock
+    private CompletableFuture<DisputeDetailsResponse> disputeDetailsFuture;
+
+    @Mock
+    private CompletableFuture<DisputeEvidenceResponse> evidenceResponseFuture;
+
+    @Mock
+    private CompletableFuture<IdResponse> idResponseFuture;
+
+    @Mock
+    private CompletableFuture<FileDetailsResponse> fileDetailsResponseFuture;
+
+    private PaymentDispute paymentDispute;
+
+    @BeforeEach
+    public void setUp() {
+        disputesQueryResponseFuture = CompletableFuture.completedFuture(disputesQueryResponse);
+        disputeDetailsFuture = CompletableFuture.completedFuture(disputeDetailsResponse);
+        evidenceResponseFuture = CompletableFuture.completedFuture(evidenceResponse);
+        idResponseFuture = CompletableFuture.completedFuture(idResponse);
+        fileDetailsResponseFuture = CompletableFuture.completedFuture(fileDetailsResponse);
+        client = new DisputesClientImpl(apiClient, configuration);
+        paymentDispute = PaymentDispute.builder().id(PAYMENT_ID).amount(PAYMENT_AMOUNT).arn(PAYMENT_ARN).build();
+    }
+
+    @Test
+    public void shouldPerformQuery() throws ExecutionException, InterruptedException {
+        final DisputesQueryFilter request = DisputesQueryFilter.builder().paymentId(PAYMENT_ID).limit(250).build();
+        doReturn(disputesQueryResponseFuture)
+                .when(apiClient)
+                .queryAsync(eq(DISPUTES), any(ApiCredentials.class),
+                        any(DisputesQueryFilter.class), eq(DisputesQueryResponse.class));
+        when(disputesQueryResponse.getLimit()).thenReturn(request.getLimit());
+        when(disputesQueryResponse.getTotalCount()).thenReturn(1);
+        when(disputesQueryResponse.getData()).thenReturn(Collections.singletonList(dispute));
+        when(dispute.getId()).thenReturn(DISPUTE_ID);
+        when(dispute.getCategory()).thenReturn(DisputeCategory.FRAUDULENT);
+        when(dispute.getPaymentId()).thenReturn(PAYMENT_ID);
+
+        final DisputesQueryResponse response = client.query(request).get();
+        assertNotNull(response);
+        assertEquals(request.getLimit(), response.getLimit());
+        assertEquals(1, response.getTotalCount().intValue());
+        assertNotNull(response.getData());
+        assertEquals(DISPUTE_ID, response.getData().get(0).getId());
+        assertEquals(DisputeCategory.FRAUDULENT, response.getData().get(0).getCategory());
+        assertEquals(PAYMENT_ID, response.getData().get(0).getPaymentId());
+    }
+
+    @Test
+    public void shouldGetDisputeDetails() throws ExecutionException, InterruptedException {
+        doReturn(disputeDetailsFuture)
+                .when(apiClient)
+                .getAsync(eq("disputes/dsp_9ec11deafd679h77356a"), any(ApiCredentials.class), eq(DisputeDetailsResponse.class));
+        when(disputeDetailsResponse.getId()).thenReturn(DISPUTE_ID);
+        when(disputeDetailsResponse.getCategory()).thenReturn(DisputeCategory.FRAUDULENT);
+        when(disputeDetailsResponse.getReasonCode()).thenReturn(REASON_CODE);
+        when(disputeDetailsResponse.getStatus()).thenReturn(DisputeStatus.EVIDENCE_REQUIRED);
+        when(disputeDetailsResponse.getPayment()).thenReturn(paymentDispute);
+        final DisputeDetailsResponse response = client.getDisputeDetails(DISPUTE_ID).get();
+        assertNotNull(response);
+        assertEquals(DISPUTE_ID, response.getId());
+        assertEquals(DisputeCategory.FRAUDULENT, response.getCategory());
+        assertEquals(REASON_CODE, response.getReasonCode());
+        assertEquals(DisputeStatus.EVIDENCE_REQUIRED, response.getStatus());
+        assertNotNull(response.getPayment());
+        assertEquals(PAYMENT_ID, response.getPayment().getId());
+        assertEquals(PAYMENT_AMOUNT, response.getPayment().getAmount().longValue());
+        assertEquals(PAYMENT_ARN, response.getPayment().getArn());
+    }
+
+    @Test
+    public void shouldUploadFile() throws ExecutionException, InterruptedException {
+        final FileRequest request = FileRequest.builder()
+                .file(new File(FILE_NAME))
+                .contentType(ContentType.IMAGE_JPEG)
+                .purpose(FilePurpose.DISPUTE_EVIDENCE).build();
+        doReturn(idResponseFuture)
+                .when(apiClient)
+                .submitFileAsync(eq(FILES), any(ApiCredentials.class), any(FileRequest.class),
+                        eq(IdResponse.class));
+        when(idResponse.getId()).thenReturn(FILE_ID);
+        final IdResponse response = client.uploadFile(request).get();
+        assertNotNull(response);
+        assertEquals(FILE_ID, response.getId());
+    }
+
+    @Test
+    public void shouldGetEvidence() throws ExecutionException, InterruptedException {
+        doReturn(evidenceResponseFuture)
+                .when(apiClient)
+                .getAsync(eq("disputes/dsp_9ec11deafd679h77356a/evidence"),
+                        any(ApiCredentials.class), eq(DisputeEvidenceResponse.class));
+        when(evidenceResponse.getProofOfDeliveryOrServiceFile()).thenReturn(FILE_NAME);
+        when(evidenceResponse.getProofOfDeliveryOrServiceText()).thenReturn(TEXT_MESSAGE);
+        when(evidenceResponse.getInvoiceOrReceiptFile()).thenReturn(FILE_NAME);
+        when(evidenceResponse.getInvoiceOrReceiptText()).thenReturn(TEXT_MESSAGE);
+        when(evidenceResponse.getInvoiceShowingDistinctTransactionsFile()).thenReturn(FILE_NAME);
+        when(evidenceResponse.getInvoiceShowingDistinctTransactionsText()).thenReturn(TEXT_MESSAGE);
+        when(evidenceResponse.getCustomerCommunicationFile()).thenReturn(FILE_NAME);
+        when(evidenceResponse.getCustomerCommunicationText()).thenReturn(TEXT_MESSAGE);
+        when(evidenceResponse.getRefundOrCancellationPolicyFile()).thenReturn(FILE_NAME);
+        when(evidenceResponse.getRefundOrCancellationPolicyText()).thenReturn(TEXT_MESSAGE);
+        when(evidenceResponse.getRecurringTransactionAgreementFile()).thenReturn(FILE_NAME);
+        when(evidenceResponse.getRecurringTransactionAgreementText()).thenReturn(TEXT_MESSAGE);
+        when(evidenceResponse.getAdditionalEvidenceFile()).thenReturn(FILE_NAME);
+        when(evidenceResponse.getAdditionalEvidenceText()).thenReturn(TEXT_MESSAGE);
+        when(evidenceResponse.getProofOfDeliveryOrServiceDateFile()).thenReturn(FILE_NAME);
+        when(evidenceResponse.getProofOfDeliveryOrServiceDateText()).thenReturn(TEXT_MESSAGE);
+        final DisputeEvidenceResponse response = client.getEvidence(DISPUTE_ID).get();
+        assertNotNull(response);
+        assertEquals(FILE_NAME, response.getProofOfDeliveryOrServiceFile());
+        assertEquals(TEXT_MESSAGE, response.getProofOfDeliveryOrServiceText());
+        assertEquals(FILE_NAME, response.getInvoiceOrReceiptFile());
+        assertEquals(TEXT_MESSAGE, response.getInvoiceOrReceiptText());
+        assertEquals(FILE_NAME, response.getInvoiceShowingDistinctTransactionsFile());
+        assertEquals(TEXT_MESSAGE, response.getInvoiceShowingDistinctTransactionsText());
+        assertEquals(FILE_NAME, response.getCustomerCommunicationFile());
+        assertEquals(TEXT_MESSAGE, response.getCustomerCommunicationText());
+        assertEquals(FILE_NAME, response.getRefundOrCancellationPolicyFile());
+        assertEquals(TEXT_MESSAGE, response.getProofOfDeliveryOrServiceText());
+        assertEquals(FILE_NAME, response.getProofOfDeliveryOrServiceFile());
+        assertEquals(TEXT_MESSAGE, response.getRefundOrCancellationPolicyText());
+        assertEquals(FILE_NAME, response.getRecurringTransactionAgreementFile());
+        assertEquals(TEXT_MESSAGE, response.getRecurringTransactionAgreementText());
+        assertEquals(FILE_NAME, response.getAdditionalEvidenceFile());
+        assertEquals(TEXT_MESSAGE, response.getAdditionalEvidenceText());
+        assertEquals(FILE_NAME, response.getProofOfDeliveryOrServiceDateFile());
+        assertEquals(TEXT_MESSAGE, response.getProofOfDeliveryOrServiceDateText());
+    }
+
+    @Test
+    public void shouldGetFileDetails() throws ExecutionException, InterruptedException {
+        doReturn(fileDetailsResponseFuture)
+                .when(apiClient)
+                .getAsync(eq("files/file_7kxknf5ftrgurfouydbbs74gvq"), any(ApiCredentials.class), eq(FileDetailsResponse.class));
+        when(fileDetailsResponse.getFilename()).thenReturn(FILE_NAME);
+        when(fileDetailsResponse.getId()).thenReturn(FILE_ID);
+        when(fileDetailsResponse.getPurpose()).thenReturn(FilePurpose.DISPUTE_EVIDENCE.getPurpose());
+        final FileDetailsResponse response = client.getFileDetails(FILE_ID).get();
+        assertNotNull(response);
+        assertEquals(FILE_ID, response.getId());
+        assertEquals(FILE_NAME, response.getFilename());
+        assertEquals(FilePurpose.DISPUTE_EVIDENCE.getPurpose(), response.getPurpose());
+    }
+
+}

--- a/src/test/java/com/checkout/disputes/beta/DisputesTestIT.java
+++ b/src/test/java/com/checkout/disputes/beta/DisputesTestIT.java
@@ -1,0 +1,181 @@
+package com.checkout.disputes.beta;
+
+import com.checkout.CheckoutValidationException;
+import com.checkout.common.FileDetailsResponse;
+import com.checkout.common.FilePurpose;
+import com.checkout.common.FileRequest;
+import com.checkout.common.IdResponse;
+import com.checkout.payments.beta.AbstractPaymentsTestIT;
+import com.checkout.payments.beta.request.PaymentRequest;
+import com.checkout.payments.beta.request.source.RequestCardSource;
+import com.checkout.payments.beta.response.PaymentResponse;
+import com.checkout.payments.beta.response.source.ResponseCardSource;
+import com.checkout.payments.beta.sender.RequestIndividualSender;
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.File;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static com.checkout.payments.beta.CardSourceHelper.getCardSourcePaymentForDispute;
+import static com.checkout.payments.beta.CardSourceHelper.getIndividualSender;
+import static com.checkout.payments.beta.CardSourceHelper.getRequestCardSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class DisputesTestIT extends AbstractPaymentsTestIT {
+
+    @Test
+    public void shouldQueryDisputes() {
+        DisputesQueryFilter query = DisputesQueryFilter
+                .builder()
+                .limit(100)
+                .thisChannelOnly(true)
+                .build();
+        final DisputesQueryResponse response = blocking(getApiV2().disputesClient().query(query));
+        assertNotNull(response);
+        assertEquals(query.getLimit(), response.getLimit());
+        assertEquals(query.isThisChannelOnly(), response.isThisChannelOnly());
+        if (response.getTotalCount() > 0) {
+            final Dispute dispute = response.getData().get(0);
+            query = DisputesQueryFilter.builder().id(dispute.getId()).build();
+            final DisputesQueryResponse responseDsp = blocking(getApiV2().disputesClient().query(query));
+            assertNotNull(responseDsp);
+            assertEquals(1, responseDsp.getTotalCount());
+        }
+    }
+
+    @Test
+    public void shouldGetDisputeDetails() {
+        final DisputesQueryResponse queryResponse = blocking(getApiV2().disputesClient().query(DisputesQueryFilter.builder().build()));
+        assertNotNull(queryResponse);
+        if (queryResponse.getTotalCount() > 0) {
+            final Dispute disputeQueried = queryResponse.getData().get(0);
+            final DisputeDetailsResponse detailsResponse = blocking(getApiV2().disputesClient().getDisputeDetails(disputeQueried.getId()));
+            assertNotNull(detailsResponse);
+            assertEquals(disputeQueried.getId(), detailsResponse.getId());
+            assertNotNull(detailsResponse.getStatus());
+            assertEquals(disputeQueried.getCategory(), detailsResponse.getCategory());
+            assertEquals(disputeQueried.getAmount(), detailsResponse.getAmount());
+            assertEquals(disputeQueried.getCurrency(), detailsResponse.getCurrency());
+            assertEquals(disputeQueried.getReasonCode(), detailsResponse.getReasonCode());
+            assertEquals(disputeQueried.getStatus(), detailsResponse.getStatus());
+            assertEquals(disputeQueried.getReceivedOn(), detailsResponse.getReceivedOn());
+            if (disputeQueried.getPaymentId() != null) {
+                assertNotNull(detailsResponse.getPayment());
+                assertEquals(disputeQueried.getPaymentId(), detailsResponse.getPayment().getId());
+                assertEquals(disputeQueried.getPaymentActionId(), detailsResponse.getPayment().getActionId());
+                assertEquals(disputeQueried.getPaymentMethod(), detailsResponse.getPayment().getMethod());
+                assertEquals(disputeQueried.getPaymentArn(), detailsResponse.getPayment().getArn());
+            }
+        }
+    }
+
+    @Test
+    public void shouldFailOnAcceptDisputeAlreadyAccepted() {
+        final DisputesQueryResponse queryResponse = blocking(getApiV2().disputesClient().query(DisputesQueryFilter.builder()
+                .statuses(DisputeStatus.ACCEPTED.toString()).build()));
+        assertNotNull(queryResponse);
+        if (queryResponse.getTotalCount() > 0) {
+            final Dispute dispute = queryResponse.getData().get(0);
+            try {
+                getApiV2().disputesClient().accept(dispute.getId()).get();
+                fail();
+            } catch (final Exception ex) {
+                assertTrue(ex.getCause() instanceof CheckoutValidationException);
+                assertTrue(ex.getMessage().contains("dispute_already_accepted"));
+            }
+        }
+    }
+
+    /**
+     * This test is disabled to avoid long waiting due the async operations that requires to perform a dispute
+     * however its complete functional and can be enabled for digging purposes
+     */
+    //@Test
+    //@Timeout(value = 3, unit = TimeUnit.MINUTES)
+    public void shouldTestFullDisputesWorkFlow() throws Exception {
+        //Create a payment who triggers a dispute
+        final RequestCardSource source = getRequestCardSource();
+        final RequestIndividualSender sender = getIndividualSender();
+        final PaymentRequest request = getCardSourcePaymentForDispute(source, sender, false);
+
+        // payment
+        final PaymentResponse<ResponseCardSource> paymentResponse = makeCardPayment(request);
+        assertTrue(paymentResponse.canCapture());
+
+        // capture
+        capturePayment(paymentResponse.getId());
+
+        //Query for dispute
+        DisputesQueryResponse queryResponse = null;
+        final DisputesQueryFilter query = DisputesQueryFilter.builder()
+                .paymentId(paymentResponse.getId())
+                .statuses("evidence_required")
+                .build();
+        while (queryResponse == null || queryResponse.getTotalCount() == 0) {
+            TimeUnit.SECONDS.sleep(20);
+            queryResponse = blocking(getApiV2().disputesClient().query(query));
+        }
+
+        //Get dispute details
+        final DisputeDetailsResponse disputeDetails = blocking(getApiV2().disputesClient()
+                .getDisputeDetails(queryResponse.getData().get(0).getId()));
+        assertEquals(paymentResponse.getId(), disputeDetails.getPayment().getId());
+        assertEquals(paymentResponse.getAmount(), disputeDetails.getPayment().getAmount());
+        assertNotNull(disputeDetails.getRelevantEvidence());
+
+        //Upload your dispute file evidence
+        final URL resource = getClass().getClassLoader().getResource("checkout.pdf");
+        final File file = new File(resource.toURI());
+        final FileRequest fileRequest = FileRequest.builder()
+                .file(file)
+                .contentType(ContentType.create("application/pdf"))
+                .purpose(FilePurpose.DISPUTE_EVIDENCE)
+                .build();
+        final IdResponse fileResponse = blocking(getApiV2().disputesClient().uploadFile(fileRequest));
+        assertNotNull(fileResponse);
+        assertNotNull(fileResponse.getId());
+        final FileDetailsResponse fileDetailsResponse = blocking(getApiV2().disputesClient().getFileDetails(fileResponse.getId()));
+        assertNotNull(fileDetailsResponse);
+        assertEquals(fileRequest.getFile().getName(), fileDetailsResponse.getFilename());
+        assertEquals(fileRequest.getPurpose().getPurpose(), fileDetailsResponse.getPurpose());
+
+        //Provide dispute evidence
+        final DisputeEvidenceRequest evidenceRequest = DisputeEvidenceRequest.builder()
+                .proofOfDeliveryOrServiceFile(fileDetailsResponse.getId())
+                .proofOfDeliveryOrServiceText("proof of delivery or service text")
+                .invoiceOrReceiptFile(fileDetailsResponse.getId())
+                .invoiceOrReceiptText("Copy of the invoice")
+                .invoiceShowingDistinctTransactionsFile(fileDetailsResponse.getId())
+                .invoiceShowingDistinctTransactionsText("Copy of invoice #1244 showing two transactions")
+                .customerCommunicationFile(fileDetailsResponse.getId())
+                .customerCommunicationText("Copy of an email exchange with the cardholder")
+                .refundOrCancellationPolicyFile(fileDetailsResponse.getId())
+                .refundOrCancellationPolicyText("Copy of the refund policy")
+                .recurringTransactionAgreementFile(fileDetailsResponse.getId())
+                .recurringTransactionAgreementText("Copy of the recurring transaction agreement")
+                .additionalEvidenceFile(fileDetailsResponse.getId())
+                .additionalEvidenceText("Scanned document")
+                .proofOfDeliveryOrServiceDateFile(fileDetailsResponse.getId())
+                .proofOfDeliveryOrServiceDateText("Copy of the customer receipt showing the merchandise was delivered on 2018-12-20")
+                .build();
+        blocking(getApiV2().disputesClient().putEvidence(disputeDetails.getId(), evidenceRequest));
+
+        //Retrieve your dispute evidence details
+        final DisputeEvidenceResponse evidenceResponse = blocking(getApiV2().disputesClient().getEvidence(disputeDetails.getId()));
+        assertNotNull(evidenceResponse);
+        assertEquals(evidenceRequest.getProofOfDeliveryOrServiceFile(), evidenceResponse.getProofOfDeliveryOrServiceFile());
+        assertEquals(evidenceRequest.getProofOfDeliveryOrServiceText(), evidenceResponse.getProofOfDeliveryOrServiceText());
+        assertEquals(evidenceRequest.getProofOfDeliveryOrServiceDateText(), evidenceResponse.getProofOfDeliveryOrServiceDateText());
+
+        //Submit your dispute evidence
+        blocking(getApiV2().disputesClient().submitEvidence(disputeDetails.getId()));
+    }
+
+
+}

--- a/src/test/java/com/checkout/payments/beta/CardSourceHelper.java
+++ b/src/test/java/com/checkout/payments/beta/CardSourceHelper.java
@@ -14,6 +14,8 @@ import java.util.UUID;
 
 public class CardSourceHelper {
 
+    private static long amount = 10L;
+
     public static class Visa {
 
         public static final String NUMBER = "4242424242424242";
@@ -63,12 +65,17 @@ public class CardSourceHelper {
         return Payments.card(cardSource).fromSender(sender)
                 .capture(false)
                 .reference(UUID.randomUUID().toString())
-                .amount(10L)
+                .amount(amount)
                 .currency(Currency.EUR)
                 .threeDSRequest(threeDSRequest)
                 .successUrl(three3ds ? "https://test.checkout.com/success" : null)
                 .failureUrl(three3ds ? "https://test.checkout.com/failure" : null)
                 .build();
+    }
+
+    public static PaymentRequest getCardSourcePaymentForDispute(final RequestCardSource cardSource, final RequestSender sender, final boolean three3ds) {
+        amount = 1040L;
+        return getCardSourcePayment(cardSource, sender, three3ds);
     }
 
 }

--- a/src/test/java/com/checkout/payments/beta/RequestPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/beta/RequestPaymentsTestIT.java
@@ -14,7 +14,7 @@ import com.checkout.payments.beta.response.PaymentResponse;
 import com.checkout.payments.beta.response.PaymentResponseBalances;
 import com.checkout.payments.beta.response.PaymentStatus;
 import com.checkout.payments.beta.response.ThreeDSEnrollmentData;
-import com.checkout.payments.beta.response.ThreeDSEnrollmentStatus;
+import com.checkout.common.beta.ThreeDSEnrollmentStatus;
 import com.checkout.payments.beta.response.source.ResponseCardSource;
 import com.checkout.payments.beta.sender.RequestCorporateSender;
 import com.checkout.payments.beta.sender.RequestIndividualSender;


### PR DESCRIPTION
Similar to CS1, the purpose of this commit is to add Dispute operations that support CS2.
`Query`, `getDisputeDetails`, `accept`, `putEvidence`, `getEvidence`, `submitEvidence`, `uploadFile` & `getFileDetails` were added to new DisputesClient.