### PR TITLE
add name to GetCardInstrumentResponse

### DIFF
--- a/src/main/java/com/checkout/instruments/four/get/GetCardInstrumentResponse.java
+++ b/src/main/java/com/checkout/instruments/four/get/GetCardInstrumentResponse.java
@@ -28,6 +28,8 @@ public final class GetCardInstrumentResponse extends GetInstrumentResponse {
 
     private String bin;
 
+    private String name;
+
     @SerializedName("card_type")
     private CardType cardType;
 


### PR DESCRIPTION
the `name` member was missing from `GetCardInstrumentResponse` but it was part of the json and the api documentation.