### PR TITLE
Make all specific Checkout exceptions extend generic CheckoutException

### DIFF
--- a/src/main/java/com/checkout/CheckoutArgumentException.java
+++ b/src/main/java/com/checkout/CheckoutArgumentException.java
@@ -1,6 +1,6 @@
 package com.checkout;
 
-public class CheckoutArgumentException extends IllegalArgumentException {
+public class CheckoutArgumentException extends CheckoutException {
 
     public CheckoutArgumentException(final String message) {
         super(message);

--- a/src/main/java/com/checkout/CheckoutAuthorizationException.java
+++ b/src/main/java/com/checkout/CheckoutAuthorizationException.java
@@ -2,7 +2,7 @@ package com.checkout;
 
 import static java.lang.String.format;
 
-public class CheckoutAuthorizationException extends IllegalArgumentException {
+public class CheckoutAuthorizationException extends CheckoutException {
 
     public CheckoutAuthorizationException(final String message) {
         super(message);

--- a/src/main/java/com/checkout/tokens/CardTokenRequest.java
+++ b/src/main/java/com/checkout/tokens/CardTokenRequest.java
@@ -1,5 +1,6 @@
 package com.checkout.tokens;
 
+import com.checkout.CheckoutArgumentException;
 import com.checkout.common.Address;
 import com.checkout.common.Phone;
 import com.google.gson.annotations.SerializedName;
@@ -36,7 +37,7 @@ public final class CardTokenRequest implements TokenRequest {
     public CardTokenRequest(final String number, final int expiryMonth, final int expiryYear) {
         validateParams("number", number);
         if (expiryMonth < 1 || expiryMonth > 12) {
-            throw new IllegalArgumentException("The expiry month must be between 1 and 12");
+            throw new CheckoutArgumentException("The expiry month must be between 1 and 12");
         }
         this.number = number;
         this.expiryMonth = expiryMonth;

--- a/src/test/java/com/checkout/disputes/DisputesTestIT.java
+++ b/src/test/java/com/checkout/disputes/DisputesTestIT.java
@@ -4,11 +4,11 @@ import com.checkout.CheckoutApiException;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
+import com.checkout.common.Currency;
 import com.checkout.common.FileDetailsResponse;
 import com.checkout.common.FilePurpose;
 import com.checkout.common.FileRequest;
 import com.checkout.common.IdResponse;
-import com.checkout.common.Currency;
 import com.checkout.payments.CaptureRequest;
 import com.checkout.payments.PaymentRequest;
 import com.checkout.payments.PaymentResponse;
@@ -17,7 +17,6 @@ import com.checkout.tokens.CardTokenRequest;
 import com.checkout.tokens.CardTokenResponse;
 import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -89,7 +88,7 @@ class DisputesTestIT extends SandboxTestFixture {
                 defaultApi.disputesClient().accept(dispute.getId()).get();
                 fail();
             } catch (final Exception e) {
-                assertTrue(e instanceof CheckoutApiException);
+                assertTrue(e.getCause() instanceof CheckoutApiException);
                 assertTrue(e.getMessage().contains("dispute_already_accepted"));
             }
         }


### PR DESCRIPTION
For backwards compatibility, CheckoutArgumentException was inheriting IllegalArgumentException.
From now on, all `Checkout` specific exceptions will extend the base `CheckoutException`.