### PR TITLE
Extend Hosted Payments & Payment Links to Four API

### DIFF
--- a/src/main/java/com/checkout/four/CheckoutApi.java
+++ b/src/main/java/com/checkout/four/CheckoutApi.java
@@ -6,6 +6,8 @@ import com.checkout.forex.four.ForexClient;
 import com.checkout.instruments.four.InstrumentsClient;
 import com.checkout.marketplace.MarketplaceClient;
 import com.checkout.payments.four.PaymentsClient;
+import com.checkout.payments.hosted.HostedPaymentsClient;
+import com.checkout.payments.links.PaymentLinksClient;
 import com.checkout.risk.RiskClient;
 import com.checkout.sessions.SessionsClient;
 import com.checkout.tokens.TokensClient;
@@ -32,6 +34,10 @@ public interface CheckoutApi extends CheckoutApmApi {
     SessionsClient sessionsClient();
 
     ForexClient forexClient();
+
+    PaymentLinksClient paymentLinksClient();
+
+    HostedPaymentsClient hostedPaymentsClient();
 
 }
 

--- a/src/main/java/com/checkout/four/CheckoutApiImpl.java
+++ b/src/main/java/com/checkout/four/CheckoutApiImpl.java
@@ -17,6 +17,10 @@ import com.checkout.marketplace.MarketplaceClient;
 import com.checkout.marketplace.MarketplaceClientImpl;
 import com.checkout.payments.four.PaymentsClient;
 import com.checkout.payments.four.PaymentsClientImpl;
+import com.checkout.payments.hosted.HostedPaymentsClient;
+import com.checkout.payments.hosted.HostedPaymentsClientImpl;
+import com.checkout.payments.links.PaymentLinksClient;
+import com.checkout.payments.links.PaymentLinksClientImpl;
 import com.checkout.risk.RiskClient;
 import com.checkout.risk.RiskClientImpl;
 import com.checkout.sessions.SessionsClient;
@@ -38,6 +42,8 @@ public class CheckoutApiImpl extends AbstractCheckoutApmApi implements CheckoutA
     private final MarketplaceClient marketplaceClient;
     private final SessionsClient sessionsClient;
     private final ForexClient forexClient;
+    private final PaymentLinksClient paymentLinksClient;
+    private final HostedPaymentsClient hostedPaymentsClient;
 
     public CheckoutApiImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
         super(apiClient, configuration);
@@ -51,6 +57,9 @@ public class CheckoutApiImpl extends AbstractCheckoutApmApi implements CheckoutA
         this.marketplaceClient = new MarketplaceClientImpl(apiClient, configuration);
         this.sessionsClient = new SessionsClientImpl(apiClient, configuration);
         this.forexClient = new ForexClientImpl(apiClient, configuration);
+        this.paymentLinksClient = new PaymentLinksClientImpl(apiClient, configuration);
+        this.hostedPaymentsClient = new HostedPaymentsClientImpl(apiClient, configuration);
+
     }
 
     @Override
@@ -102,4 +111,15 @@ public class CheckoutApiImpl extends AbstractCheckoutApmApi implements CheckoutA
     public ForexClient forexClient() {
         return forexClient;
     }
+
+    @Override
+    public PaymentLinksClient paymentLinksClient() {
+        return paymentLinksClient;
+    }
+
+    @Override
+    public HostedPaymentsClient hostedPaymentsClient() {
+        return hostedPaymentsClient;
+    }
+
 }

--- a/src/main/java/com/checkout/payments/hosted/HostedPaymentRequest.java
+++ b/src/main/java/com/checkout/payments/hosted/HostedPaymentRequest.java
@@ -2,6 +2,8 @@ package com.checkout.payments.hosted;
 
 import com.checkout.common.Currency;
 import com.checkout.common.CustomerRequest;
+import com.checkout.common.MarketplaceData;
+import com.checkout.common.PaymentSourceType;
 import com.checkout.common.Product;
 import com.checkout.payments.BillingDescriptor;
 import com.checkout.payments.BillingInformation;
@@ -15,7 +17,6 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import lombok.Data;
 
