### PR TITLE
Review Account holder implementations

### DIFF
--- a/src/main/java/com/checkout/common/four/AccountHolder.java
+++ b/src/main/java/com/checkout/common/four/AccountHolder.java
@@ -6,21 +6,23 @@ import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
 @AllArgsConstructor
-public final class AccountHolder {
+@NoArgsConstructor
+public class AccountHolder {
 
     @SerializedName("first_name")
-    private final String firstName;
+    private String firstName;
 
     @SerializedName("last_name")
-    private final String lastName;
+    private String lastName;
 
     @SerializedName("billing_address")
-    private final Address billingAddress;
+    private Address billingAddress;
 
-    private final Phone phone;
+    private Phone phone;
 
 }

--- a/src/main/java/com/checkout/instruments/CreateInstrumentRequest.java
+++ b/src/main/java/com/checkout/instruments/CreateInstrumentRequest.java
@@ -17,7 +17,7 @@ public final class CreateInstrumentRequest {
     private String token;
 
     @SerializedName("account_holder")
-    private AccountHolder accountHolder;
+    private InstrumentAccountHolder accountHolder;
 
     private InstrumentCustomerRequest customer;
 

--- a/src/main/java/com/checkout/instruments/InstrumentAccountHolder.java
+++ b/src/main/java/com/checkout/instruments/InstrumentAccountHolder.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public final class AccountHolder {
+public final class InstrumentAccountHolder {
 
     @SerializedName("billing_address")
     private Address billingAddress;

--- a/src/main/java/com/checkout/instruments/InstrumentDetailsResponse.java
+++ b/src/main/java/com/checkout/instruments/InstrumentDetailsResponse.java
@@ -48,7 +48,7 @@ public final class InstrumentDetailsResponse {
     private String productType;
 
     @SerializedName("account_holder")
-    private AccountHolder accountHolder;
+    private InstrumentAccountHolder accountHolder;
 
     private InstrumentCustomerResponse customer;
 

--- a/src/main/java/com/checkout/instruments/UpdateInstrumentRequest.java
+++ b/src/main/java/com/checkout/instruments/UpdateInstrumentRequest.java
@@ -21,7 +21,7 @@ public final class UpdateInstrumentRequest {
     private String name;
 
     @SerializedName("account_holder")
-    private AccountHolder accountHolder;
+    private InstrumentAccountHolder accountHolder;
 
     private Customer customer;
 

--- a/src/main/java/com/checkout/instruments/four/update/UpdateInstrumentCardRequest.java
+++ b/src/main/java/com/checkout/instruments/four/update/UpdateInstrumentCardRequest.java
@@ -24,7 +24,6 @@ public final class UpdateInstrumentCardRequest extends UpdateInstrumentRequest {
 
     private String name;
 
-    // TODO Implement specific UpdateCardAccountHolder domain when it's available
     @SerializedName("account_holder")
     private AccountHolder accountHolder;
 

--- a/src/main/java/com/checkout/marketplace/MarketplaceAccountHolder.java
+++ b/src/main/java/com/checkout/marketplace/MarketplaceAccountHolder.java
@@ -1,22 +1,18 @@
 package com.checkout.marketplace;
 
-import com.checkout.common.Address;
 import com.checkout.common.CountryCode;
+import com.checkout.common.four.AccountHolder;
 import com.google.gson.annotations.SerializedName;
-import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Data
-@Builder
-public final class InstrumentAccountHolder {
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class MarketplaceAccountHolder extends AccountHolder {
 
-    private InstrumentAccountHolderType type;
-
-    @SerializedName("first_name")
-    private String firstName;
-
-    @SerializedName("last_name")
-    private String lastName;
+    private MarketplaceAccountHolderType type;
 
     @SerializedName("company_name")
     private String companyName;
@@ -30,12 +26,8 @@ public final class InstrumentAccountHolder {
     @SerializedName("country_of_birth")
     private CountryCode countryOfBirth;
 
+    @SerializedName("residential_status")
     private String residentialStatus;
-
-    @SerializedName("billing_address")
-    private Address billingAddress;
-
-    private Phone phone;
 
     private Identification identification;
 

--- a/src/main/java/com/checkout/marketplace/MarketplaceAccountHolderType.java
+++ b/src/main/java/com/checkout/marketplace/MarketplaceAccountHolderType.java
@@ -2,7 +2,7 @@ package com.checkout.marketplace;
 
 import com.google.gson.annotations.SerializedName;
 
-public enum InstrumentAccountHolderType {
+public enum MarketplaceAccountHolderType {
 
     @SerializedName("individual")
     INDIVIDUAL,

--- a/src/test/java/com/checkout/instruments/InstrumentsTestIT.java
+++ b/src/test/java/com/checkout/instruments/InstrumentsTestIT.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InstrumentsTestIT extends SandboxTestFixture {
 
-    private AccountHolder accountHolder;
+    private InstrumentAccountHolder accountHolder;
 
     InstrumentsTestIT() {
         super(PlatformType.DEFAULT);
@@ -25,7 +25,7 @@ class InstrumentsTestIT extends SandboxTestFixture {
 
     @BeforeEach
     void setUp() {
-        accountHolder = AccountHolder.builder()
+        accountHolder = InstrumentAccountHolder.builder()
                 .billingAddress(Address.builder()
                         .addressLine1("123 Street")
                         .addressLine2("Hollywood Avenue")

--- a/src/test/java/com/checkout/risk/PreAuthenticationCaptureTestIT.java
+++ b/src/test/java/com/checkout/risk/PreAuthenticationCaptureTestIT.java
@@ -9,7 +9,7 @@ import com.checkout.common.CountryCode;
 import com.checkout.common.Currency;
 import com.checkout.common.CustomerRequest;
 import com.checkout.common.Phone;
-import com.checkout.instruments.AccountHolder;
+import com.checkout.instruments.InstrumentAccountHolder;
 import com.checkout.instruments.CreateInstrumentRequest;
 import com.checkout.instruments.CreateInstrumentResponse;
 import com.checkout.CardSourceHelper;
@@ -116,7 +116,7 @@ class PreAuthenticationCaptureTestIT extends SandboxTestFixture {
         final CreateInstrumentRequest request = CreateInstrumentRequest.builder()
                 .type("token")
                 .token(cardToken.getToken())
-                .accountHolder(AccountHolder.builder()
+                .accountHolder(InstrumentAccountHolder.builder()
                         .billingAddress(Address.builder()
                                 .addressLine1("123 Street")
                                 .addressLine2("Hollywood Avenue")


### PR DESCRIPTION
Existing instruments `AccountHolder` was renamed to `InstrumentAccountHolder` and extends
the base type define in common. Common type is not final anymore. Marketplace defined
incorrectly a `InstrumentAccountHolder` that was renamed to `MarketplaceAccountHolder.`