### PR TITLE
Reuse HTTP client builder for OAuth related operations

### DIFF
--- a/src/main/java/com/checkout/AbstractCheckoutSdkBuilder.java
+++ b/src/main/java/com/checkout/AbstractCheckoutSdkBuilder.java
@@ -4,16 +4,17 @@ import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.net.URI;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 
 import static java.util.Optional.ofNullable;
 
 public abstract class AbstractCheckoutSdkBuilder<T extends CheckoutApiClient> {
 
+    protected HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
     private Environment environment;
     private Environment filesApiEnvironment;
     private URI uri;
-    private HttpClientBuilder httpClientBuilder;
-    private Executor executor;
+    private Executor executor = ForkJoinPool.commonPool();
 
     public AbstractCheckoutSdkBuilder<T> environment(final Environment environment) {
         this.environment = environment;

--- a/src/main/java/com/checkout/CheckoutFourSdk.java
+++ b/src/main/java/com/checkout/CheckoutFourSdk.java
@@ -55,7 +55,7 @@ public final class CheckoutFourSdk {
                 }
                 this.authorizationUri = environment.getOAuthAuthorizeUri();
             }
-            final FourOAuthSdkCredentials credentials = new FourOAuthSdkCredentials(authorizationUri, clientId, clientSecret, scopes);
+            final FourOAuthSdkCredentials credentials = new FourOAuthSdkCredentials(httpClientBuilder, authorizationUri, clientId, clientSecret, scopes);
             credentials.initOAuthAccess();
             return credentials;
         }

