### PR TITLE
Remove deprecated Events and CountryCode methods

### DIFF
--- a/src/main/java/com/checkout/common/Address.java
+++ b/src/main/java/com/checkout/common/Address.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Optional;
-
 @Data
 @Builder
 @NoArgsConstructor
@@ -27,25 +25,5 @@ public class Address {
     private String zip;
 
     private CountryCode country;
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setCountry(final String country) {
-        this.country = CountryCode.fromString(country);
-    }
-
-    public void setCountry(final CountryCode country) {
-        this.country = country;
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getCountry() {
-        return Optional.ofNullable(country).map(CountryCode::name).orElse(null);
-    }
 
 }

--- a/src/main/java/com/checkout/events/EventsClient.java
+++ b/src/main/java/com/checkout/events/EventsClient.java
@@ -1,15 +1,11 @@
 package com.checkout.events;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public interface EventsClient {
 
     CompletableFuture<List<EventTypesResponse>> retrieveAllEventTypes(String version);
-
-    @Deprecated
-    CompletableFuture<EventsPageResponse> retrieveEvents(Instant from, Instant to, Integer limit, Integer skip, String paymentId);
 
     CompletableFuture<EventsPageResponse> retrieveEvents(RetrieveEventsRequest retrieveEventsRequest);
 

--- a/src/main/java/com/checkout/events/EventsClientImpl.java
+++ b/src/main/java/com/checkout/events/EventsClientImpl.java
@@ -5,7 +5,6 @@ import com.checkout.ApiClient;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.SdkAuthorizationType;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -33,26 +32,6 @@ public class EventsClientImpl extends AbstractClient implements EventsClient {
         return apiClient.getAsync(path.toString(), sdkAuthorization(), EventTypesResponse[].class)
                 .thenApply(it -> it == null ? new EventTypesResponse[0] : it)
                 .thenApply(Arrays::asList);
-    }
-
-    /**
-     * @deprecated Please use {@link #retrieveEvents(RetrieveEventsRequest)}
-     */
-    @Deprecated
-    @Override
-    public CompletableFuture<EventsPageResponse> retrieveEvents(final Instant from,
-                                                                final Instant to,
-                                                                final Integer limit,
-                                                                final Integer skip,
-                                                                final String paymentId) {
-        final RetrieveEventsRequest retrieveEventsRequest = RetrieveEventsRequest.builder()
-                .from(from)
-                .to(to)
-                .limit(limit)
-                .skip(skip)
-                .paymentId(paymentId)
-                .build();
-        return apiClient.queryAsync(EVENTS, sdkAuthorization(), retrieveEventsRequest, EventsPageResponse.class);
     }
 
     @Override

--- a/src/main/java/com/checkout/instruments/CreateInstrumentResponse.java
+++ b/src/main/java/com/checkout/instruments/CreateInstrumentResponse.java
@@ -5,8 +5,6 @@ import com.checkout.common.CustomerResponse;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
-import java.util.Optional;
-
 @Data
 public final class CreateInstrumentResponse {
 
@@ -48,24 +46,5 @@ public final class CreateInstrumentResponse {
 
     private CustomerResponse customer;
 
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getIssuerCountry() {
-        return Optional.ofNullable(issuerCountry).map(CountryCode::name).orElse(null);
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setIssuerCountry(final String issuerCountry) {
-        this.issuerCountry = CountryCode.fromString(issuerCountry);
-    }
-
-    public void setIssuerCountry(final CountryCode issuerCountry) {
-        this.issuerCountry = issuerCountry;
-    }
-
 }
+

--- a/src/main/java/com/checkout/instruments/InstrumentDetailsResponse.java
+++ b/src/main/java/com/checkout/instruments/InstrumentDetailsResponse.java
@@ -4,8 +4,6 @@ import com.checkout.common.CountryCode;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
-import java.util.Optional;
-
 @Data
 public final class InstrumentDetailsResponse {
 
@@ -51,25 +49,5 @@ public final class InstrumentDetailsResponse {
     private InstrumentAccountHolder accountHolder;
 
     private InstrumentCustomerResponse customer;
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getIssuerCountry() {
-        return Optional.ofNullable(issuerCountry).map(CountryCode::name).orElse(null);
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setIssuerCountry(final String issuerCountry) {
-        this.issuerCountry = CountryCode.fromString(issuerCountry);
-    }
-
-    public void setIssuerCountry(final CountryCode issuerCountry) {
-        this.issuerCountry = issuerCountry;
-    }
 
 }

--- a/src/main/java/com/checkout/payments/CardDestinationResponse.java
+++ b/src/main/java/com/checkout/payments/CardDestinationResponse.java
@@ -4,8 +4,6 @@ import com.checkout.common.CountryCode;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
-import java.util.Optional;
-
 @Data
 public class CardDestinationResponse {
 
@@ -43,25 +41,5 @@ public class CardDestinationResponse {
     private String productId;
 
     private String fingerprint;
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getIssuerCountry() {
-        return Optional.ofNullable(issuerCountry).map(CountryCode::name).orElse(null);
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setIssuerCountry(final String issuerCountry) {
-        this.issuerCountry = CountryCode.fromString(issuerCountry);
-    }
-
-    public void setIssuerCountry(final CountryCode issuerCountry) {
-        this.issuerCountry = issuerCountry;
-    }
 
 }

--- a/src/main/java/com/checkout/payments/CardSourceResponse.java
+++ b/src/main/java/com/checkout/payments/CardSourceResponse.java
@@ -9,8 +9,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Optional;
-
 @Data
 @Builder
 @NoArgsConstructor
@@ -76,26 +74,6 @@ public class CardSourceResponse implements ResponseSource {
     @Override
     public String getType() {
         return type;
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getIssuerCountry() {
-        return Optional.ofNullable(issuerCountry).map(CountryCode::name).orElse(null);
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setIssuerCountry(final String issuerCountry) {
-        this.issuerCountry = CountryCode.fromString(issuerCountry);
-    }
-
-    public void setIssuerCountry(final CountryCode issuerCountry) {
-        this.issuerCountry = issuerCountry;
     }
 
 }

--- a/src/main/java/com/checkout/payments/DLocal.java
+++ b/src/main/java/com/checkout/payments/DLocal.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Optional;
-
 @Data
 @Builder
 @NoArgsConstructor
@@ -36,23 +34,4 @@ public class DLocal {
     private Payer payer;
     private Installments installments;
 
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getCountry() {
-        return Optional.ofNullable(country).map(CountryCode::name).orElse(null);
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setCountry(final String country) {
-        this.country = CountryCode.fromString(country);
-    }
-
-    public void setCountry(final CountryCode country) {
-        this.country = country;
-    }
 }

--- a/src/main/java/com/checkout/payments/PaymentRecipient.java
+++ b/src/main/java/com/checkout/payments/PaymentRecipient.java
@@ -5,7 +5,6 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
 import java.time.LocalDate;
-import java.util.Optional;
 
 @Data
 public class PaymentRecipient {
@@ -18,25 +17,18 @@ public class PaymentRecipient {
     private final String lastName;
     private final CountryCode country;
 
-    public PaymentRecipient(LocalDate dateOfBirth,
-                            String accountNumber,
-                            String zip,
-                            String firstName,
-                            String lastName,
-                            String country) {
+    public PaymentRecipient(final LocalDate dateOfBirth,
+                            final String accountNumber,
+                            final String zip,
+                            final String firstName,
+                            final String lastName,
+                            final CountryCode country) {
         this.dateOfBirth = dateOfBirth;
         this.accountNumber = accountNumber;
         this.zip = zip;
         this.firstName = firstName;
         this.lastName = lastName;
-        this.country = CountryCode.fromString(country);
+        this.country = country;
     }
 
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getCountry() {
-        return Optional.ofNullable(country).map(CountryCode::name).orElse(null);
-    }
 }

--- a/src/main/java/com/checkout/payments/SenderInformation.java
+++ b/src/main/java/com/checkout/payments/SenderInformation.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Optional;
-
 @Data
 @Builder
 @NoArgsConstructor
@@ -40,24 +38,5 @@ public class SenderInformation {
 
     private String reference;
 
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getCountry() {
-        return Optional.ofNullable(country).map(CountryCode::name).orElse(null);
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setCountry(final String country) {
-        this.country = CountryCode.fromString(country);
-    }
-
-    public void setCountry(final CountryCode country) {
-        this.country = country;
-    }
-
 }
+

--- a/src/main/java/com/checkout/reconciliation/PaymentReportData.java
+++ b/src/main/java/com/checkout/reconciliation/PaymentReportData.java
@@ -10,7 +10,6 @@ import lombok.ToString;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -52,44 +51,5 @@ public final class PaymentReportData extends Resource {
 
     private List<Action> actions;
 
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getIssuerCountry() {
-        return Optional.ofNullable(issuerCountry).map(CountryCode::name).orElse(null);
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setIssuerCountry(final String issuerCountry) {
-        this.issuerCountry = CountryCode.fromString(issuerCountry);
-    }
-
-    public void setIssuerCountry(final CountryCode issuerCountry) {
-        this.issuerCountry = issuerCountry;
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getMerchantCountry() {
-        return Optional.ofNullable(issuerCountry).map(CountryCode::name).orElse(null);
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setMerchantCountry(final String merchantCountry) {
-        this.merchantCountry = CountryCode.fromString(merchantCountry);
-    }
-
-    public void setMerchantCountry(final CountryCode merchantCountry) {
-        this.merchantCountry = merchantCountry;
-    }
-
 }
+

--- a/src/main/java/com/checkout/tokens/CardTokenResponse.java
+++ b/src/main/java/com/checkout/tokens/CardTokenResponse.java
@@ -8,8 +8,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.util.Optional;
-
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -50,25 +48,5 @@ public final class CardTokenResponse extends TokenResponse {
 
     @SerializedName("product_type")
     private String productType;
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public void setIssuerCountry(final String issuerCountry) {
-        this.issuerCountry = CountryCode.fromString(issuerCountry);
-    }
-
-    public void setIssuerCountry(final CountryCode issuerCountry) {
-        this.issuerCountry = issuerCountry;
-    }
-
-    /**
-     * @deprecated Will be removed on a future version
-     */
-    @Deprecated
-    public String getIssuerCountry() {
-        return Optional.ofNullable(issuerCountry).map(CountryCode::name).orElse(null);
-    }
 
 }

--- a/src/test/java/com/checkout/disputes/DisputesTestIT.java
+++ b/src/test/java/com/checkout/disputes/DisputesTestIT.java
@@ -89,7 +89,7 @@ class DisputesTestIT extends SandboxTestFixture {
                 defaultApi.disputesClient().accept(dispute.getId()).get();
                 fail();
             } catch (final Exception e) {
-                assertTrue(e instanceof CheckoutApiException);
+                assertTrue(e.getCause() instanceof CheckoutApiException);
                 assertTrue(e.getMessage().contains("dispute_already_accepted"));
             }
         }

--- a/src/test/java/com/checkout/events/EventsClientImplTest.java
+++ b/src/test/java/com/checkout/events/EventsClientImplTest.java
@@ -115,34 +115,6 @@ class EventsClientImplTest {
     }
 
     @Test
-    void shouldRetrieveEvents_deprecated() throws ExecutionException, InterruptedException {
-
-        when(sdkCredentials.getAuthorization(SdkAuthorizationType.SECRET_KEY)).thenReturn(authorization);
-        when(configuration.getSdkCredentials()).thenReturn(sdkCredentials);
-
-        final Instant from = LocalDateTime.now().minusYears(2).toInstant(ZoneOffset.UTC);
-        final Instant to = LocalDateTime.now().toInstant(ZoneOffset.UTC);
-
-        final RetrieveEventsRequest retrieveEventsRequest = RetrieveEventsRequest.builder()
-                .from(from)
-                .to(to)
-                .limit(15)
-                .skip(0)
-                .paymentId("paymentId")
-                .build();
-        final EventsPageResponse eventsPageResponse = mock(EventsPageResponse.class);
-
-        when(apiClient.queryAsync(eq(EVENTS), eq(authorization), eq(retrieveEventsRequest), eq(EventsPageResponse.class)))
-                .thenReturn(CompletableFuture.completedFuture(eventsPageResponse));
-
-        final CompletableFuture<EventsPageResponse> response = eventsClient.retrieveEvents(from, to, 15, 0, "paymentId");
-
-        assertNotNull(response.get());
-        assertEquals(eventsPageResponse, response.get());
-
-    }
-
-    @Test
     void shouldRetrieveEvents() throws ExecutionException, InterruptedException {
 
         when(sdkCredentials.getAuthorization(SdkAuthorizationType.SECRET_KEY)).thenReturn(authorization);

--- a/src/test/java/com/checkout/events/EventsTestIT.java
+++ b/src/test/java/com/checkout/events/EventsTestIT.java
@@ -76,36 +76,6 @@ class EventsTestIT extends SandboxTestFixture {
     }
 
     @Test
-    void shouldRetrieveEventsByPaymentId_deprecated() {
-
-        registerWebhook();
-
-        final String paymentId = makeCardPayment().getId();
-
-        nap(15);
-
-        final EventsPageResponse eventsPageResponse = blocking(
-                defaultApi.eventsClient().retrieveEvents(
-                        LocalDateTime.now().minusYears(2).toInstant(ZoneOffset.UTC),
-                        LocalDateTime.now().toInstant(ZoneOffset.UTC),
-                        10, 0, paymentId));
-
-        assertNotNull(eventsPageResponse);
-        assertEquals(1, eventsPageResponse.getTotalCount());
-        assertEquals(10, eventsPageResponse.getLimit());
-        assertEquals(0, eventsPageResponse.getSkip());
-        assertEquals(1, eventsPageResponse.getData().size());
-
-        final EventSummaryResponse eventSummaryResponse = eventsPageResponse.getData().get(0);
-        assertNotNull(eventSummaryResponse.getId());
-        assertNotNull(eventSummaryResponse.getCreatedOn());
-        assertEquals("payment_approved", eventSummaryResponse.getType());
-        assertNotNull(eventSummaryResponse.getLink("self"));
-        assertNotNull(eventSummaryResponse.getLink("webhooks-retry"));
-
-    }
-
-    @Test
     void shouldRetrieveEventsByPaymentId_andRetrieveEventById_andGetNotification() {
 
         registerWebhook();

--- a/src/test/java/com/checkout/payments/four/GetPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/four/GetPaymentsTestIT.java
@@ -176,7 +176,7 @@ class GetPaymentsTestIT extends AbstractPaymentsTestIT {
 
         final ShippingDetails shippingDetails = paymentReturned.getShipping();
         assertEquals("City", shippingDetails.getAddress().getCity());
-        assertEquals(CountryCode.GB.name(), shippingDetails.getAddress().getCountry());
+        assertEquals(CountryCode.GB, shippingDetails.getAddress().getCountry());
         assertEquals(phone, shippingDetails.getPhone());
 
     }

--- a/src/test/java/com/checkout/sources/SourcesTestIT.java
+++ b/src/test/java/com/checkout/sources/SourcesTestIT.java
@@ -3,6 +3,7 @@ package com.checkout.sources;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.common.Address;
+import com.checkout.common.CountryCode;
 import com.checkout.common.Phone;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class SourcesTestIT extends SandboxTestFixture {
         billingAddress.setCity("London");
         billingAddress.setState("London");
         billingAddress.setZip("W1T 4TJ");
-        billingAddress.setCountry("GB");
+        billingAddress.setCountry(CountryCode.GB);
 
         final Phone phone = new Phone();
         phone.setCountryCode("+1");


### PR DESCRIPTION
This commit removes the deprecated method `retrieveEvents` in favor of using
the alternative version with a request mapping class `RetrieveEventsRequest`.

Also, all setter compatibility methods of legacy `String` country codes were
removed in favor of using the `CountryCode` enum.