### PR TITLE
Fix `cvv` typo

### DIFF
--- a/src/main/java/com/checkout/payments/four/request/source/RequestCardSource.java
+++ b/src/main/java/com/checkout/payments/four/request/source/RequestCardSource.java
@@ -26,7 +26,7 @@ public final class RequestCardSource extends RequestSource {
 
     private String name;
 
-    private Integer ccv;
+    private Integer cvv;
 
     private boolean stored;
 
@@ -40,7 +40,7 @@ public final class RequestCardSource extends RequestSource {
                               final Integer expiryMonth,
                               final Integer expiryYear,
                               final String name,
-                              final Integer ccv,
+                              final Integer cvv,
                               final boolean stored,
                               final Address billingAddress,
                               final Phone phone) {
@@ -49,7 +49,7 @@ public final class RequestCardSource extends RequestSource {
         this.expiryMonth = expiryMonth;
         this.expiryYear = expiryYear;
         this.name = name;
-        this.ccv = ccv;
+        this.cvv = cvv;
         this.stored = stored;
         this.billingAddress = billingAddress;
         this.phone = phone;

--- a/src/main/java/com/checkout/payments/four/request/source/RequestIdSource.java
+++ b/src/main/java/com/checkout/payments/four/request/source/RequestIdSource.java
@@ -15,13 +15,13 @@ public final class RequestIdSource extends RequestSource {
 
     private String id;
 
-    private Integer ccv;
+    private Integer cvv;
 
     @Builder
-    private RequestIdSource(final String id, final Integer ccv) {
+    private RequestIdSource(final String id, final Integer cvv) {
         super(PaymentSourceType.ID);
         this.id = id;
-        this.ccv = ccv;
+        this.cvv = cvv;
     }
 
     public RequestIdSource() {

--- a/src/main/java/com/checkout/tokens/four/request/CardTokenRequest.java
+++ b/src/main/java/com/checkout/tokens/four/request/CardTokenRequest.java
@@ -23,7 +23,7 @@ public final class CardTokenRequest {
 
     private String name;
 
-    private String ccv;
+    private String cvv;
 
     @SerializedName("billing_address")
     private Address billingAddress;

--- a/src/test/java/com/checkout/CardSourceHelper.java
+++ b/src/test/java/com/checkout/CardSourceHelper.java
@@ -22,7 +22,7 @@ public class CardSourceHelper {
         public static final String NUMBER = "4242424242424242";
         public static final int EXPIRY_MONTH = 6;
         public static final int EXPIRY_YEAR = 2025;
-        public static final Integer CCV = 100;
+        public static final Integer CVV = 100;
 
     }
 
@@ -56,7 +56,7 @@ public class CardSourceHelper {
                 .number(CardSourceHelper.Visa.NUMBER)
                 .expiryMonth(CardSourceHelper.Visa.EXPIRY_MONTH)
                 .expiryYear(CardSourceHelper.Visa.EXPIRY_YEAR)
-                .ccv(CardSourceHelper.Visa.CCV)
+                .cvv(CardSourceHelper.Visa.CVV)
                 .stored(false)
                 .build();
     }

--- a/src/test/java/com/checkout/four/OAuthTestIT.java
+++ b/src/test/java/com/checkout/four/OAuthTestIT.java
@@ -39,7 +39,7 @@ public class OAuthTestIT extends SandboxTestFixture {
                 .number(CardSourceHelper.Visa.NUMBER)
                 .expiryMonth(CardSourceHelper.Visa.EXPIRY_MONTH)
                 .expiryYear(CardSourceHelper.Visa.EXPIRY_YEAR)
-                .ccv(CardSourceHelper.Visa.CCV)
+                .cvv(CardSourceHelper.Visa.CVV)
                 .stored(false)
                 .build();
 

--- a/src/test/java/com/checkout/payments/four/AbstractPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/four/AbstractPaymentsTestIT.java
@@ -61,7 +61,7 @@ public abstract class AbstractPaymentsTestIT extends SandboxTestFixture {
 
         final RequestIdSource idSource = RequestIdSource.builder()
                 .id(cardPaymentResponse.getSource().getId())
-                .ccv(CardSourceHelper.Visa.CCV)
+                .cvv(CardSourceHelper.Visa.CVV)
                 .build();
 
         final RequestIndividualSender sender = getIndividualSender();

--- a/src/test/java/com/checkout/payments/four/RequestPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/four/RequestPaymentsTestIT.java
@@ -42,7 +42,7 @@ public class RequestPaymentsTestIT extends AbstractPaymentsTestIT {
                 .number(CardSourceHelper.Visa.NUMBER)
                 .expiryMonth(CardSourceHelper.Visa.EXPIRY_MONTH)
                 .expiryYear(CardSourceHelper.Visa.EXPIRY_YEAR)
-                .ccv(CardSourceHelper.Visa.CCV)
+                .cvv(CardSourceHelper.Visa.CVV)
                 .stored(false)
                 .build();
 
@@ -107,7 +107,7 @@ public class RequestPaymentsTestIT extends AbstractPaymentsTestIT {
                 .number(CardSourceHelper.Visa.NUMBER)
                 .expiryMonth(CardSourceHelper.Visa.EXPIRY_MONTH)
                 .expiryYear(CardSourceHelper.Visa.EXPIRY_YEAR)
-                .ccv(CardSourceHelper.Visa.CCV)
+                .cvv(CardSourceHelper.Visa.CVV)
                 .stored(false)
                 .build();
 
@@ -167,7 +167,7 @@ public class RequestPaymentsTestIT extends AbstractPaymentsTestIT {
                 .number(CardSourceHelper.Visa.NUMBER)
                 .expiryMonth(CardSourceHelper.Visa.EXPIRY_MONTH)
                 .expiryYear(CardSourceHelper.Visa.EXPIRY_YEAR)
-                .ccv(CardSourceHelper.Visa.CCV)
+                .cvv(CardSourceHelper.Visa.CVV)
                 .stored(false)
                 .build();
 
@@ -230,7 +230,7 @@ public class RequestPaymentsTestIT extends AbstractPaymentsTestIT {
         // id payment
         final RequestIdSource idSource = RequestIdSource.builder()
                 .id(cardPaymentResponse.getSource().getId())
-                .ccv(CardSourceHelper.Visa.CCV)
+                .cvv(CardSourceHelper.Visa.CVV)
                 .build();
 
         final RequestIndividualSender sender = getIndividualSender();


### PR DESCRIPTION
This commit fixes `cvv` typo affecting payments and tokens modules.