### PR TITLE
add `@Builder.Default` to metadata field

### DIFF
--- a/src/main/java/com/checkout/payments/four/request/PaymentRequest.java
+++ b/src/main/java/com/checkout/payments/four/request/PaymentRequest.java
@@ -78,6 +78,7 @@ public class PaymentRequest {
 
     private final ProcessingSettings processing;
 
+    @Builder.Default
     private final Map<String, Object> metadata = new HashMap<>();
 
 }


### PR DESCRIPTION
Without specifying this annotation, Lombok was not exposing a builder method because I believe it thinks the assignment of `HashMap<>()` made it immutable