### PR TITLE
Support for alternative CardCategory and CardType serialization

### DIFF
--- a/src/main/java/com/checkout/common/CardCategory.java
+++ b/src/main/java/com/checkout/common/CardCategory.java
@@ -4,9 +4,9 @@ import com.google.gson.annotations.SerializedName;
 
 public enum CardCategory {
 
-    @SerializedName("Consumer")
+    @SerializedName(value = "Consumer", alternate = {"CONSUMER"})
     CONSUMER,
-    @SerializedName("Commercial")
+    @SerializedName(value = "Commercial", alternate = {"COMMERCIAL"})
     COMMERCIAL
 
 }

--- a/src/main/java/com/checkout/common/CardType.java
+++ b/src/main/java/com/checkout/common/CardType.java
@@ -4,15 +4,15 @@ import com.google.gson.annotations.SerializedName;
 
 public enum CardType {
 
-    @SerializedName("Credit")
+    @SerializedName(value = "Credit", alternate = {"CREDIT"})
     CREDIT,
-    @SerializedName("Debit")
+    @SerializedName(value = "Debit", alternate = {"DEBIT"})
     DEBIT,
-    @SerializedName("Prepaid")
+    @SerializedName(value = "Prepaid", alternate = {"PREPAID"})
     PREPAID,
-    @SerializedName("Charge")
+    @SerializedName(value = "Charge", alternate = {"CHARGE"})
     CHARGE,
-    @SerializedName("Deferred Debit")
+    @SerializedName(value = "Deferred Debit", alternate = {"DEFERRED DEBIT"})
     DEFERRED_DEBIT
 
 }

--- a/src/test/java/com/checkout/instruments/four/CardTokenInstrumentsTestIT.java
+++ b/src/test/java/com/checkout/instruments/four/CardTokenInstrumentsTestIT.java
@@ -49,6 +49,9 @@ public class CardTokenInstrumentsTestIT extends AbstractPaymentsTestIT {
         assertNotNull(cardResponse.getAccountHolder());
         assertNotNull(cardResponse.getAccountHolder().getBillingAddress());
         assertNotNull(cardResponse.getAccountHolder().getPhone());
+        assertNotNull(cardResponse.getCardType());
+        assertNotNull(cardResponse.getCardCategory());
+
 
     }
 
@@ -116,6 +119,8 @@ public class CardTokenInstrumentsTestIT extends AbstractPaymentsTestIT {
         assertEquals("John", cardResponse.getAccountHolder().getFirstName());
         assertEquals("Doe", cardResponse.getAccountHolder().getLastName());
         assertTrue(cardResponse.getCustomer().isDefault());
+        assertNotNull(cardResponse.getCardType());
+        assertNotNull(cardResponse.getCardCategory());
 
     }
 
@@ -189,6 +194,8 @@ public class CardTokenInstrumentsTestIT extends AbstractPaymentsTestIT {
         assertNotNull(response.getProductId());
         assertNotNull(response.getProductType());
         assertNotNull(response.getCustomer());
+        assertNotNull(response.getCardType());
+        assertNotNull(response.getCardCategory());
 
         return response;
 

--- a/src/test/java/com/checkout/payments/GetPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/GetPaymentsTestIT.java
@@ -15,7 +15,6 @@ import com.checkout.payments.response.PaymentResponse;
 import com.checkout.payments.response.source.CardResponseSource;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;


### PR DESCRIPTION
This PR solves an Issue when  GET an Instrument from CS2, the serialization from CardType and CardCategory are different.