### PR TITLE
Update Java distribution

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -8,11 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 11
-          java-package: jdk
-          architecture: x64
+          distribution: 'temurin'
+          java-version: '11'
       - id: validate-wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - id: build

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -8,11 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 11
-          java-package: jdk
-          architecture: x64
+          distribution: 'temurin'
+          java-version: '11'
       - id: validate-wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - id: build

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,11 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 11
-          java-package: jdk
-          architecture: x64
+          distribution: 'temurin'
+          java-version: '11'
       - id: read-version
         uses: HardNorth/github-version-generate@v1.1.1
         with:


### PR DESCRIPTION
This commit updates build actions to use `setup-java@v2` action and
enforce `Temurin` distribution (former AdoptOpenJDK).