### PR TITLE
Remove redundant enum lookup methods

### DIFF
--- a/src/main/java/com/checkout/Environment.java
+++ b/src/main/java/com/checkout/Environment.java
@@ -1,7 +1,5 @@
 package com.checkout;
 
-import org.apache.commons.lang3.EnumUtils;
-
 public enum Environment {
 
     SANDBOX("https://api.sandbox.checkout.com/", "https://files.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"),
@@ -29,14 +27,6 @@ public enum Environment {
 
     public String getOauthAuthorizeURI() {
         return oauthAuthorizeURI;
-    }
-
-    public static Environment fromString(final String environment) {
-        if (EnumUtils.isValidEnum(Environment.class, environment)) {
-            return Environment.valueOf(environment.toUpperCase());
-        } else {
-            return null;
-        }
     }
 
     /**

--- a/src/main/java/com/checkout/common/CountryCode.java
+++ b/src/main/java/com/checkout/common/CountryCode.java
@@ -1,7 +1,7 @@
 package com.checkout.common;
 
 import com.google.gson.annotations.SerializedName;
-import org.apache.commons.lang3.EnumUtils;
+import lombok.Getter;
 
 public enum CountryCode {
 
@@ -508,18 +508,11 @@ public enum CountryCode {
     @SerializedName("ZW")
     ZW("263");
 
+    @Getter
     private final String dialCode;
 
     CountryCode(final String dialCode) {
         this.dialCode = dialCode;
-    }
-
-    public static CountryCode fromString(final String countryCode) {
-        if (EnumUtils.isValidEnum(CountryCode.class, countryCode)) {
-            return CountryCode.valueOf(countryCode.toUpperCase());
-        } else {
-            return null;
-        }
     }
 
 }

--- a/src/main/java/com/checkout/common/Currency.java
+++ b/src/main/java/com/checkout/common/Currency.java
@@ -1,7 +1,5 @@
 package com.checkout.common;
 
-import org.apache.commons.lang3.EnumUtils;
-
 public enum Currency {
     ALL,
     STN,
@@ -163,13 +161,5 @@ public enum Currency {
     ZAR,
     GEL,
     ZMW;
-
-    public static Currency fromString(final String currency) {
-        if (EnumUtils.isValidEnum(Currency.class, currency)) {
-            return Currency.valueOf(currency.toUpperCase());
-        } else {
-            return null;
-        }
-    }
 
 }


### PR DESCRIPTION
This commit removes redundant existing `fromString` methods. Dial code was
also made accessible in `CountryCode`.