### PR TITLE
Review parameter validation system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    implementation 'com.google.guava:guava:30.0-jre'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.slf4j:slf4j-api:1.7.26'
     implementation 'org.apache.httpcomponents:httpclient:4.5.12'

--- a/samples/spring/src/main/java/com/checkout/sample/spring/RestTemplateTransport.java
+++ b/samples/spring/src/main/java/com/checkout/sample/spring/RestTemplateTransport.java
@@ -5,7 +5,6 @@ import com.checkout.Response;
 import com.checkout.Transport;
 import com.checkout.common.CheckoutUtils;
 import com.checkout.common.FileRequest;
-import com.google.common.collect.ImmutableMap;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -25,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static com.checkout.common.CheckoutUtils.validateMultipleRequires;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public class RestTemplateTransport implements Transport {
 
@@ -41,18 +40,18 @@ public class RestTemplateTransport implements Transport {
     private final URI baseUri;
     private final RestTemplate restTemplate;
 
-    public RestTemplateTransport(String baseUri) {
+    public RestTemplateTransport(final String baseUri) {
         this(baseUri, DEFAULT_REST_TEMPLATE);
     }
 
-    public RestTemplateTransport(String baseUri, RestTemplate restTemplate) {
+    public RestTemplateTransport(final String baseUri, final RestTemplate restTemplate) {
         this.baseUri = URI.create(baseUri);
         this.restTemplate = restTemplate;
     }
 
     @Override
-    public CompletableFuture<Response> invoke(String httpMethod, String path, ApiCredentials apiCredentials, String jsonRequest, String idempotencyKey) {
-        validateMultipleRequires(ImmutableMap.of("httpMethod", httpMethod, "path", path, "apiCredentials", apiCredentials, "jsonRequest", jsonRequest));
+    public CompletableFuture<Response> invoke(final String httpMethod, final String path, final ApiCredentials apiCredentials, final String jsonRequest, final String idempotencyKey) {
+        validateParams("httpMethod", httpMethod, "path", path, "apiCredentials", apiCredentials, "jsonRequest", jsonRequest);
         RequestEntity.BodyBuilder requestBuilder = RequestEntity
                 .method(HttpMethod.resolve(httpMethod), getRequestUri(path))
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -63,7 +62,7 @@ public class RestTemplateTransport implements Transport {
         if (idempotencyKey != null) {
             requestBuilder = requestBuilder.header("Cko-Idempotency-Key", idempotencyKey);
         }
-        RequestEntity<?> request;
+        final RequestEntity<?> request;
         if (jsonRequest != null) {
             request = requestBuilder.body(jsonRequest);
         } else {
@@ -72,9 +71,9 @@ public class RestTemplateTransport implements Transport {
 
         return CompletableFuture.supplyAsync(() -> {
             try {
-                ResponseEntity<String> response = restTemplate.exchange(request, String.class);
+                final ResponseEntity<String> response = restTemplate.exchange(request, String.class);
                 return new Response(response.getStatusCodeValue(), response.getBody(), extractRequestId(response.getHeaders()));
-            } catch (HttpStatusCodeException e) {
+            } catch (final HttpStatusCodeException e) {
                 return new Response(e.getRawStatusCode(), e.getResponseBodyAsString(), extractRequestId(e.getResponseHeaders()));
             }
         });
@@ -82,9 +81,9 @@ public class RestTemplateTransport implements Transport {
 
     @Override
     public CompletableFuture<Response> invokeQuery(final String path, final ApiCredentials apiCredentials, final Map<String, String> queryParams) {
-        validateMultipleRequires(ImmutableMap.of("path", path, "apiCredentials", apiCredentials, "queryParams", queryParams));
-        String queryPath = path + "?queryParameter= {queryParameter}";
-        RequestEntity<?> request = RequestEntity
+        validateParams("path", path, "apiCredentials", apiCredentials, "queryParams", queryParams);
+        final String queryPath = path + "?queryParameter= {queryParameter}";
+        final RequestEntity<?> request = RequestEntity
                 .method(HttpMethod.GET, getRequestUri(queryPath))
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON_UTF8)
@@ -94,9 +93,9 @@ public class RestTemplateTransport implements Transport {
                 .build();
         return CompletableFuture.supplyAsync(() -> {
             try {
-                ResponseEntity<String> response = restTemplate.exchange(queryPath, HttpMethod.GET, request, String.class, queryParams);
+                final ResponseEntity<String> response = restTemplate.exchange(queryPath, HttpMethod.GET, request, String.class, queryParams);
                 return new Response(response.getStatusCodeValue(), response.getBody(), extractRequestId(response.getHeaders()));
-            } catch (HttpStatusCodeException e) {
+            } catch (final HttpStatusCodeException e) {
                 return new Response(e.getRawStatusCode(), e.getResponseBodyAsString(), extractRequestId(e.getResponseHeaders()));
             }
         });
@@ -104,33 +103,33 @@ public class RestTemplateTransport implements Transport {
 
     @Override
     public CompletableFuture<Response> submitFile(final String path, final ApiCredentials apiCredentials, final FileRequest fileRequest) {
-        validateMultipleRequires(ImmutableMap.of("path", path, "apiCredentials", apiCredentials, "fileRequest", fileRequest));
-        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        validateParams("path", path, "apiCredentials", apiCredentials, "fileRequest", fileRequest);
+        final MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
         body.add("file", fileRequest.getFile());
         body.add("purpose", fileRequest.getPurpose().getPurpose());
-        HttpHeaders headers = new HttpHeaders();
+        final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON_UTF8));
         headers.add(USER_AGENT, USER_AGENT_VALUE + CheckoutUtils.getVersionFromManifest());
         headers.add(AUTHORIZATION, apiCredentials.getAuthorizationHeader());
-        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+        final HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
         return CompletableFuture.supplyAsync(() -> {
             try {
-                ResponseEntity<String> response = restTemplate.postForEntity(getRequestUri(path), requestEntity, String.class);
+                final ResponseEntity<String> response = restTemplate.postForEntity(getRequestUri(path), requestEntity, String.class);
                 return new Response(response.getStatusCodeValue(), response.getBody(), extractRequestId(response.getHeaders()));
-            } catch (HttpStatusCodeException e) {
+            } catch (final HttpStatusCodeException e) {
                 return new Response(e.getRawStatusCode(), e.getResponseBodyAsString(), extractRequestId(e.getResponseHeaders()));
             }
         });
     }
 
-    private String extractRequestId(HttpHeaders headers) {
+    private String extractRequestId(final HttpHeaders headers) {
         return Optional.ofNullable(headers.get("Ck-Request-Id"))
                 .flatMap(list -> list.stream().findFirst())
                 .orElse("NO_REQUEST_ID_SUPPLIED");
     }
 
-    private URI getRequestUri(String path) {
+    private URI getRequestUri(final String path) {
         return baseUri.resolve(path);
     }
 }

--- a/src/main/java/com/checkout/AbstractClient.java
+++ b/src/main/java/com/checkout/AbstractClient.java
@@ -1,6 +1,6 @@
 package com.checkout;
 
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public abstract class AbstractClient {
 
@@ -8,8 +8,8 @@ public abstract class AbstractClient {
     protected final ApiCredentials apiCredentials;
 
     protected AbstractClient(final ApiClient apiClient, final ApiCredentials apiCredentials) {
-        requiresNonNull("apiClient", apiClient);
-        requiresNonNull("apiCredentials", apiCredentials);
+        validateParams("apiClient", apiClient);
+        validateParams("apiCredentials", apiCredentials);
         this.apiClient = apiClient;
         this.apiCredentials = apiCredentials;
     }

--- a/src/main/java/com/checkout/AbstractKeyCredentials.java
+++ b/src/main/java/com/checkout/AbstractKeyCredentials.java
@@ -1,6 +1,6 @@
 package com.checkout;
 
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public abstract class AbstractKeyCredentials {
 
@@ -9,7 +9,7 @@ public abstract class AbstractKeyCredentials {
     protected final CheckoutConfiguration configuration;
 
     public AbstractKeyCredentials(final CheckoutConfiguration configuration) {
-        requiresNonNull("configuration", configuration);
+        validateParams("configuration", configuration);
         this.configuration = configuration;
     }
 

--- a/src/main/java/com/checkout/ApiClientImpl.java
+++ b/src/main/java/com/checkout/ApiClientImpl.java
@@ -5,7 +5,6 @@ import com.checkout.common.CheckoutUtils;
 import com.checkout.common.ErrorResponse;
 import com.checkout.common.FileRequest;
 import com.checkout.common.Resource;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
@@ -13,7 +12,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static com.checkout.common.CheckoutUtils.validateMultipleRequires;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public class ApiClientImpl implements ApiClient {
 
@@ -30,62 +29,62 @@ public class ApiClientImpl implements ApiClient {
     }
 
     public ApiClientImpl(final Serializer serializer, final Transport transport) {
-        validateMultipleRequires(ImmutableMap.of("serializer", serializer, "transport", transport));
+        validateParams("serializer", serializer, "transport", transport);
         this.serializer = serializer;
         this.transport = transport;
     }
 
     @Override
     public <T> CompletableFuture<T> getAsync(final String path, final ApiCredentials credentials, final Class<T> responseType) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials));
+        validateParams(PATH, path, CREDENTIALS, credentials);
         return sendRequestAsync("GET", path, credentials, null, null, responseType);
     }
 
     @Override
     public <T> CompletableFuture<T> getAsync(final String path, final ApiCredentials credentials, final Type responseType) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials));
+        validateParams(PATH, path, CREDENTIALS, credentials);
         return sendRequestAsync("GET", path, credentials, null, null, responseType);
     }
 
     @Override
     public <T> CompletableFuture<T> putAsync(final String path, final ApiCredentials credentials, final Class<T> responseType, final Object request) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials));
+        validateParams(PATH, path, CREDENTIALS, credentials);
         return sendRequestAsync("PUT", path, credentials, request, null, responseType);
     }
 
     @Override
     public CompletableFuture<Void> deleteAsync(final String path, final ApiCredentials credentials) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials));
+        validateParams(PATH, path, CREDENTIALS, credentials);
         return sendRequestAsync("DELETE", path, credentials, null, null, Void.class);
     }
 
     @Override
     public <T> CompletableFuture<T> postAsync(final String path, final ApiCredentials credentials, final Class<T> responseType, final Object request, final String idempotencyKey) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials));
+        validateParams(PATH, path, CREDENTIALS, credentials);
         return sendRequestAsync("POST", path, credentials, request, idempotencyKey, responseType);
     }
 
     @Override
     public <T> CompletableFuture<T> postAsync(final String path, final ApiCredentials credentials, final Type responseType, final Object request, final String idempotencyKey) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials));