-import javax.validation.constraints.NotEmpty;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,6 @@ public final class HostedPaymentRequest {
 
     private Long amount;
 
-    @NotEmpty
     private Currency currency;
 
     private String reference;
@@ -37,7 +37,6 @@ public final class HostedPaymentRequest {
 
     private ShippingDetails shipping;
 
-    @NotEmpty
     private BillingInformation billing;
 
     private PaymentRecipient recipient;
@@ -48,15 +47,12 @@ public final class HostedPaymentRequest {
 
     private RiskRequest risk;
 
-    @NotEmpty
     @SerializedName("success_url")
     private String successUrl;
 
-    @NotEmpty
     @SerializedName("cancel_url")
     private String cancelUrl;
 
-    @NotEmpty
     @SerializedName("failure_url")
     private String failureUrl;
 
@@ -76,9 +72,19 @@ public final class HostedPaymentRequest {
     private PaymentType paymentType;
 
     @SerializedName("payment_ip")
-    public String paymentIp;
+    private String paymentIp;
 
     @SerializedName("billing_descriptor")
-    public BillingDescriptor billingDescriptor;
+    private BillingDescriptor billingDescriptor;
+
+    @SerializedName("allow_payment_methods")
+    private List<PaymentSourceType> allowPaymentMethods;
+
+    // Only available in Four
+
+    @SerializedName("processing_channel_id")
+    private String processingChannelId;
+
+    private MarketplaceData marketplace;
 
 }

--- a/src/main/java/com/checkout/payments/hosted/HostedPaymentResponse.java
+++ b/src/main/java/com/checkout/payments/hosted/HostedPaymentResponse.java
@@ -5,6 +5,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.List;
+
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -13,5 +15,7 @@ public final class HostedPaymentResponse extends Resource {
     private String id;
 
     private String reference;
+
+    private List<Object> warnings;
 
 }

--- a/src/main/java/com/checkout/payments/links/PaymentLinkDetailsResponse.java
+++ b/src/main/java/com/checkout/payments/links/PaymentLinkDetailsResponse.java
@@ -2,6 +2,7 @@ package com.checkout.payments.links;
 
 import com.checkout.common.Currency;
 import com.checkout.common.CustomerResponse;
+import com.checkout.common.MarketplaceData;
 import com.checkout.common.Product;
 import com.checkout.common.Resource;
 import com.checkout.payments.BillingInformation;
@@ -41,5 +42,12 @@ public final class PaymentLinkDetailsResponse extends Resource {
     private List<Product> products;
 
     private Map<String, Object> metadata;
+
+    // Only available in Four
+
+    @SerializedName("processing_channel_id")
+    private String processingChannelId;
+
+    private MarketplaceData marketplace;
 
 }

--- a/src/main/java/com/checkout/payments/links/PaymentLinkRequest.java
+++ b/src/main/java/com/checkout/payments/links/PaymentLinkRequest.java
@@ -2,6 +2,7 @@ package com.checkout.payments.links;
 
 import com.checkout.common.Currency;
 import com.checkout.common.CustomerRequest;
+import com.checkout.common.PaymentSourceType;
 import com.checkout.common.Product;
 import com.checkout.payments.BillingDescriptor;
 import com.checkout.payments.BillingInformation;
@@ -15,7 +16,6 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import lombok.Data;
 
-import javax.validation.constraints.NotEmpty;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -24,10 +24,8 @@ import java.util.Map;
 @Builder
 public final class PaymentLinkRequest {
 
-    @NotEmpty
     private Long amount;
 
-    @NotEmpty
     private Currency currency;
 
     private String reference;
@@ -41,7 +39,6 @@ public final class PaymentLinkRequest {
 
     private ShippingDetails shipping;
 
-    @NotEmpty
     private BillingInformation billing;
 
     private PaymentRecipient recipient;
@@ -71,9 +68,12 @@ public final class PaymentLinkRequest {
     private PaymentType paymentType;
 
     @SerializedName("payment_ip")
-    public String paymentIp;
+    private String paymentIp;
 
     @SerializedName("billing_descriptor")
-    public BillingDescriptor billingDescriptor;
+    private BillingDescriptor billingDescriptor;
+
+    @SerializedName("allow_payment_methods")
+    private List<PaymentSourceType> allowPaymentMethods;
 
 }

--- a/src/main/java/com/checkout/payments/links/PaymentLinkResponse.java
+++ b/src/main/java/com/checkout/payments/links/PaymentLinkResponse.java
@@ -5,6 +5,8 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.util.List;
+
 @Data
 @EqualsAndHashCode(callSuper = true)
 public final class PaymentLinkResponse extends Resource {
@@ -15,5 +17,7 @@ public final class PaymentLinkResponse extends Resource {
     private String expiresOn;
 
     private String reference;
+
+    private List<Object> warnings;
 
 }

--- a/src/test/java/com/checkout/TestHelper.java
+++ b/src/test/java/com/checkout/TestHelper.java
@@ -5,6 +5,7 @@ import com.checkout.common.ChallengeIndicator;
 import com.checkout.common.CountryCode;
 import com.checkout.common.Currency;
 import com.checkout.common.CustomerRequest;
+import com.checkout.common.PaymentSourceType;
 import com.checkout.common.Phone;
 import com.checkout.common.Product;
 import com.checkout.payments.BillingDescriptor;
@@ -21,6 +22,7 @@ import com.checkout.payments.links.PaymentLinkRequest;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -116,6 +118,7 @@ public final class TestHelper {
                         .city("London")
                         .name("Awesome name")
                         .build())
+                .allowPaymentMethods(Arrays.asList(PaymentSourceType.CARD, PaymentSourceType.IDEAL))
                 .build();
     }
 
@@ -153,6 +156,7 @@ public final class TestHelper {
                         .city("London")
                         .name("Awesome name")
                         .build())
+                .allowPaymentMethods(Arrays.asList(PaymentSourceType.CARD, PaymentSourceType.IDEAL))
                 .build();
     }
 

--- a/src/test/java/com/checkout/four/CheckoutApiImplTest.java
+++ b/src/test/java/com/checkout/four/CheckoutApiImplTest.java
@@ -25,6 +25,9 @@ class CheckoutApiImplTest {
         assertNotNull(checkoutApi.marketplaceClient());
         assertNotNull(checkoutApi.sessionsClient());
         assertNotNull(checkoutApi.forexClient());
+        assertNotNull(checkoutApi.hostedPaymentsClient());
+        assertNotNull(checkoutApi.paymentLinksClient());
+        assertNotNull(checkoutApi.forexClient());
         // APMs
         assertNotNull(checkoutApi.idealClient());
     }

--- a/src/test/java/com/checkout/payments/four/hosted/HostedPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/four/hosted/HostedPaymentsTestIT.java
@@ -1,0 +1,52 @@
+package com.checkout.payments.four.hosted;
+
+import com.checkout.PlatformType;
+import com.checkout.SandboxTestFixture;
+import com.checkout.TestHelper;
+import com.checkout.common.Currency;
+import com.checkout.payments.hosted.HostedPaymentDetailsResponse;
+import com.checkout.payments.hosted.HostedPaymentRequest;
+import com.checkout.payments.hosted.HostedPaymentResponse;
+import com.checkout.payments.hosted.HostedPaymentStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HostedPaymentsTestIT extends SandboxTestFixture {
+
+    static final String REFERENCE = "ORD-123A";
+
+    HostedPaymentsTestIT() {
+        super(PlatformType.FOUR);
+    }
+
+    @Test
+    void shouldCreateAndGetHostedPayments() {
+        final HostedPaymentRequest request = TestHelper.createHostedPaymentRequest(REFERENCE);
+        final HostedPaymentResponse response = blocking(() -> fourApi.hostedPaymentsClient().createAsync(request));
+        assertNotNull(response);
+        assertNotNull(response.getId());
+        assertEquals(REFERENCE, response.getReference());
+        assertNotNull(response.getLinks());
+        assertTrue(response.getLinks().containsKey("redirect"));
+        assertNotNull(response.getWarnings());
+
+        final HostedPaymentDetailsResponse detailsResponse = blocking(() -> fourApi.hostedPaymentsClient().get(response.getId()));
+
+        assertNotNull(detailsResponse);
+        assertNotNull(detailsResponse.getId());
+        assertNotNull(detailsResponse.getReference());
+        assertEquals(HostedPaymentStatus.PAYMENT_PENDING, detailsResponse.getStatus());
+        assertNotNull(detailsResponse.getAmount());
+        assertNotNull(detailsResponse.getBilling());
+        assertEquals(Currency.GBP, detailsResponse.getCurrency());
+        assertNotNull(detailsResponse.getCustomer());
+        assertNotNull(detailsResponse.getDescription());
+        assertNotNull(detailsResponse.getFailureUrl());
+        assertNotNull(detailsResponse.getSuccessUrl());
+        assertNotNull(detailsResponse.getCancelUrl());
+
+    }
+}

--- a/src/test/java/com/checkout/payments/four/links/PaymentLinksTestIT.java
+++ b/src/test/java/com/checkout/payments/four/links/PaymentLinksTestIT.java
@@ -1,0 +1,54 @@
+package com.checkout.payments.four.links;
+
+import com.checkout.PlatformType;
+import com.checkout.SandboxTestFixture;
+import com.checkout.TestHelper;
+import com.checkout.payments.links.PaymentLinkDetailsResponse;
+import com.checkout.payments.links.PaymentLinkRequest;
+import com.checkout.payments.links.PaymentLinkResponse;
+import com.checkout.payments.links.PaymentLinkStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PaymentLinksTestIT extends SandboxTestFixture {
+
+    static final String REFERENCE = "ORD-123A";
+
+    PaymentLinksTestIT() {
+        super(PlatformType.FOUR);
+    }
+
+    @Test
+    void shouldCreateAndGetPaymentsLink() {
+
+        final PaymentLinkRequest paymentLinksRequest = TestHelper.createPaymentLinksRequest(REFERENCE);
+        final PaymentLinkResponse paymentLinkResponse = blocking(() -> fourApi.paymentLinksClient().createAsync(paymentLinksRequest));
+
+        assertNotNull(paymentLinkResponse);
+        assertEquals(REFERENCE, paymentLinkResponse.getReference());
+        assertNotNull(paymentLinkResponse.getExpiresOn());
+        assertNotNull(paymentLinkResponse.getLinks());
+        assertTrue(paymentLinkResponse.getLinks().containsKey("redirect"));
+        assertNotNull(paymentLinkResponse.getWarnings());
+
+        final PaymentLinkDetailsResponse detailsResponse = blocking(() -> fourApi.paymentLinksClient().getAsync(paymentLinkResponse.getId()));
+        assertNotNull(detailsResponse);
+        assertEquals(paymentLinkResponse.getId(), detailsResponse.getId());
+        assertThat(detailsResponse.getStatus(), anyOf(equalTo(PaymentLinkStatus.ACTIVE), equalTo(PaymentLinkStatus.PAYMENT_RECEIVED), equalTo(PaymentLinkStatus.EXPIRED)));
+        assertNotNull(detailsResponse.getExpiresOn());
+        assertEquals(paymentLinksRequest.getReturnUrl(), detailsResponse.getReturnUrl());
+        assertEquals(paymentLinksRequest.getAmount(), detailsResponse.getAmount());
+        assertEquals(paymentLinksRequest.getCurrency(), detailsResponse.getCurrency());
+        assertEquals(paymentLinksRequest.getReference(), detailsResponse.getReference());
+        assertEquals(paymentLinksRequest.getDescription(), detailsResponse.getDescription());
+        assertEquals(paymentLinksRequest.getBilling(), detailsResponse.getBilling());
+        assertEquals(paymentLinksRequest.getProducts(), detailsResponse.getProducts());
+        assertNotNull(detailsResponse.getCustomer());
+    }
+}


### PR DESCRIPTION
This commit extends the existing default Hosted Payments & Payment Links to Four CheckoutApi. A few improvements and updates were performed on the existing Request/Response classes to be up to date with the latest API changes.