### PR TITLE
Deprecate Giropay operations and BIC attribute

### DIFF
--- a/src/main/java/com/checkout/AbstractCheckoutApmApi.java
+++ b/src/main/java/com/checkout/AbstractCheckoutApmApi.java
@@ -55,6 +55,10 @@ public abstract class AbstractCheckoutApmApi {
         return fawryClient;
     }
 
+    /**
+     * @deprecated GiropayClient client will be removed in a future version.
+     */
+    @Deprecated
     public GiropayClient giropayClient() {
         return giropayClient;
     }

--- a/src/main/java/com/checkout/apm/giropay/GiropayClient.java
+++ b/src/main/java/com/checkout/apm/giropay/GiropayClient.java
@@ -2,10 +2,16 @@ package com.checkout.apm.giropay;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * @deprecated GiropayClient client will be removed in a future version.
+ */
+@Deprecated
 public interface GiropayClient {
 
+    @Deprecated
     CompletableFuture<BanksResponse> getEpsBanks();
 
+    @Deprecated
     CompletableFuture<BanksResponse> getBanks();
 
 }

--- a/src/main/java/com/checkout/apm/giropay/GiropayClientImpl.java
+++ b/src/main/java/com/checkout/apm/giropay/GiropayClientImpl.java
@@ -7,6 +7,10 @@ import com.checkout.SdkAuthorizationType;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * @deprecated GiropayClient client will be removed in a future version.
+ */
+@Deprecated
 public class GiropayClientImpl extends AbstractClient implements GiropayClient {
 
     private static final String GIROPAY_PATH = "/giropay";
@@ -15,11 +19,19 @@ public class GiropayClientImpl extends AbstractClient implements GiropayClient {
         super(apiClient, configuration, SdkAuthorizationType.SECRET_KEY);
     }
 
+    /**
+     * @deprecated This operation will be removed in a future version.
+     */
+    @Deprecated
     @Override
     public CompletableFuture<BanksResponse> getBanks() {
         return apiClient.getAsync(buildPath(GIROPAY_PATH, "banks"), sdkAuthorization(), BanksResponse.class);
     }
 
+    /**
+     * @deprecated This operation will be removed in a future version.
+     */
+    @Deprecated
     @Override
     public CompletableFuture<BanksResponse> getEpsBanks() {
         return apiClient.getAsync(buildPath(GIROPAY_PATH, "eps", "banks"), sdkAuthorization(), BanksResponse.class);

--- a/src/main/java/com/checkout/payments/apm/GiropaySource.java
+++ b/src/main/java/com/checkout/payments/apm/GiropaySource.java
@@ -15,6 +15,10 @@ public final class GiropaySource implements RequestSource {
 
     private final PaymentSourceType type = PaymentSourceType.GIROPAY;
 
+    /**
+     * @deprecated BIC doesn't need to be supplied anymore. This attribute will be removed in a future version.
+     */
+    @Deprecated
     private String bic;
 
     private String purpose;

--- a/src/test/java/com/checkout/apm/giropay/GiropayPaymentsTestIT.java
+++ b/src/test/java/com/checkout/apm/giropay/GiropayPaymentsTestIT.java
@@ -24,7 +24,8 @@ class GiropayPaymentsTestIT extends SandboxTestFixture {
     void shouldMakeGiropayPayment() {
 
         final GiropaySource giropaySource = GiropaySource.builder()
-                .bic("TESTDETT421")
+                // TODO BIC doesn't need to be supplied anymore. Remove setter when deprecated attribute is deleted.
+                //.bic("TESTDETT421")
                 .purpose("CKO Giropay test")
                 .build();
 


### PR DESCRIPTION
This commit deprecates Giropay `getBanks` and `getEpsBanks` and the BIC attribute
from `GiropaySource`.