+        validateParams(PATH, path, CREDENTIALS, credentials);
         return sendRequestAsync("POST", path, credentials, request, idempotencyKey, responseType);
     }
 
     @Override
     public <T> CompletableFuture<T> patchAsync(final String path, final ApiCredentials credentials, final Class<T> responseType, final Object request, final String idempotencyKey) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials));
+        validateParams(PATH, path, CREDENTIALS, credentials);
         return sendRequestAsync("PATCH", path, credentials, request, idempotencyKey, responseType);
     }
 
     @Override
     public <T> CompletableFuture<T> patchAsync(final String path, final ApiCredentials credentials, final Type type, final Object request, final String idempotencyKey) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials, "type", type, "request", request));
+        validateParams(PATH, path, CREDENTIALS, credentials, "type", type, "request", request);
         return sendRequestAsync("PATCH", path, credentials, request, idempotencyKey, type);
     }
 
     @Override
     public CompletableFuture<? extends Resource> postAsync(final String path, final ApiCredentials credentials, final Map<Integer, Class<? extends Resource>> resultTypeMappings, final Object request, final String idempotencyKey) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials, "resultTypeMappings", resultTypeMappings));
+        validateParams(PATH, path, CREDENTIALS, credentials, "resultTypeMappings", resultTypeMappings);
         return transport.invoke("POST", path, credentials, serializer.toJson(request), idempotencyKey)
                 .thenApply(this::errorCheck)
                 .thenApply(response -> {
@@ -100,7 +99,7 @@ public class ApiClientImpl implements ApiClient {
     @Override
     public <T> CompletableFuture<T> queryAsync(final String path, final ApiCredentials credentials, final Object filter,
                                                final Class<T> responseType) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials, "filter", filter));
+        validateParams(PATH, path, CREDENTIALS, credentials, "filter", filter);
         final Map<String, String> params = serializer.fromJson(serializer.toJson(filter),
                 new TypeToken<Map<String, String>>() {
                 }.getType());
@@ -112,7 +111,7 @@ public class ApiClientImpl implements ApiClient {
     @Override
     public <T> CompletableFuture<T> submitFileAsync(final String path, final ApiCredentials credentials,
                                                     final FileRequest request, final Class<T> responseType) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials, "fileRequest", request));
