### PR TITLE
Improve code base for instruments operations (CS1)

### DIFF
--- a/src/main/java/com/checkout/common/Address.java
+++ b/src/main/java/com/checkout/common/Address.java
@@ -11,12 +11,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public final class Address {
+
     @SerializedName(value="address_line1", alternate={"addressLine1"})
     private String addressLine1;
+
     @SerializedName(value="address_line2", alternate={"addressLine2"})
     private String addressLine2;
+
     private String city;
+
     private String state;
+
     private String zip;
+
     private String country;
+
 }

--- a/src/main/java/com/checkout/common/Phone.java
+++ b/src/main/java/com/checkout/common/Phone.java
@@ -11,7 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public final class Phone {
+
     @SerializedName(value="country_code", alternate={"countryCode"})
     private String countryCode;
+
     private String number;
+
 }

--- a/src/main/java/com/checkout/instruments/AccountHolder.java
+++ b/src/main/java/com/checkout/instruments/AccountHolder.java
@@ -2,6 +2,7 @@ package com.checkout.instruments;
 
 import com.checkout.common.Address;
 import com.checkout.common.Phone;
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,6 +13,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AccountHolder {
+
+    @SerializedName("billing_address")
     private Address billingAddress;
+
     private Phone phone;
+
 }

--- a/src/main/java/com/checkout/instruments/CreateInstrumentRequest.java
+++ b/src/main/java/com/checkout/instruments/CreateInstrumentRequest.java
@@ -1,5 +1,6 @@
 package com.checkout.instruments;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,6 +11,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateInstrumentRequest {
+
     private String type;
+
     private String token;
+
+    @SerializedName("account_holder")
+    private AccountHolder accountHolder;
+
 }

--- a/src/main/java/com/checkout/instruments/CreateInstrumentResponse.java
+++ b/src/main/java/com/checkout/instruments/CreateInstrumentResponse.java
@@ -5,18 +5,43 @@ import lombok.Data;
 
 @Data
 public class CreateInstrumentResponse {
+
     private String id;
+
     private String type;
+
+    private String fingerprint;
+
+    @SerializedName("expiry_month")
     private Integer expiryMonth;
+
+    @SerializedName("expiry_year")
     private Integer expiryYear;
+
     private String scheme;
+
     @SerializedName("last4")
     private String last4;
+
     private String bin;
+
+    @SerializedName("card_type")
     private String cardType;
+
+    @SerializedName("card_category")
     private String cardCategory;
+
     private String issuer;
+
+    @SerializedName("issuer_country")
     private String issuerCountry;
+
+    @SerializedName("product_id")
     private String productId;
+
+    @SerializedName("product_type")
     private String productType;
+
+    private CustomerResponse customer;
+
 }

--- a/src/main/java/com/checkout/instruments/CustomerRequest.java
+++ b/src/main/java/com/checkout/instruments/CustomerRequest.java
@@ -11,7 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CustomerRequest {
+
     private String id;
+
     @SerializedName("default")
     private boolean isDefault;
+
 }

--- a/src/main/java/com/checkout/instruments/CustomerResponse.java
+++ b/src/main/java/com/checkout/instruments/CustomerResponse.java
@@ -5,9 +5,13 @@ import lombok.Data;
 
 @Data
 public class CustomerResponse {
+
     private String id;
+
     private String email;
+
     private String name;
+
     @SerializedName("default")
     private boolean isDefault;
 }

