### PR TITLE
Change invalid authorization exception message

### DIFF
--- a/src/main/java/com/checkout/CheckoutAuthorizationException.java
+++ b/src/main/java/com/checkout/CheckoutAuthorizationException.java
@@ -9,7 +9,7 @@ public class CheckoutAuthorizationException extends CheckoutException {
     }
 
     public static CheckoutAuthorizationException invalidAuthorization(final SdkAuthorizationType authorizationType) {
-        return new CheckoutAuthorizationException(format("Operation does not support %s authorization type", authorizationType));
+        return new CheckoutAuthorizationException(format("Operation requires %s authorization type", authorizationType));
     }
 
 }

--- a/src/test/java/com/checkout/DefaultStaticKeysSdkCredentialsTest.java
+++ b/src/test/java/com/checkout/DefaultStaticKeysSdkCredentialsTest.java
@@ -104,7 +104,7 @@ class DefaultStaticKeysSdkCredentialsTest {
             credentials.getAuthorization(SdkAuthorizationType.SECRET_KEY_OR_OAUTH);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutAuthorizationException);
-            assertEquals("Operation does not support SECRET_KEY_OR_OAUTH authorization type", e.getMessage());
+            assertEquals("Operation requires SECRET_KEY_OR_OAUTH authorization type", e.getMessage());
         }
 
     }

--- a/src/test/java/com/checkout/instruments/four/CardTokenInstrumentsTestIT.java
+++ b/src/test/java/com/checkout/instruments/four/CardTokenInstrumentsTestIT.java
@@ -210,7 +210,7 @@ public class CardTokenInstrumentsTestIT extends AbstractPaymentsTestIT {
             fourApi.instrumentsClient().getBankAccountFieldFormatting(CountryCode.GB, Currency.GBP, BankAccountFieldQuery.builder().build());
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutAuthorizationException);
-            assertEquals("Operation does not support OAUTH authorization type", e.getMessage());
+            assertEquals("Operation requires OAUTH authorization type", e.getMessage());
         }
     }
 

--- a/src/test/java/com/checkout/sessions/SessionSecretSdkCredentialsTest.java
+++ b/src/test/java/com/checkout/sessions/SessionSecretSdkCredentialsTest.java
@@ -54,7 +54,7 @@ class SessionSecretSdkCredentialsTest {
             credentials.getAuthorization(SdkAuthorizationType.OAUTH);
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutAuthorizationException);
-            assertEquals("Operation does not support OAUTH authorization type", e.getMessage());
+            assertEquals("Operation requires OAUTH authorization type", e.getMessage());
         }
 
     }


### PR DESCRIPTION
Changing the exception message to `Operation requires` makes the exception easier to understand.