### PR TITLE
Remove deprecated instantiation constructors

### DIFF
--- a/src/main/java/com/checkout/CheckoutApiImpl.java
+++ b/src/main/java/com/checkout/CheckoutApiImpl.java
@@ -56,26 +56,6 @@ public class CheckoutApiImpl extends AbstractCheckoutApmApi implements CheckoutA
         this.riskClient = new RiskClientImpl(apiClient, configuration);
     }
 
-    /**
-     * @deprecated Please use {@link CheckoutSdk} as the entrypoint to create new SDK instances.
-     */
-    @Deprecated
-    public static CheckoutApi create(final String secretKey, final boolean useSandbox, final String publicKey) {
-        final CheckoutConfiguration configuration = new CheckoutConfiguration(secretKey, useSandbox, publicKey);
-        final ApiClient client = new ApiClientImpl(configuration);
-        return new CheckoutApiImpl(client, configuration);
-    }
-
-    /**
-     * @deprecated Please use {@link CheckoutSdk} as the entrypoint to create new SDK instances.
-     */
-    @Deprecated
-    public static CheckoutApi create(final String secretKey, final String uri, final String publicKey) {
-        final CheckoutConfiguration configuration = new CheckoutConfiguration(secretKey, uri);
-        final ApiClient client = new ApiClientImpl(configuration);
-        return new CheckoutApiImpl(client, configuration);
-    }
-
     @Override
     public PaymentsClient paymentsClient() {
         return paymentsClient;

--- a/src/main/java/com/checkout/CheckoutConfiguration.java
+++ b/src/main/java/com/checkout/CheckoutConfiguration.java
@@ -4,7 +4,6 @@ import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.net.URI;
 
-import static com.checkout.Environment.lookup;
 import static com.checkout.common.CheckoutUtils.validateParams;
 
 public final class CheckoutConfiguration {
@@ -44,40 +43,6 @@ public final class CheckoutConfiguration {
         this.sdkCredentials = sdkCredentials;
         this.uri = uri.toString();
         this.filesApiConfiguration = filesApiConfiguration;
-    }
-
-    /**
-     * @deprecated Please use {@link CheckoutSdk#defaultSdk()} as the entrypoint to create new SDK instances.
-     */
-    @Deprecated
-    private CheckoutConfiguration(final String publicKey, final String secretKey, final String uri) {
-        validateParams("secretKey", secretKey, "uri", uri);
-        this.uri = uri;
-        this.sdkCredentials = new DefaultStaticKeysSdkCredentials(secretKey, publicKey);
-    }
-
-    /**
-     * @deprecated Please use {@link CheckoutSdk#defaultSdk()} as the entrypoint to create new SDK instances.
-     */
-    @Deprecated
-    public CheckoutConfiguration(final String secretKey, final boolean useSandbox) {
-        this(null, secretKey, lookup(useSandbox).getUri());
-    }
-
-    /**
-     * @deprecated Please use {@link CheckoutSdk#defaultSdk()} as the entrypoint to create new SDK instances.
-     */
-    @Deprecated
-    public CheckoutConfiguration(final String secretKey, final boolean useSandbox, final String publicKey) {
-        this(publicKey, secretKey, lookup(useSandbox).getUri());
-    }
-
-    /**
-     * @deprecated Please use {@link CheckoutSdk#defaultSdk()} as the entrypoint to create new SDK instances.
-     */
-    @Deprecated
-    public CheckoutConfiguration(final String secretKey, final String uri) {
-        this(null, secretKey, uri);
     }
 
     public String getUri() {

--- a/src/main/java/com/checkout/Environment.java
+++ b/src/main/java/com/checkout/Environment.java
@@ -29,12 +29,4 @@ public enum Environment {
         return oauthAuthorizeURI;
     }
 
-    /**
-     * @deprecated Will be removed in a future version
-     */
-    @Deprecated
-    public static Environment lookup(final boolean useSandbox) {
-        return useSandbox ? SANDBOX : PRODUCTION;
-    }
-
 }

--- a/src/test/java/com/checkout/CheckoutConfigurationTest.java
+++ b/src/test/java/com/checkout/CheckoutConfigurationTest.java
@@ -1,20 +1,14 @@
 package com.checkout;
 
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import static com.checkout.TestHelper.INVALID_DEFAULT_SK;
-import static com.checkout.TestHelper.VALID_DEFAULT_PK;
-import static com.checkout.TestHelper.VALID_DEFAULT_SK;
-import static com.checkout.TestHelper.VALID_FOUR_PK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
 
 class CheckoutConfigurationTest {
 
@@ -52,46 +46,6 @@ class CheckoutConfigurationTest {
 
         final CheckoutConfiguration configuration2 = new CheckoutConfiguration(credentials, new URI("https://www.test.checkout.com/"));
         assertEquals("https://www.test.checkout.com/", configuration2.getUri());
-
-    }
-
-    @Test
-    void deprecated_shouldFailCreatingConfiguration_default_invalidURI() {
-        try {
-            new CheckoutConfiguration(VALID_FOUR_PK, null);
-            fail();
-        } catch (final Exception e) {
-            assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("uri cannot be null", e.getMessage());
-        }
-    }
-
-    @Test
-    void deprecated_shouldFailCreatingConfiguration_invalidKeys() {
-        try {
-            new CheckoutConfiguration(INVALID_DEFAULT_SK, true);
-            fail();
-        } catch (final Exception e) {
-            assertTrue(e instanceof CheckoutArgumentException);
-            assertEquals("invalid secret key", e.getMessage());
-        }
-    }
-
-    @Test
-    void deprecated_shouldCreateConfiguration() {
-
-        final CheckoutConfiguration configuration1 = new CheckoutConfiguration(VALID_DEFAULT_SK, true);
-        assertEquals(Environment.SANDBOX.getUri(), configuration1.getUri());
-
-        final CheckoutConfiguration configuration2 = new CheckoutConfiguration(VALID_DEFAULT_SK, false, VALID_DEFAULT_PK);
-        assertEquals(Environment.PRODUCTION.getUri(), configuration2.getUri());
-
-        final HttpClientBuilder builder = mock(HttpClientBuilder.class);
-
-        final CheckoutConfiguration configuration3 = new CheckoutConfiguration(VALID_DEFAULT_SK, "www.google.com");
-        configuration3.setApacheHttpClientBuilder(builder);
-        assertEquals("www.google.com", configuration3.getUri());
-        assertEquals(builder, configuration3.getApacheHttpClientBuilder());
 
     }
 


### PR DESCRIPTION
This commit removes deprecated `CheckoutConfiguration` and `CheckoutApi` constructors
in favor of using the SDK fluent instantiation classes.