--- a/src/main/java/com/checkout/instruments/InstrumentDetailsResponse.java
+++ b/src/main/java/com/checkout/instruments/InstrumentDetailsResponse.java
@@ -5,22 +5,47 @@ import lombok.Data;
 
 @Data
 public class InstrumentDetailsResponse {
+
     private String id;
+
     private String type;
+
     private String fingerprint;
+
+    @SerializedName("expiry_month")
     private Integer expiryMonth;
+
+    @SerializedName("expiry_year")
     private Integer expiryYear;
+
     private String name;
+
     private String scheme;
+
     @SerializedName("last4")
     private String last4;
+
     private String bin;
+
+    @SerializedName("card_type")
     private String cardType;
+
+    @SerializedName("card_category")
     private String cardCategory;
+
     private String issuer;
+
+    @SerializedName("issuer_country")
     private String issuerCountry;
+
+    @SerializedName("product_id")
     private String productId;
+
+    @SerializedName("product_type")
     private String productType;
+
+    @SerializedName("account_holder")
     private AccountHolder accountHolder;
+
     private CustomerResponse customer;
 }

--- a/src/main/java/com/checkout/instruments/InstrumentsClientImpl.java
+++ b/src/main/java/com/checkout/instruments/InstrumentsClientImpl.java
@@ -1,11 +1,14 @@
 package com.checkout.instruments;
 
+import com.checkout.AbstractClient;
 import com.checkout.ApiClient;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.SecretKeyCredentials;
-import com.checkout.AbstractClient;
 
 import java.util.concurrent.CompletableFuture;
+
+import static com.checkout.common.CheckoutUtils.requiresNonBlank;
+import static com.checkout.common.CheckoutUtils.requiresNonNull;
 
 public class InstrumentsClientImpl extends AbstractClient implements InstrumentsClient {
 
@@ -17,21 +20,27 @@ public class InstrumentsClientImpl extends AbstractClient implements Instruments
 
     @Override
     public CompletableFuture<CreateInstrumentResponse> createInstrument(final CreateInstrumentRequest createInstrumentRequest) {
+        requiresNonNull("createInstrumentRequest", createInstrumentRequest);
         return apiClient.postAsync(INSTRUMENTS, apiCredentials, CreateInstrumentResponse.class, createInstrumentRequest, null);
     }
 
     @Override
     public CompletableFuture<InstrumentDetailsResponse> getInstrument(final String instrumentId) {
-        return apiClient.getAsync(INSTRUMENTS + "/" + instrumentId, apiCredentials, InstrumentDetailsResponse.class);
+        requiresNonBlank("instrumentId", instrumentId);
+        return apiClient.getAsync(constructApiPath(INSTRUMENTS, instrumentId), apiCredentials, InstrumentDetailsResponse.class);
     }
 
     @Override
     public CompletableFuture<UpdateInstrumentResponse> updateInstrument(final String instrumentId, final UpdateInstrumentRequest updateInstrumentRequest) {
-        return apiClient.patchAsync(INSTRUMENTS + "/" + instrumentId, apiCredentials, UpdateInstrumentResponse.class, updateInstrumentRequest, null);
+        requiresNonBlank("instrumentId", instrumentId);
+        requiresNonNull("updateInstrumentRequest", updateInstrumentRequest);
+        return apiClient.patchAsync(constructApiPath(INSTRUMENTS, instrumentId), apiCredentials, UpdateInstrumentResponse.class, updateInstrumentRequest, null);
     }
 
     @Override
     public CompletableFuture<Void> deleteInstrument(final String instrumentId) {
-        return apiClient.deleteAsync(INSTRUMENTS + "/" + instrumentId, apiCredentials);
+        requiresNonBlank("instrumentId", instrumentId);
+        return apiClient.deleteAsync(constructApiPath(INSTRUMENTS, instrumentId), apiCredentials);
     }
+    
 }

--- a/src/main/java/com/checkout/instruments/UpdateInstrumentRequest.java
+++ b/src/main/java/com/checkout/instruments/UpdateInstrumentRequest.java
@@ -1,5 +1,6 @@
 package com.checkout.instruments;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,9 +11,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateInstrumentRequest {
+
+    @SerializedName("expiry_month")
     private int expiryMonth;
+
+    @SerializedName("expiry_year")
     private int expiryYear;
+
     private String name;
+
+    @SerializedName("account_holder")
     private AccountHolder accountHolder;
+
     private CustomerRequest customer;
+
 }