+        validateParams(PATH, path, CREDENTIALS, credentials, "fileRequest", request);
         return transport.submitFile(path, credentials, request)
                 .thenApply(this::errorCheck)
                 .thenApply(response -> deserialize(response, responseType));
@@ -120,7 +119,7 @@ public class ApiClientImpl implements ApiClient {
 
     @Override
     public CompletableFuture<String> retrieveFileAsync(final String path, final ApiCredentials credentials, final String targetFile) {
-        validateMultipleRequires(ImmutableMap.of(PATH, path, CREDENTIALS, credentials));
+        validateParams(PATH, path, CREDENTIALS, credentials);
         return transport.invoke("GET_FILE", path, credentials, targetFile, null)
                 .thenApply(this::errorCheck)
                 .thenApply(Response::getBody);

--- a/src/main/java/com/checkout/CheckoutConfiguration.java
+++ b/src/main/java/com/checkout/CheckoutConfiguration.java
@@ -7,8 +7,7 @@ import java.net.URI;
 import static com.checkout.Environment.lookup;
 import static com.checkout.PlatformType.DEFAULT;
 import static com.checkout.PlatformType.FOUR;
-import static com.checkout.common.CheckoutUtils.requiresNonBlank;
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public final class CheckoutConfiguration {
 
@@ -25,13 +24,13 @@ public final class CheckoutConfiguration {
     private HttpClientBuilder apacheHttpClientBuilder;
 
     public CheckoutConfiguration(final String publicKey, final String secretKey, final Environment environment) {
-        requiresNonNull("environment", environment);
+        validateParams("environment", environment);
         this.uri = environment.getUri();
         validateAndSetKeys(publicKey, secretKey, FOUR);
     }
 
     public CheckoutConfiguration(final String publicKey, final String secretKey, final URI uri) {
-        requiresNonNull("uri", uri);
+        validateParams("uri", uri);
         this.uri = uri.toString();
         validateAndSetKeys(publicKey, secretKey, FOUR);
     }
@@ -49,13 +48,13 @@ public final class CheckoutConfiguration {
     }
 
     private CheckoutConfiguration(final String publicKey, final String secretKey, final String uri) {
-        requiresNonBlank("uri", uri);
+        validateParams("uri", uri);
         this.uri = uri;
         validateAndSetKeys(publicKey, secretKey, DEFAULT);
     }
 
     private void validateAndSetKeys(final String publicKey, final String secretKey, final PlatformType platformType) {
-        requiresNonNull("platformType", platformType);
+        validateParams("platformType", platformType);
         if (publicKey != null) {
             platformType.validatePublicKey(publicKey);
             this.publicKey = publicKey;

--- a/src/main/java/com/checkout/Environment.java
+++ b/src/main/java/com/checkout/Environment.java
@@ -1,8 +1,8 @@
 package com.checkout;
 
-import com.checkout.common.CheckoutUtils;
-
 import java.util.stream.Stream;
+
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public enum Environment {
 
@@ -20,7 +20,7 @@ public enum Environment {
     }
 
     public static Environment lookup(final String environment) {
-        CheckoutUtils.requiresNonBlank("environment", environment);
+        validateParams("environment", environment);
         return Stream.of(values())
                 .filter(entry -> entry.name().equals(environment.toUpperCase()))
                 .findFirst()

--- a/src/main/java/com/checkout/beta/AbstractClient.java
+++ b/src/main/java/com/checkout/beta/AbstractClient.java
@@ -3,7 +3,7 @@ package com.checkout.beta;
 import com.checkout.ApiClient;
 import com.checkout.ApiCredentials;
 
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public abstract class AbstractClient {
 
@@ -11,8 +11,8 @@ public abstract class AbstractClient {
     protected final ApiCredentials apiCredentials;
 
     protected AbstractClient(final ApiClient apiClient, final ApiCredentials apiCredentials) {
-        requiresNonNull("apiClient", apiClient);
-        requiresNonNull("apiCredentials", apiCredentials);
+        validateParams("apiClient", apiClient);
+        validateParams("apiCredentials", apiCredentials);
         this.apiClient = apiClient;
         this.apiCredentials = apiCredentials;
     }

--- a/src/main/java/com/checkout/beta/Checkout.java
+++ b/src/main/java/com/checkout/beta/Checkout.java
@@ -5,11 +5,15 @@ import com.checkout.ApiClientImpl;
 import com.checkout.CheckoutArgumentException;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.Environment;
-import com.google.common.annotations.Beta;
 
 import java.net.URI;
 
-@Beta
+/**
+ * BETA
+ *
+ * SDK entrypoint class to build FOUR credentials based {@link CheckoutApi} instances.
+ *
+ */
 public final class Checkout {
 
     private Checkout() {

--- a/src/main/java/com/checkout/common/CheckoutUtils.java
+++ b/src/main/java/com/checkout/common/CheckoutUtils.java
@@ -3,9 +3,10 @@ package com.checkout.common;
 import com.checkout.CheckoutArgumentException;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Map;
+public final class CheckoutUtils {
 
-public class CheckoutUtils {
+    private CheckoutUtils() {
+    }
 
     /**
      * @deprecated Will be removed in a future version
@@ -31,28 +32,56 @@ public class CheckoutUtils {
         return httpStatusCode >= 200 && httpStatusCode <= 299;
     }
 
-    public static void requiresNonBlank(final String property, final String content) {
+    public static void validateParams(final String p1, final Object o1) {
+        validateMultipleRequires(new Object[][]{{p1, o1}});
+    }
+
+    public static void validateParams(final String p1, final Object o1,
+                                      final String p2, final Object o2) {
+        validateMultipleRequires(new Object[][]{{p1, o1}, {p2, o2}});
+    }
+
+    public static void validateParams(final String p1, final Object o1,
+                                      final String p2, final Object o2,
+                                      final String p3, final Object o3) {
+        validateMultipleRequires(new Object[][]{{p1, o1}, {p2, o2}, {p3, o3}});
+    }
+
+    public static void validateParams(final String p1, final Object o1,
+                                      final String p2, final Object o2,
+                                      final String p3, final Object o3,
+                                      final String p4, final Object o4) {
+        validateMultipleRequires(new Object[][]{{p1, o1}, {p2, o2}, {p3, o3}, {p4, o4}});
+    }
+
+    private static void validateMultipleRequires(final Object[][] params) {
+        if (params.length == 0) {
+            return;
+        }
+        for (final Object[] param : params) {
+            final Object property = param[0];
+            if (!(property instanceof String) || StringUtils.isBlank((CharSequence) property)) {
+                throw new IllegalStateException("invalid validation key");
+            }
+            final Object value = param[1];
+            if (value instanceof String) {
+                requiresNonBlank((String) property, (String) value);
+                continue;
+            }
+            requiresNonNull((String) property, value);
+        }
+    }
+
+    private static void requiresNonBlank(final String property, final String content) {
         if (StringUtils.isBlank(content)) {
-            throw new CheckoutArgumentException(property + " must be not be blank");
+            throw new CheckoutArgumentException(property + " cannot be blank");
         }
     }
 
-    public static void requiresNonNull(final String property, final Object obj) {
+    private static void requiresNonNull(final String property, final Object obj) {
         if (obj == null) {
-            throw new CheckoutArgumentException(property + " must be not be null");
+            throw new CheckoutArgumentException(property + " cannot be null");
         }
     }
 
-    public static void validateMultipleRequires(final Map<String, Object> params) {
-        if (params != null) {
-            params.forEach((property, object) -> {
-                if (object instanceof String)
-                    requiresNonBlank(property, (String) object);
-                requiresNonNull(property, object);
-            });
-        }
-    }
-
-    private CheckoutUtils() {
-    }
 }

--- a/src/main/java/com/checkout/events/EventsClientImpl.java
+++ b/src/main/java/com/checkout/events/EventsClientImpl.java
@@ -10,8 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static com.checkout.common.CheckoutUtils.requiresNonBlank;
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public class EventsClientImpl extends AbstractClient implements EventsClient {
 
@@ -50,33 +49,31 @@ public class EventsClientImpl extends AbstractClient implements EventsClient {
 
     @Override
     public CompletableFuture<EventsPageResponse> retrieveEvents(final RetrieveEventsRequest retrieveEventsRequest) {
-        requiresNonNull("retrieveEventsRequest", retrieveEventsRequest);
+        validateParams("retrieveEventsRequest", retrieveEventsRequest);
         return apiClient.queryAsync(EVENTS, apiCredentials, retrieveEventsRequest, EventsPageResponse.class);
     }
 
     @Override
     public CompletableFuture<EventResponse> retrieveEvent(final String eventId) {
-        requiresNonBlank("eventId", eventId);
+        validateParams("eventId", eventId);
         return apiClient.getAsync(constructApiPath(EVENTS, eventId), apiCredentials, EventResponse.class);
     }
 
     @Override
     public CompletableFuture<EventNotificationResponse> retrieveEventNotification(final String eventId, final String notificationId) {
-        requiresNonBlank("eventId", eventId);
-        requiresNonBlank("notificationId", notificationId);
+        validateParams("eventId", eventId, "notificationId", notificationId);
         return apiClient.getAsync(constructApiPath(EVENTS, eventId, NOTIFICATIONS, notificationId), apiCredentials, EventNotificationResponse.class);
     }
 
     @Override
     public CompletableFuture<Void> retryWebhook(final String eventId, final String webhookId) {
-        requiresNonBlank("eventId", eventId);
-        requiresNonBlank("webhookId", webhookId);
+        validateParams("eventId", eventId, "webhookId", webhookId);
         return apiClient.postAsync(constructApiPath(EVENTS, eventId, WEBHOOKS, webhookId, "retry"), apiCredentials, Void.class, null, null);
     }
 
     @Override
     public CompletableFuture<Void> retryAllWebhooks(final String eventId) {
-        requiresNonBlank("eventId", eventId);
+        validateParams("eventId", eventId);
         return apiClient.postAsync(constructApiPath(EVENTS, eventId, WEBHOOKS, "retry"), apiCredentials, Void.class, null, null);
     }
 

--- a/src/main/java/com/checkout/instruments/InstrumentsClientImpl.java
+++ b/src/main/java/com/checkout/instruments/InstrumentsClientImpl.java
@@ -7,8 +7,7 @@ import com.checkout.SecretKeyCredentials;
 
 import java.util.concurrent.CompletableFuture;
 
-import static com.checkout.common.CheckoutUtils.requiresNonBlank;
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public class InstrumentsClientImpl extends AbstractClient implements InstrumentsClient {
 
@@ -20,27 +19,26 @@ public class InstrumentsClientImpl extends AbstractClient implements Instruments
 
     @Override
     public CompletableFuture<CreateInstrumentResponse> createInstrument(final CreateInstrumentRequest createInstrumentRequest) {
-        requiresNonNull("createInstrumentRequest", createInstrumentRequest);
+        validateParams("createInstrumentRequest", createInstrumentRequest);
         return apiClient.postAsync(INSTRUMENTS, apiCredentials, CreateInstrumentResponse.class, createInstrumentRequest, null);
     }
 
     @Override
     public CompletableFuture<InstrumentDetailsResponse> getInstrument(final String instrumentId) {
-        requiresNonBlank("instrumentId", instrumentId);
+        validateParams("instrumentId", instrumentId);
         return apiClient.getAsync(constructApiPath(INSTRUMENTS, instrumentId), apiCredentials, InstrumentDetailsResponse.class);
     }
 
     @Override
     public CompletableFuture<UpdateInstrumentResponse> updateInstrument(final String instrumentId, final UpdateInstrumentRequest updateInstrumentRequest) {
-        requiresNonBlank("instrumentId", instrumentId);
-        requiresNonNull("updateInstrumentRequest", updateInstrumentRequest);
+        validateParams("instrumentId", instrumentId, "updateInstrumentRequest", updateInstrumentRequest);
         return apiClient.patchAsync(constructApiPath(INSTRUMENTS, instrumentId), apiCredentials, UpdateInstrumentResponse.class, updateInstrumentRequest, null);
     }
 
     @Override
     public CompletableFuture<Void> deleteInstrument(final String instrumentId) {
-        requiresNonBlank("instrumentId", instrumentId);
+        validateParams("instrumentId", instrumentId);
         return apiClient.deleteAsync(constructApiPath(INSTRUMENTS, instrumentId), apiCredentials);
     }
-    
+
 }

--- a/src/main/java/com/checkout/payments/PaymentRequest.java
+++ b/src/main/java/com/checkout/payments/PaymentRequest.java
@@ -15,8 +15,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.checkout.common.CheckoutUtils.requiresNonBlank;
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 @Data
 @Builder
@@ -57,9 +56,7 @@ public class PaymentRequest<T extends RequestSource> {
      */
     @Deprecated
     private PaymentRequest(final T sourceOrDestination, final String currency, final Long amount, final boolean isSource) {
-        requiresNonNull("sourceOrDestination", sourceOrDestination);
-        requiresNonBlank("currency", currency);
-        requiresNonNull("amount", amount);
+        validateParams("sourceOrDestination", sourceOrDestination, "currency", currency, "amount", amount);
         this.source = isSource ? sourceOrDestination : null;
         this.destination = isSource ? null : sourceOrDestination;
         this.amount = amount;
@@ -68,9 +65,7 @@ public class PaymentRequest<T extends RequestSource> {
     }
 
     private PaymentRequest(final T sourceOrDestination, final Currency currency, final Long amount, final boolean isSource) {
-        requiresNonNull("sourceOrDestination", sourceOrDestination);
-        requiresNonNull("currency", currency);
-        requiresNonNull("amount", amount);
+        validateParams("sourceOrDestination", sourceOrDestination, "currency", currency, "amount", amount);
         this.source = isSource ? sourceOrDestination : null;
         this.destination = isSource ? null : sourceOrDestination;
         this.amount = amount;

--- a/src/main/java/com/checkout/tokens/CardTokenRequest.java
+++ b/src/main/java/com/checkout/tokens/CardTokenRequest.java
@@ -1,12 +1,13 @@
 package com.checkout.tokens;
 
 import com.checkout.common.Address;
-import com.checkout.common.CheckoutUtils;
 import com.checkout.common.Phone;
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 @Data
 @Builder
@@ -33,7 +34,7 @@ public final class CardTokenRequest implements TokenRequest {
     private Phone phone;
 
     public CardTokenRequest(final String number, final int expiryMonth, final int expiryYear) {
-        CheckoutUtils.requiresNonBlank("number", number);
+        validateParams("number", number);
         if (expiryMonth < 1 || expiryMonth > 12) {
             throw new IllegalArgumentException("The expiry month must be between 1 and 12");
         }

--- a/src/main/java/com/checkout/tokens/TokensClientImpl.java
+++ b/src/main/java/com/checkout/tokens/TokensClientImpl.java
@@ -7,7 +7,7 @@ import com.checkout.beta.AbstractClient;
 
 import java.util.concurrent.CompletableFuture;
 
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public class TokensClientImpl extends AbstractClient implements TokensClient {
 
@@ -19,13 +19,13 @@ public class TokensClientImpl extends AbstractClient implements TokensClient {
 
     @Override
     public CompletableFuture<CardTokenResponse> requestAsync(final CardTokenRequest cardTokenRequest) {
-        requiresNonNull("cardTokenRequest", cardTokenRequest);
+        validateParams("cardTokenRequest", cardTokenRequest);
         return apiClient.postAsync(TOKENS_PATH, apiCredentials, CardTokenResponse.class, cardTokenRequest, null);
     }
 
     @Override
     public CompletableFuture<TokenResponse> requestAsync(final WalletTokenRequest walletTokenRequest) {
-        requiresNonNull("walletTokenRequest", walletTokenRequest);
+        validateParams("walletTokenRequest", walletTokenRequest);
         return apiClient.postAsync(TOKENS_PATH, apiCredentials, TokenResponse.class, walletTokenRequest, null);
     }
 

--- a/src/main/java/com/checkout/tokens/beta/TokensClientImpl.java
+++ b/src/main/java/com/checkout/tokens/beta/TokensClientImpl.java
@@ -11,7 +11,7 @@ import com.checkout.tokens.beta.response.TokenResponse;
 
 import java.util.concurrent.CompletableFuture;
 
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public final class TokensClientImpl extends AbstractClient implements TokensClient {
 
@@ -23,13 +23,13 @@ public final class TokensClientImpl extends AbstractClient implements TokensClie
 
     @Override
     public CompletableFuture<CardTokenResponse> requestAsync(final CardTokenRequest cardTokenRequest) {
-        requiresNonNull("cardTokenRequest", cardTokenRequest);
+        validateParams("cardTokenRequest", cardTokenRequest);
         return apiClient.postAsync(TOKENS_PATH, apiCredentials, CardTokenResponse.class, cardTokenRequest, null);
     }
 
     @Override
     public CompletableFuture<TokenResponse> requestAsync(final WalletTokenRequest walletTokenRequest) {
-        requiresNonNull("walletTokenRequest", walletTokenRequest);
+        validateParams("walletTokenRequest", walletTokenRequest);
         return apiClient.postAsync(TOKENS_PATH, apiCredentials, TokenResponse.class, walletTokenRequest, null);
     }
 

--- a/src/main/java/com/checkout/webhooks/WebhooksClientImpl.java
+++ b/src/main/java/com/checkout/webhooks/WebhooksClientImpl.java
@@ -9,8 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static com.checkout.common.CheckoutUtils.requiresNonBlank;
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 
 public class WebhooksClientImpl extends AbstractClient implements WebhooksClient {
 
@@ -34,26 +33,25 @@ public class WebhooksClientImpl extends AbstractClient implements WebhooksClient
 
     @Override
     public CompletableFuture<WebhookResponse> registerWebhook(final WebhookRequest webhookRequest, final String idempotencyKey) {
-        requiresNonNull("webhookRequest", webhookRequest);
+        validateParams("webhookRequest", webhookRequest);
         return apiClient.postAsync(WEBHOOKS, apiCredentials, WebhookResponse.class, webhookRequest, idempotencyKey);
     }
 
     @Override
     public CompletableFuture<WebhookResponse> retrieveWebhook(final String webhookId) {
-        requiresNonBlank("webhookId", webhookId);
+        validateParams("webhookId", webhookId);
         return apiClient.getAsync(constructApiPath(WEBHOOKS, webhookId), apiCredentials, WebhookResponse.class);
     }
 
     @Override
     public CompletableFuture<WebhookResponse> updateWebhook(final String webhookId, final WebhookRequest webhookRequest) {
-        requiresNonBlank("webhookId", webhookId);
-        requiresNonNull("webhookRequest", webhookRequest);
+        validateParams("webhookId", webhookId, "webhookRequest", webhookRequest);
         return apiClient.putAsync(constructApiPath(WEBHOOKS, webhookId), apiCredentials, WebhookResponse.class, webhookRequest);
     }
 
     @Override
     public CompletableFuture<Void> removeWebhook(final String webhookId) {
-        requiresNonBlank("webhookId", webhookId);
+        validateParams("webhookId", webhookId);
         return apiClient.deleteAsync(constructApiPath(WEBHOOKS, webhookId), apiCredentials);
     }
 

--- a/src/test/java/com/checkout/CheckoutConfigurationTest.java
+++ b/src/test/java/com/checkout/CheckoutConfigurationTest.java
@@ -31,7 +31,7 @@ public class CheckoutConfigurationTest {
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("environment must be not be null", e.getMessage());
+            assertEquals("environment cannot be null", e.getMessage());
         }
     }
 
@@ -60,7 +60,7 @@ public class CheckoutConfigurationTest {
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("uri must be not be null", e.getMessage());
+            assertEquals("uri cannot be null", e.getMessage());
         }
     }
 
@@ -88,7 +88,7 @@ public class CheckoutConfigurationTest {
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("uri must be not be blank", e.getMessage());
+            assertEquals("uri cannot be null", e.getMessage());
         }
     }
 

--- a/src/test/java/com/checkout/PublicKeyCredentialsTest.java
+++ b/src/test/java/com/checkout/PublicKeyCredentialsTest.java
@@ -16,7 +16,7 @@ public class PublicKeyCredentialsTest {
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("configuration must be not be null", e.getMessage());
+            assertEquals("configuration cannot be null", e.getMessage());
         }
     }
 
@@ -41,7 +41,7 @@ public class PublicKeyCredentialsTest {
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("configuration must be not be null", e.getMessage());
+            assertEquals("configuration cannot be null", e.getMessage());
         }
     }
 

--- a/src/test/java/com/checkout/SecretKeyCredentialsTest.java
+++ b/src/test/java/com/checkout/SecretKeyCredentialsTest.java
@@ -16,7 +16,7 @@ public class SecretKeyCredentialsTest {
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("configuration must be not be null", e.getMessage());
+            assertEquals("configuration cannot be null", e.getMessage());
         }
     }
 
@@ -41,7 +41,7 @@ public class SecretKeyCredentialsTest {
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("configuration must be not be null", e.getMessage());
+            assertEquals("configuration cannot be null", e.getMessage());
         }
     }
 

--- a/src/test/java/com/checkout/common/CheckoutUtilsTest.java
+++ b/src/test/java/com/checkout/common/CheckoutUtilsTest.java
@@ -3,36 +3,47 @@ package com.checkout.common;
 import com.checkout.CheckoutArgumentException;
 import org.junit.jupiter.api.Test;
 
-import static com.checkout.common.CheckoutUtils.requiresNonBlank;
-import static com.checkout.common.CheckoutUtils.requiresNonNull;
+import static com.checkout.common.CheckoutUtils.validateParams;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class CheckoutUtilsTest {
 
     @Test
-    public void testRequiresNonBlank() {
+    public void shouldRequireNonBlank() {
 
-        testNoExceptionIsThrownRequiresNonBlank("name", "john");
-        testExceptionIsThrownRequiresNonBlank("name", null);
-        testExceptionIsThrownRequiresNonBlank("age", "");
-        testExceptionIsThrownRequiresNonBlank("age", "  ");
+        testNoExceptionIsThrownRequiresNonBlank("name1", "john");
+        testExceptionIsThrownRequiresNonBlank("age1", "");
+        testExceptionIsThrownRequiresNonBlank("age2", "  ");
 
     }
 
     @Test
-    public void testRequiresNonNull() {
+    public void shouldRequireNonNull() {
 
-        testNoExceptionIsThrownRequiresNonNull("name", "john");
-        testNoExceptionIsThrownRequiresNonNull("name", new Object());
-        testNoExceptionIsThrownRequiresNonNull("name", 20L);
-        testExceptionIsThrownRequiresNonNull("name", null);
+        testNoExceptionIsThrownRequiresNonNull("name1", "john");
+        testNoExceptionIsThrownRequiresNonNull("name2", new Object());
+        testNoExceptionIsThrownRequiresNonNull("name3", 20L);
+        testExceptionIsThrownRequiresNonNull("name4", null);
+
+    }
+
+    @Test
+    public void shouldThrowOnNullOrEmptyProperty() {
+
+        testExceptionIsThrownOnInvalidProperty(null);
+        testExceptionIsThrownOnInvalidProperty("");
+        testExceptionIsThrownOnInvalidProperty(" ");
 
     }
 
     private void testNoExceptionIsThrownRequiresNonBlank(final String property, final String content) {
         try {
-            requiresNonBlank(property, content);
+            validateParams(property, content);
+            validateParams(property, content, "test", new Object());
+            validateParams("test1", new Object(), property, content, "test2", new Object());
+            validateParams("test1", new Object(), "test2", new Object(), property, content, "test3", new Object());
         } catch (final Exception e) {
             fail();
         }
@@ -40,27 +51,105 @@ public class CheckoutUtilsTest {
 
     private void testExceptionIsThrownRequiresNonBlank(final String property, final String content) {
         try {
-            requiresNonBlank(property, content);
+            validateParams(property, content);
             fail();
-        } catch (final CheckoutArgumentException e) {
-            assertEquals(property + " must be not be blank", e.getMessage());
+        } catch (final Exception e) {
+            assertTrue(e instanceof CheckoutArgumentException);
+            assertEquals(property + " cannot be blank", e.getMessage());
+        }
+        try {
+            validateParams(property, content, "test", new Object());
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof CheckoutArgumentException);
+            assertEquals(property + " cannot be blank", e.getMessage());
+        }
+        try {
+            validateParams("test1", new Object(), property, content, "test2", new Object());
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof CheckoutArgumentException);
+            assertEquals(property + " cannot be blank", e.getMessage());
+        }
+        try {
+            validateParams("test1", new Object(), "test2", new Object(), property, content, "test3", new Object());
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof CheckoutArgumentException);
+            assertEquals(property + " cannot be blank", e.getMessage());
+        }
+    }
+
+    private void testExceptionIsThrownRequiresNonNull(final String property, final String content) {
+        try {
+            validateParams(property, content);
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof CheckoutArgumentException);
+            assertEquals(property + " cannot be null", e.getMessage());
+        }
+        try {
+            validateParams(property, content, "test", new Object());
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof CheckoutArgumentException);
+            assertEquals(property + " cannot be null", e.getMessage());
+        }
+        try {
+            validateParams("test1", new Object(), property, content, "test2", new Object());
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof CheckoutArgumentException);
+            assertEquals(property + " cannot be null", e.getMessage());
+        }
+        try {
+            validateParams("test1", new Object(), "test2", new Object(), property, content, "test3", new Object());
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof CheckoutArgumentException);
+            assertEquals(property + " cannot be null", e.getMessage());
         }
     }
 
     private void testNoExceptionIsThrownRequiresNonNull(final String property, final Object content) {
         try {
-            requiresNonNull(property, content);
+            validateParams(property, content);
+            validateParams(property, content, "test", new Object());
+            validateParams("test1", new Object(), property, content, "test2", new Object());
+            validateParams("test1", new Object(), "test2", new Object(), property, content, "test3", new Object());
         } catch (final Exception e) {
             fail();
         }
     }
 
-    private void testExceptionIsThrownRequiresNonNull(final String property, final Object content) {
+    private void testExceptionIsThrownOnInvalidProperty(final String property) {
         try {
-            requiresNonNull(property, content);
+            validateParams(property, new Object());
             fail();
-        } catch (final CheckoutArgumentException e) {
-            assertEquals(property + " must be not be null", e.getMessage());
+        } catch (final Exception e) {
+            assertTrue(e instanceof IllegalStateException);
+            assertEquals("invalid validation key", e.getMessage());
+        }
+        try {
+            validateParams(property, new Object(), "test", new Object());
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof IllegalStateException);
+            assertEquals("invalid validation key", e.getMessage());
+        }
+        try {
+            validateParams("test1", new Object(), property, new Object(), "test2", new Object());
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof IllegalStateException);
+            assertEquals("invalid validation key", e.getMessage());
+        }
+        try {
+            validateParams("test1", new Object(), "test2", new Object(), property, new Object(), "test3", new Object());
+            fail();
+        } catch (final Exception e) {
+            assertTrue(e instanceof IllegalStateException);
+            assertEquals("invalid validation key", e.getMessage());
         }
     }
 

--- a/src/test/java/com/checkout/events/EventsClientImplTest.java
+++ b/src/test/java/com/checkout/events/EventsClientImplTest.java
@@ -158,7 +158,7 @@ public class EventsClientImplTest {
             eventsClient.retrieveEvents(null);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("retrieveEventsRequest must be not be null", e.getMessage());
+            assertEquals("retrieveEventsRequest cannot be null", e.getMessage());
         }
 
         verifyNoInteractions(apiClient);
@@ -188,14 +188,14 @@ public class EventsClientImplTest {
             eventsClient.retrieveEvent(null);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("eventId must be not be blank", e.getMessage());
+            assertEquals("eventId cannot be null", e.getMessage());
         }
 
         try {
             eventsClient.retrieveEvent("");
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("eventId must be not be blank", e.getMessage());
+            assertEquals("eventId cannot be blank", e.getMessage());
         }
 
         verifyNoInteractions(apiClient);
@@ -209,14 +209,14 @@ public class EventsClientImplTest {
             eventsClient.retrieveEventNotification("eventId", null);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("notificationId must be not be blank", e.getMessage());
+            assertEquals("notificationId cannot be null", e.getMessage());
         }
 
         try {
             eventsClient.retrieveEventNotification("eventId", "");
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("notificationId must be not be blank", e.getMessage());
+            assertEquals("notificationId cannot be blank", e.getMessage());
         }
 
         verifyNoInteractions(apiClient);
@@ -258,14 +258,14 @@ public class EventsClientImplTest {
             eventsClient.retryWebhook(null, "notificationId");
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("eventId must be not be blank", e.getMessage());
+            assertEquals("eventId cannot be null", e.getMessage());
         }
 
         try {
             eventsClient.retryWebhook("", "notificationId");
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("eventId must be not be blank", e.getMessage());
+            assertEquals("eventId cannot be blank", e.getMessage());
         }
 
         verifyNoInteractions(apiClient);
@@ -279,14 +279,14 @@ public class EventsClientImplTest {
             eventsClient.retryWebhook("eventId", null);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("webhookId must be not be blank", e.getMessage());
+            assertEquals("webhookId cannot be null", e.getMessage());
         }
 
         try {
             eventsClient.retryWebhook("eventId", "");
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("webhookId must be not be blank", e.getMessage());
+            assertEquals("webhookId cannot be blank", e.getMessage());
         }
 
         verifyNoInteractions(apiClient);

--- a/src/test/java/com/checkout/reconciliation/ReconciliationClientImplTest.java
+++ b/src/test/java/com/checkout/reconciliation/ReconciliationClientImplTest.java
@@ -5,8 +5,6 @@ import com.checkout.ApiCredentials;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.common.Currency;
 import com.checkout.common.QueryFilterDateRange;
-import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -85,27 +84,27 @@ public class ReconciliationClientImplTest {
 
     private void setUpPaymentReport() {
         when(reconciliationPaymentReportResponse.getCount()).thenReturn(1);
-        when(reconciliationPaymentReportResponse.getData()).thenReturn(ImmutableList.of(paymentReportData));
+        when(reconciliationPaymentReportResponse.getData()).thenReturn(Collections.singletonList(paymentReportData));
         when(paymentReportData.getId()).thenReturn(PAYMENT_ID);
         when(paymentReportData.getProcessingCurrency()).thenReturn(Currency.USD);
         when(paymentReportData.getPayoutCurrency()).thenReturn(Currency.GBP);
         when(paymentReportData.getReference()).thenReturn(REFERENCE);
-        when(paymentReportData.getActions()).thenReturn(ImmutableList.of(action));
+        when(paymentReportData.getActions()).thenReturn(Collections.singletonList(action));
         when(action.getId()).thenReturn(ACTION_ID);
         when(action.getType()).thenReturn(ACTION_TYPE);
-        when(action.getBreakdown()).thenReturn(ImmutableList.of(breakdown));
+        when(action.getBreakdown()).thenReturn(Collections.singletonList(breakdown));
         when(breakdown.getType()).thenReturn(BREAKDOWN_TYPE);
 
     }
 
     private void setUpStatementResponse() {
         when(statementReportResponse.getCount()).thenReturn(1);
-        when(statementReportResponse.getData()).thenReturn(ImmutableList.of(statementData));
+        when(statementReportResponse.getData()).thenReturn(Collections.singletonList(statementData));
         when(statementData.getId()).thenReturn(STATEMENT_ID);
         when(statementData.getPeriodStart()).thenReturn(FROM);
         when(statementData.getPeriodEnd()).thenReturn(TO);
         when(statementData.getDate()).thenReturn(TO);
-        when(statementData.getPayouts()).thenReturn(ImmutableList.of(payout));
+        when(statementData.getPayouts()).thenReturn(Collections.singletonList(payout));
         when(payout.getCurrency()).thenReturn(Currency.GBP);
         when(payout.getPeriodStart()).thenReturn(FROM);
         when(payout.getPeriodEnd()).thenReturn(TO);

--- a/src/test/java/com/checkout/tokens/TokensClientTest.java
+++ b/src/test/java/com/checkout/tokens/TokensClientTest.java
@@ -45,7 +45,7 @@ public class TokensClientTest {
             new TokensClientImpl(null, checkoutConfiguration);
             fail();
         } catch (final CheckoutArgumentException checkoutArgumentException) {
-            assertEquals("apiClient must be not be null", checkoutArgumentException.getMessage());
+            assertEquals("apiClient cannot be null", checkoutArgumentException.getMessage());
         }
 
     }
@@ -57,7 +57,7 @@ public class TokensClientTest {
             tokensClient.requestAsync((CardTokenRequest) null);
             fail();
         } catch (final CheckoutArgumentException checkoutArgumentException) {
-            assertEquals("cardTokenRequest must be not be null", checkoutArgumentException.getMessage());
+            assertEquals("cardTokenRequest cannot be null", checkoutArgumentException.getMessage());
         }
 
         verifyNoInteractions(apiClient);
@@ -82,7 +82,7 @@ public class TokensClientTest {
             tokensClient.requestAsync((WalletTokenRequest) null);
             fail();
         } catch (final CheckoutArgumentException checkoutArgumentException) {
-            assertEquals("walletTokenRequest must be not be null", checkoutArgumentException.getMessage());
+            assertEquals("walletTokenRequest cannot be null", checkoutArgumentException.getMessage());
         }
 
         verifyNoInteractions(apiClient);

--- a/src/test/java/com/checkout/tokens/beta/TokensClientTest.java
+++ b/src/test/java/com/checkout/tokens/beta/TokensClientTest.java
@@ -51,7 +51,7 @@ public class TokensClientTest {
             new TokensClientImpl(null, checkoutConfiguration);
             fail();
         } catch (final CheckoutArgumentException checkoutArgumentException) {
-            assertEquals("apiClient must be not be null", checkoutArgumentException.getMessage());
+            assertEquals("apiClient cannot be null", checkoutArgumentException.getMessage());
         }
 
     }
@@ -63,7 +63,7 @@ public class TokensClientTest {
             tokensClient.requestAsync((CardTokenRequest) null);
             fail();
         } catch (final CheckoutArgumentException checkoutArgumentException) {
-            assertEquals("cardTokenRequest must be not be null", checkoutArgumentException.getMessage());
+            assertEquals("cardTokenRequest cannot be null", checkoutArgumentException.getMessage());
         }
 
         verifyNoInteractions(apiClient);
@@ -88,7 +88,7 @@ public class TokensClientTest {
             tokensClient.requestAsync((WalletTokenRequest) null);
             fail();
         } catch (final CheckoutArgumentException checkoutArgumentException) {
-            assertEquals("walletTokenRequest must be not be null", checkoutArgumentException.getMessage());
+            assertEquals("walletTokenRequest cannot be null", checkoutArgumentException.getMessage());
         }
 
         verifyNoInteractions(apiClient);

--- a/src/test/java/com/checkout/webhooks/WebhooksClientImplTest.java
+++ b/src/test/java/com/checkout/webhooks/WebhooksClientImplTest.java
@@ -96,7 +96,7 @@ public class WebhooksClientImplTest {
             webhooksClient.registerWebhook(null);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("webhookRequest must be not be null", e.getMessage());
+            assertEquals("webhookRequest cannot be null", e.getMessage());
         }
 
         verifyNoInteractions(apiClient);
@@ -141,14 +141,14 @@ public class WebhooksClientImplTest {
             webhooksClient.retrieveWebhook("");
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("webhookId must be not be blank", e.getMessage());
+            assertEquals("webhookId cannot be blank", e.getMessage());
         }
 
         try {
             webhooksClient.retrieveWebhook(null);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("webhookId must be not be blank", e.getMessage());
+            assertEquals("webhookId cannot be null", e.getMessage());
         }
 
         verifyNoInteractions(apiClient);
@@ -178,14 +178,14 @@ public class WebhooksClientImplTest {
             webhooksClient.updateWebhook("id", null);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("webhookRequest must be not be null", e.getMessage());
+            assertEquals("webhookRequest cannot be null", e.getMessage());
         }
 
         try {
             webhooksClient.updateWebhook("", new WebhookRequest());
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("webhookId must be not be blank", e.getMessage());
+            assertEquals("webhookId cannot be blank", e.getMessage());
         }
 
         verifyNoInteractions(apiClient);
@@ -211,14 +211,14 @@ public class WebhooksClientImplTest {
             webhooksClient.removeWebhook(null);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("webhookId must be not be blank", e.getMessage());
+            assertEquals("webhookId cannot be null", e.getMessage());
         }
 
         try {
             webhooksClient.removeWebhook("");
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("webhookId must be not be blank", e.getMessage());
+            assertEquals("webhookId cannot be blank", e.getMessage());
         }
 
         verifyNoInteractions(apiClient);


### PR DESCRIPTION
Existing `validateMultipleRequires` intruduced a new way to
validate multiple parameters. Although, this didn't reveal to be
a convenient feature due to the complexity of building validation
property maps (specially in Java 8).

This commit adds a more convenient and perfomant way of validating
groups of properties, by providing multiple methods depending on
the number of properties to validate (syntactic sugar).

As a result, Guava dependency was removed along with the `@Beta`
annotation added at Checkout main entry class for CS2.