### PR TITLE
Change secrets getters visibility

### DIFF
--- a/src/main/java/com/checkout/AbstractStaticKeysSdkCredentials.java
+++ b/src/main/java/com/checkout/AbstractStaticKeysSdkCredentials.java
@@ -39,11 +39,11 @@ abstract class AbstractStaticKeysSdkCredentials extends SdkCredentials {
         return key.matches(pattern);
     }
 
-    public String getSecretKey() {
+    String getSecretKey() {
         return secretKey;
     }
 
-    public String getPublicKey() {
+    String getPublicKey() {
         return publicKey;
     }
 


### PR DESCRIPTION
The abstract class for static keys `AbstractStaticKeysSdkCredentials` is set to package private
 and this should be enough to avoid being able to retrieve them after client instantiation. In
 any case account secrets getters should be package-private. This commit does exactly just that.