--- a/src/main/java/com/checkout/instruments/UpdateInstrumentResponse.java
+++ b/src/main/java/com/checkout/instruments/UpdateInstrumentResponse.java
@@ -6,5 +6,7 @@ import lombok.Data;
 public class UpdateInstrumentResponse {
 
     private String type;
+
     private String fingerprint;
+
 }

--- a/src/test/java/com/checkout/instruments/InstrumentsClientImplTest.java
+++ b/src/test/java/com/checkout/instruments/InstrumentsClientImplTest.java
@@ -1,0 +1,104 @@
+package com.checkout.instruments;
+
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SecretKeyCredentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class InstrumentsClientImplTest {
+
+    private static final String INSTRUMENTS = "instruments";
+
+    private InstrumentsClientImpl client;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private CheckoutConfiguration configuration;
+
+    @BeforeEach
+    public void setUp() {
+        client = new InstrumentsClientImpl(apiClient, configuration);
+    }
+
+
+    @Test
+    public void shouldCreateInstrument() throws ExecutionException, InterruptedException {
+
+        final CreateInstrumentRequest request = mock(CreateInstrumentRequest.class);
+        final CreateInstrumentResponse response = mock(CreateInstrumentResponse.class);
+
+        when(apiClient.postAsync(eq(INSTRUMENTS), any(SecretKeyCredentials.class), eq(CreateInstrumentResponse.class),
+                eq(request), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CompletableFuture<CreateInstrumentResponse> future = client.createInstrument(request);
+
+        assertNotNull(future.get());
+        assertEquals(response, future.get());
+
+    }
+
+    @Test
+    public void shouldGetInstrument() throws ExecutionException, InterruptedException {
+
+        final InstrumentDetailsResponse response = mock(InstrumentDetailsResponse.class);
+        when(apiClient.getAsync(eq(INSTRUMENTS + "/src_wmlfc3zyhqzehihu7giusaaawu"), any(SecretKeyCredentials.class),
+                eq(InstrumentDetailsResponse.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CompletableFuture<InstrumentDetailsResponse> future = client.getInstrument("src_wmlfc3zyhqzehihu7giusaaawu");
+
+        assertNotNull(future.get());
+
+    }
+
+    @Test
+    public void shouldUpdateInstrument() throws ExecutionException, InterruptedException {
+
+        final UpdateInstrumentRequest request = mock(UpdateInstrumentRequest.class);
+        final UpdateInstrumentResponse response = mock(UpdateInstrumentResponse.class);
+
+        when(apiClient.patchAsync(eq(INSTRUMENTS + "/src_wmlfc3zyhqzehihu7giusaaawu123"), any(SecretKeyCredentials.class),
+                eq(UpdateInstrumentResponse.class), eq(request), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CompletableFuture<UpdateInstrumentResponse> future = client.updateInstrument("src_wmlfc3zyhqzehihu7giusaaawu123", request);
+
+        assertNotNull(future.get());
+        assertEquals(response, future.get());
+
+    }
+
+    @Test
+    public void shouldDeleteInstrument() throws ExecutionException, InterruptedException {
+
+        final Void response = mock(Void.class);
+
+        when(apiClient.deleteAsync(eq(INSTRUMENTS + "/UpdateInstrumentResponse"), any(SecretKeyCredentials.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CompletableFuture<Void> future = client.deleteInstrument("UpdateInstrumentResponse");
+
+        assertNotNull(future.get());
+
+    }
+
+}


### PR DESCRIPTION
Added standards and guidelines to Instruments Client in CS1 which includes:
Enforce Serialized names.
Added `constructApiPath` method in `InstrumentsClientImpl` to build the Api Path.
Added missing `AccountHolder` object in `CreateInstrumentRequest` and the corresponding object in Test classes.
Added `InstrumentsClientImplTest` class to Unit Test `InstrumentsClient`.