### PR TITLE
Add iDEAL get information endpoint support

### DIFF
--- a/src/main/java/com/checkout/apm/ideal/IdealClient.java
+++ b/src/main/java/com/checkout/apm/ideal/IdealClient.java
@@ -4,6 +4,8 @@ import java.util.concurrent.CompletableFuture;
 
 public interface IdealClient {
 
+    CompletableFuture<IdealInfo> getInfo();
+
     CompletableFuture<IssuerResponse> getIssuers();
 
 }

--- a/src/main/java/com/checkout/apm/ideal/IdealClientImpl.java
+++ b/src/main/java/com/checkout/apm/ideal/IdealClientImpl.java
@@ -9,15 +9,21 @@ import java.util.concurrent.CompletableFuture;
 
 public class IdealClientImpl extends AbstractClient implements IdealClient {
 
-    private static final String IDEAL_PATH = "/ideal-external/issuers";
+    private static final String IDEAL_EXTERNAL_PATH = "/ideal-external";
+    private static final String ISSUERS = "issuers";
 
     public IdealClientImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
         super(apiClient, configuration, SdkAuthorizationType.SECRET_KEY);
     }
 
     @Override
+    public CompletableFuture<IdealInfo> getInfo() {
+        return apiClient.getAsync(buildPath(IDEAL_EXTERNAL_PATH), sdkAuthorization(), IdealInfo.class);
+    }
+
+    @Override
     public CompletableFuture<IssuerResponse> getIssuers() {
-        return apiClient.getAsync(IDEAL_PATH, sdkAuthorization(), IssuerResponse.class);
+        return apiClient.getAsync(buildPath(IDEAL_EXTERNAL_PATH, ISSUERS), sdkAuthorization(), IssuerResponse.class);
     }
 
 }

--- a/src/main/java/com/checkout/apm/ideal/IdealInfo.java
+++ b/src/main/java/com/checkout/apm/ideal/IdealInfo.java
@@ -1,0 +1,36 @@
+package com.checkout.apm.ideal;
+
+import com.checkout.common.Link;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public final class IdealInfo {
+
+    @SerializedName("_links")
+    private IdealInfoLinks links;
+
+    @Data
+    public static final class IdealInfoLinks {
+
+        private Link self;
+
+        private List<CuriesLink> curies;
+
+        @SerializedName("ideal:issuers")
+        private Link issuers;
+
+    }
+
+    @Data
+    public static final class CuriesLink {
+
+        private String name;
+        private String href;
+        private Boolean templated;
+
+    }
+
+}

--- a/src/test/java/com/checkout/apm/ideal/IdealPaymentsTestIT.java
+++ b/src/test/java/com/checkout/apm/ideal/IdealPaymentsTestIT.java
@@ -1,0 +1,69 @@
+package com.checkout.apm.ideal;
+
+import com.checkout.PlatformType;
+import com.checkout.SandboxTestFixture;
+import com.checkout.common.Currency;
+import com.checkout.payments.PaymentPending;
+import com.checkout.payments.PaymentRequest;
+import com.checkout.payments.PaymentResponse;
+import com.checkout.payments.apm.IdealSource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class IdealPaymentsTestIT extends SandboxTestFixture {
+
+    IdealPaymentsTestIT() {
+        super(PlatformType.DEFAULT);
+    }
+
+    @Test
+    void shouldMakeIdealPayment() {
+
+        final IdealSource idealSource = IdealSource.builder()
+                .bic("INGBNL2A")
+                .description("ORD50234E89")
+                .language("nl")
+                .build();
+
+        final PaymentRequest<IdealSource> request = PaymentRequest.ideal(idealSource, Currency.EUR, 1000L);
+
+        final PaymentResponse response = blocking(defaultApi.paymentsClient().requestAsync(request));
+
+        assertNotNull(response);
+
+        final PaymentPending paymentPending = response.getPending();
+        assertNotNull(paymentPending);
+        assertEquals("Pending", paymentPending.getStatus());
+
+        assertNotNull(paymentPending.getLink("self"));
+        assertNotNull(paymentPending.getLink("redirect"));
+
+    }
+
+    @Test
+    void shouldGetInfo() {
+
+        final IdealInfo idealInfo = blocking(defaultApi.idealClient().getInfo());
+
+        assertNotNull(idealInfo);
+        assertNotNull(idealInfo.getLinks().getSelf());
+        assertNotNull(idealInfo.getLinks().getCuries());
+        assertEquals(1, idealInfo.getLinks().getCuries().size());
+        assertNotNull(idealInfo.getLinks().getIssuers());
+
+    }
+
+    @Test
+    void shouldGetIssuers() {
+
+        final IssuerResponse issuerResponse = blocking(defaultApi.idealClient().getIssuers());
+
+        assertNotNull(issuerResponse);
+        assertNotNull(issuerResponse.getSelfLink());
+        assertNotNull(issuerResponse.getCountries());
+
+    }
+
+}


### PR DESCRIPTION
This commit adds support for ideal `/ideal-external` informational endpoint.