--- a/src/main/java/com/checkout/DefaultCheckoutConfiguration.java
+++ b/src/main/java/com/checkout/DefaultCheckoutConfiguration.java
@@ -4,14 +4,10 @@ import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.net.URI;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
 
 import static com.checkout.common.CheckoutUtils.validateParams;
 
 class DefaultCheckoutConfiguration implements CheckoutConfiguration {
-
-    private static final HttpClientBuilder DEFAULT_CLIENT_BUILDER = HttpClientBuilder.create();
-    private static final Executor DEFAULT_EXECUTOR = ForkJoinPool.commonPool();
 
     private final SdkCredentials sdkCredentials;
     private final URI baseUri;
@@ -24,11 +20,11 @@ class DefaultCheckoutConfiguration implements CheckoutConfiguration {
                                  final HttpClientBuilder httpClientBuilder,
                                  final Executor executor,
                                  final FilesApiConfiguration filesApiConfiguration) {
-        validateParams("sdkCredentials", sdkCredentials, "environment", environment);
+        validateParams("sdkCredentials", sdkCredentials, "environment", environment, "httpClientBuilder", httpClientBuilder, "executor", executor);
         this.sdkCredentials = sdkCredentials;
         this.baseUri = environment.getUri();
-        this.httpClientBuilder = httpClientBuilder != null ? httpClientBuilder : DEFAULT_CLIENT_BUILDER;
-        this.executor = executor != null ? executor : DEFAULT_EXECUTOR;
+        this.httpClientBuilder = httpClientBuilder;
+        this.executor = executor;
         this.filesApiConfiguration = filesApiConfiguration;
     }
 
@@ -40,8 +36,8 @@ class DefaultCheckoutConfiguration implements CheckoutConfiguration {
         validateParams("sdkCredentials", sdkCredentials, "uri", uri);
         this.sdkCredentials = sdkCredentials;
         this.baseUri = uri;
-        this.httpClientBuilder = httpClientBuilder != null ? httpClientBuilder : DEFAULT_CLIENT_BUILDER;
-        this.executor = executor != null ? executor : DEFAULT_EXECUTOR;
+        this.httpClientBuilder = httpClientBuilder;
+        this.executor = executor;
         this.filesApiConfiguration = filesApiConfiguration;
     }
 

--- a/src/main/java/com/checkout/FourOAuthSdkCredentials.java
+++ b/src/main/java/com/checkout/FourOAuthSdkCredentials.java
@@ -39,14 +39,19 @@ final class FourOAuthSdkCredentials extends SdkCredentials {
 
     private OAuthAccessToken accessToken;
 
-    FourOAuthSdkCredentials(final URI authorizationUri, final String clientId, final String clientSecret, final Set<FourOAuthScope> scopes) {
+    FourOAuthSdkCredentials(final HttpClientBuilder httpClientBuilder,
+                            final URI authorizationUri,
+                            final String clientId,
+                            final String clientSecret,
+                            final Set<FourOAuthScope> scopes) {
         super(PlatformType.FOUR_OAUTH);
-        validateParams("authorizationUri", authorizationUri, "clientId", clientId, "clientSecret", clientSecret, "scopes", scopes);
+        validateParams("httpClientBuilder", httpClientBuilder, "authorizationUri", authorizationUri,
+                "clientId", clientId, "clientSecret", clientSecret, "scopes", scopes);
+        this.client = httpClientBuilder.build();
         this.authorizationUri = authorizationUri;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.scopes = scopes;
-        this.client = HttpClientBuilder.create().build();
         this.serializer = new GsonSerializer();
     }
 

--- a/src/main/java/com/checkout/common/CheckoutUtils.java
+++ b/src/main/java/com/checkout/common/CheckoutUtils.java
@@ -40,6 +40,14 @@ public final class CheckoutUtils {
         validateMultipleRequires(new Object[][]{{p1, o1}, {p2, o2}, {p3, o3}, {p4, o4}});
     }
 
+    public static void validateParams(final String p1, final Object o1,
+                                      final String p2, final Object o2,
+                                      final String p3, final Object o3,
+                                      final String p4, final Object o4,
+                                      final String p5, final Object o5) {
+        validateMultipleRequires(new Object[][]{{p1, o1}, {p2, o2}, {p3, o3}, {p4, o4}, {p5, o5}});
+    }
+
     private static void validateMultipleRequires(final Object[][] params) {
         if (params.length == 0) {
             return;

--- a/src/test/java/com/checkout/DefaultCheckoutConfigurationTest.java
+++ b/src/test/java/com/checkout/DefaultCheckoutConfigurationTest.java
@@ -6,6 +6,7 @@ import org.mockito.Mockito;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
@@ -16,6 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class DefaultCheckoutConfigurationTest {
+
+    private static final HttpClientBuilder DEFAULT_CLIENT_BUILDER = HttpClientBuilder.create();
+    private static final Executor DEFAULT_EXECUTOR = ForkJoinPool.commonPool();
 
     @Test
     void shouldFailCreatingConfiguration() {
@@ -46,7 +50,7 @@ class DefaultCheckoutConfigurationTest {
 
         final FourStaticKeysSdkCredentials credentials = Mockito.mock(FourStaticKeysSdkCredentials.class);
 
-        final CheckoutConfiguration configuration = new DefaultCheckoutConfiguration(credentials, Environment.PRODUCTION, null, null, null);
+        final CheckoutConfiguration configuration = new DefaultCheckoutConfiguration(credentials, Environment.PRODUCTION, DEFAULT_CLIENT_BUILDER, DEFAULT_EXECUTOR, null);
         assertEquals(Environment.PRODUCTION.getUri(), configuration.getBaseUri());
 
         final CheckoutConfiguration configuration2 = new DefaultCheckoutConfiguration(credentials, new URI("https://www.test.checkout.com/"), null, null, null);
@@ -59,7 +63,7 @@ class DefaultCheckoutConfigurationTest {
 
         final FourStaticKeysSdkCredentials credentials = Mockito.mock(FourStaticKeysSdkCredentials.class);
 
-        final CheckoutConfiguration configuration = new DefaultCheckoutConfiguration(credentials, Environment.PRODUCTION, null, null, null);
+        final CheckoutConfiguration configuration = new DefaultCheckoutConfiguration(credentials, Environment.PRODUCTION, DEFAULT_CLIENT_BUILDER, DEFAULT_EXECUTOR, null);
 
         assertEquals(Environment.PRODUCTION.getUri(), configuration.getBaseUri());
         assertNotNull(configuration.getHttpClientBuilder());
@@ -86,7 +90,7 @@ class DefaultCheckoutConfigurationTest {
 
         final FourStaticKeysSdkCredentials credentials = Mockito.mock(FourStaticKeysSdkCredentials.class);
 
-        final CheckoutConfiguration configuration = new DefaultCheckoutConfiguration(credentials, Environment.PRODUCTION, null, null, null);
+        final CheckoutConfiguration configuration = new DefaultCheckoutConfiguration(credentials, Environment.PRODUCTION, DEFAULT_CLIENT_BUILDER, DEFAULT_EXECUTOR, null);
         assertEquals(Environment.PRODUCTION.getUri(), configuration.getBaseUri());
 
         final CheckoutConfiguration configuration2 = new DefaultCheckoutConfiguration(credentials, new URI("https://www.test.checkout.com/"), null, null, null);

--- a/src/test/java/com/checkout/FourOAuthSdkCredentialsTest.java
+++ b/src/test/java/com/checkout/FourOAuthSdkCredentialsTest.java
@@ -4,6 +4,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -31,6 +32,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class FourOAuthSdkCredentialsTest {
 
+    private static final HttpClientBuilder DEFAULT_CLIENT_BUILDER = HttpClientBuilder.create();
+
     private static final String BEARER = "Bearer ";
 
     @Mock
@@ -42,28 +45,28 @@ class FourOAuthSdkCredentialsTest {
     @Test
     void shouldFailCreatingFourOAuthFourSdkCredentials() {
         try {
-            new FourOAuthSdkCredentials(null, "client_id", "client_secret", EnumSet.allOf(FourOAuthScope.class));
+            new FourOAuthSdkCredentials(DEFAULT_CLIENT_BUILDER, null, "client_id", "client_secret", EnumSet.allOf(FourOAuthScope.class));
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
             assertEquals("authorizationUri cannot be null", e.getMessage());
         }
         try {
-            new FourOAuthSdkCredentials(Mockito.mock(URI.class), null, "client_secret", EnumSet.allOf(FourOAuthScope.class));
+            new FourOAuthSdkCredentials(DEFAULT_CLIENT_BUILDER, Mockito.mock(URI.class), null, "client_secret", EnumSet.allOf(FourOAuthScope.class));
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
             assertEquals("clientId cannot be null", e.getMessage());
         }
         try {
-            new FourOAuthSdkCredentials(Mockito.mock(URI.class), "client_id", " ", EnumSet.allOf(FourOAuthScope.class));
+            new FourOAuthSdkCredentials(DEFAULT_CLIENT_BUILDER, Mockito.mock(URI.class), "client_id", " ", EnumSet.allOf(FourOAuthScope.class));
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
             assertEquals("clientSecret cannot be blank", e.getMessage());
         }
         try {
-            new FourOAuthSdkCredentials(Mockito.mock(URI.class), "client_id", "client_secret", null);
+            new FourOAuthSdkCredentials(DEFAULT_CLIENT_BUILDER, Mockito.mock(URI.class), "client_id", "client_secret", null);
             fail();
         } catch (final Exception e) {
             assertTrue(e instanceof CheckoutArgumentException);
@@ -74,7 +77,7 @@ class FourOAuthSdkCredentialsTest {
     @Test
     void shouldCreateFourOAuthFourSdkCredentials() {
 
-        final SdkCredentials credentials = new FourOAuthSdkCredentials(Mockito.mock(URI.class), "client_id", "client_secret", EnumSet.allOf(FourOAuthScope.class));
+        final SdkCredentials credentials = new FourOAuthSdkCredentials(DEFAULT_CLIENT_BUILDER, Mockito.mock(URI.class), "client_id", "client_secret", EnumSet.allOf(FourOAuthScope.class));
         assertEquals(FOUR_OAUTH, credentials.getPlatformType());
 
     }
@@ -82,7 +85,7 @@ class FourOAuthSdkCredentialsTest {
     @Test
     void authorization_shouldNotGetWhenTheresAValidAccessToken() {
 
-        final FourOAuthSdkCredentials credentials = new FourOAuthSdkCredentials(Mockito.mock(URI.class), "client_id", "client_secret", EnumSet.allOf(FourOAuthScope.class));
+        final FourOAuthSdkCredentials credentials = new FourOAuthSdkCredentials(DEFAULT_CLIENT_BUILDER, Mockito.mock(URI.class), "client_id", "client_secret", EnumSet.allOf(FourOAuthScope.class));
         credentials.setAccessToken(new OAuthAccessToken("y123", LocalDateTime.now().plusMinutes(5)));
         credentials.setClient(client);
         credentials.setSerializer(serializer);
@@ -114,6 +117,7 @@ class FourOAuthSdkCredentialsTest {
         when(client.execute(any(HttpPost.class))).thenReturn(response);
 
         final FourOAuthSdkCredentials credentials = new FourOAuthSdkCredentials(
+                DEFAULT_CLIENT_BUILDER,
                 new URI("http://test.checkout.com/oauth/token"),
                 "client_id",
                 "client_secret",
@@ -151,6 +155,7 @@ class FourOAuthSdkCredentialsTest {
         when(client.execute(any(HttpPost.class))).thenReturn(response);
 
         final FourOAuthSdkCredentials credentials = new FourOAuthSdkCredentials(
+                DEFAULT_CLIENT_BUILDER,
                 new URI("http://test.checkout.com/oauth/token"),
                 "client_id",
                 "client_secret",
@@ -184,6 +189,7 @@ class FourOAuthSdkCredentialsTest {
         when(client.execute(any(HttpPost.class))).thenReturn(response);
 
         final FourOAuthSdkCredentials credentials = new FourOAuthSdkCredentials(
+                DEFAULT_CLIENT_BUILDER,
                 new URI("http://test.checkout.com/oauth/token"),
                 "fake",
                 "fake",


### PR DESCRIPTION
This commit forces the reuse of the HTTP Client builder provided during SDK initialization for OAuth operations.