### PR TITLE
Add support for Tamara payment source & utility methods deprecation

### DIFF
--- a/src/main/java/com/checkout/common/CustomerRequest.java
+++ b/src/main/java/com/checkout/common/CustomerRequest.java
@@ -15,4 +15,6 @@ public class CustomerRequest {
 
     private String name;
 
+    private Phone phone;
+
 }

--- a/src/main/java/com/checkout/common/CustomerResponse.java
+++ b/src/main/java/com/checkout/common/CustomerResponse.java
@@ -11,4 +11,6 @@ public class CustomerResponse {
 
     private String name;
 
+    private Phone phone;
+
 }

--- a/src/main/java/com/checkout/common/PaymentSourceType.java
+++ b/src/main/java/com/checkout/common/PaymentSourceType.java
@@ -57,5 +57,7 @@ public enum PaymentSourceType {
     @SerializedName("benefitpay")
     BENEFITPAY,
     @SerializedName("bancontact")
-    BANCONTACT
+    BANCONTACT,
+    @SerializedName("tamara")
+    TAMARA
 }

--- a/src/main/java/com/checkout/common/four/Product.java
+++ b/src/main/java/com/checkout/common/four/Product.java
@@ -1,0 +1,38 @@
+package com.checkout.common.four;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public final class Product {
+
+    private String name;
+
+    private Long quantity;
+
+    @SerializedName("unit_price")
+    private Long unitPrice;
+
+    private String reference;
+
+    @SerializedName("image_url")
+    private String imageUrl;
+
+    private String url;
+
+    @SerializedName("total_amount")
+    private Long totalAmount;
+
+    @SerializedName("tax_amount")
+    private Long taxAmount;
+
+    @SerializedName("discount_amount")
+    private Long discountAmount;
+
+    private String sku;
+
+}

--- a/src/main/java/com/checkout/instruments/InstrumentCustomerRequest.java
+++ b/src/main/java/com/checkout/instruments/InstrumentCustomerRequest.java
@@ -18,17 +18,14 @@ public final class InstrumentCustomerRequest extends CustomerRequest {
     @SerializedName("default")
     private boolean isDefault;
 
-    private Phone phone;
-
     @Builder
     public InstrumentCustomerRequest(final String id,
                                      final String email,
                                      final String name,
                                      final boolean isDefault,
                                      final Phone phone) {
-        super(id, email, name);
+        super(id, email, name, phone);
         this.isDefault = isDefault;
-        this.phone = phone;
     }
 
 }

--- a/src/main/java/com/checkout/instruments/four/create/CreateCustomerInstrumentRequest.java
+++ b/src/main/java/com/checkout/instruments/four/create/CreateCustomerInstrumentRequest.java
@@ -15,8 +15,6 @@ import lombok.ToString;
 @NoArgsConstructor
 public final class CreateCustomerInstrumentRequest extends CustomerRequest {
 
-    private Phone phone;
-
     @SerializedName("default")
     private boolean defaultInstrument;
 
@@ -26,8 +24,7 @@ public final class CreateCustomerInstrumentRequest extends CustomerRequest {
                                            final String name,
                                            final Phone phone,
                                            final boolean defaultInstrument) {
-        super(id, email, name);
-        this.phone = phone;
+        super(id, email, name, phone);
         this.defaultInstrument = defaultInstrument;
     }
 

--- a/src/main/java/com/checkout/payments/ProcessingSettings.java
+++ b/src/main/java/com/checkout/payments/ProcessingSettings.java
@@ -1,5 +1,6 @@
 package com.checkout.payments;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,5 +13,11 @@ import lombok.NoArgsConstructor;
 public final class ProcessingSettings {
 
     private boolean aft;
+
+    @SerializedName("tax_amount")
+    private Long taxAmount;
+
+    @SerializedName("shipping_amount")
+    private Long shippingAmount;
 
 }

--- a/src/main/java/com/checkout/payments/four/request/PaymentRequest.java
+++ b/src/main/java/com/checkout/payments/four/request/PaymentRequest.java
@@ -3,6 +3,7 @@ package com.checkout.payments.four.request;
 import com.checkout.common.Currency;
 import com.checkout.common.CustomerRequest;
 import com.checkout.common.MarketplaceData;
+import com.checkout.common.four.Product;
 import com.checkout.payments.BillingDescriptor;
 import com.checkout.payments.PaymentRecipient;
 import com.checkout.payments.PaymentType;
@@ -19,6 +20,7 @@ import lombok.Data;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -83,6 +85,8 @@ public final class PaymentRequest {
     private MarketplaceData marketplace;
 
     private ProcessingSettings processing;
+
+    private List<Product> items;
 
     @Builder.Default
     private Map<String, Object> metadata = new HashMap<>();

--- a/src/main/java/com/checkout/payments/four/request/Payments.java
+++ b/src/main/java/com/checkout/payments/four/request/Payments.java
@@ -13,6 +13,10 @@ import com.checkout.payments.four.sender.PaymentIndividualSender;
 import com.checkout.payments.four.sender.PaymentInstrumentSender;
 import com.checkout.payments.four.sender.PaymentSender;
 
+/**
+ * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+ */
+@Deprecated
 public final class Payments {
 
     private Payments() {

--- a/src/main/java/com/checkout/payments/four/request/source/apm/RequestTamaraSource.java
+++ b/src/main/java/com/checkout/payments/four/request/source/apm/RequestTamaraSource.java
@@ -1,0 +1,23 @@
+package com.checkout.payments.four.request.source.apm;
+
+import com.checkout.common.Address;
+import com.checkout.common.PaymentSourceType;
+import com.checkout.payments.four.request.source.AbstractRequestSource;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class RequestTamaraSource extends AbstractRequestSource {
+
+    public RequestTamaraSource() {
+        super(PaymentSourceType.TAMARA);
+    }
+
+    private Address billingAddress;
+
+}

--- a/src/main/java/com/checkout/payments/request/PaymentRequest.java
+++ b/src/main/java/com/checkout/payments/request/PaymentRequest.java
@@ -107,46 +107,90 @@ public final class PaymentRequest {
         this.reference = reference;
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest baloto(final RequestBalotoSource balotoSource, final Currency currency, final Long amount) {
         return new PaymentRequest(balotoSource, currency, amount, true);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest boleto(final RequestBoletoSource boletoSource, final Currency currency, final Long amount) {
         return new PaymentRequest(boletoSource, currency, amount, true);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest fawry(final RequestFawrySource fawrySource, final Currency currency, final Long amount) {
         return new PaymentRequest(fawrySource, currency, amount, true);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest giropay(final RequestGiropaySource giropaySource, final Currency currency, final Long amount) {
         return new PaymentRequest(giropaySource, currency, amount, true);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest ideal(final RequestIdealSource idealSource, final Currency currency, final Long amount) {
         return new PaymentRequest(idealSource, currency, amount, true);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest oxxo(final RequestOxxoSource oxxoSource, final Currency currency, final Long amount) {
         return new PaymentRequest(oxxoSource, currency, amount, true);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest pagoFacil(final RequestPagoFacilSource pagoFacilSource, final Currency currency, final Long amount) {
         return new PaymentRequest(pagoFacilSource, currency, amount, true);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest rapiPago(final RequestRapiPagoSource rapiPagoSource, final Currency currency, final Long amount) {
         return new PaymentRequest(rapiPagoSource, currency, amount, true);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest klarna(final RequestKlarnaSource klarnaSource, final Currency currency, final Long amount) {
         return new PaymentRequest(klarnaSource, currency, amount, false);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest sepa(final RequestSepaSource sepaSource, final Currency currency, final Long amount, final String reference) {
         return new PaymentRequest(sepaSource, currency, amount, reference);
     }
 
+    /**
+     * @deprecated Won't be supported anymore from version 6.0.0 in favor of setting properties directly in the {@link PaymentRequest}
+     */
+    @Deprecated
     public static PaymentRequest sofort(final Currency currency, final Long amount) {
         return new PaymentRequest(new RequestSofortSource(), currency, amount, true);
     }

--- a/src/test/java/com/checkout/TestHelper.java
+++ b/src/test/java/com/checkout/TestHelper.java
@@ -48,7 +48,7 @@ public final class TestHelper {
     }
 
     public static CustomerRequest createCustomer() {
-        return new CustomerRequest(null, generateRandomEmail(), "Jack Napier");
+        return new CustomerRequest(null, generateRandomEmail(), "Jack Napier", null);
     }
 
     public static Phone createPhone() {

--- a/src/test/java/com/checkout/apm/tamara/four/TamaraPaymentsTestIT.java
+++ b/src/test/java/com/checkout/apm/tamara/four/TamaraPaymentsTestIT.java
@@ -1,0 +1,97 @@
+package com.checkout.apm.tamara.four;
+
+import com.checkout.CheckoutSdk;
+import com.checkout.Environment;
+import com.checkout.PlatformType;
+import com.checkout.SandboxTestFixture;
+import com.checkout.common.Address;
+import com.checkout.common.CountryCode;
+import com.checkout.common.Currency;
+import com.checkout.common.CustomerRequest;
+import com.checkout.common.Phone;
+import com.checkout.common.four.Product;
+import com.checkout.four.CheckoutApi;
+import com.checkout.payments.PaymentStatus;
+import com.checkout.payments.ProcessingSettings;
+import com.checkout.payments.four.request.PaymentRequest;
+import com.checkout.payments.four.request.source.apm.RequestTamaraSource;
+import com.checkout.payments.four.response.PaymentResponse;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class TamaraPaymentsTestIT extends SandboxTestFixture {
+
+    TamaraPaymentsTestIT() {
+        super(PlatformType.FOUR);
+    }
+
+    @Disabled("preview")
+    @Test
+    void shouldMakeTamaraPayment() {
+
+        final CheckoutApi previewApi = CheckoutSdk.fourSdk()
+                .oAuth()
+                .clientCredentials(
+                        requireNonNull(System.getenv("CHECKOUT_FOUR_PREVIEW_OAUTH_CLIENT_ID")),
+                        requireNonNull(System.getenv("CHECKOUT_FOUR_PREVIEW_OAUTH_CLIENT_SECRET")))
+                .environment(Environment.SANDBOX)
+                .build();
+
+        final Address billingAddress = new Address();
+        billingAddress.setAddressLine1("Cecilia Chapman");
+        billingAddress.setAddressLine2("711-2880 Nulla St.");
+        billingAddress.setCity("Mankato");
+        billingAddress.setState("Mississippi");
+        billingAddress.setZip("96522");
+        billingAddress.setCountry(CountryCode.SA);
+
+        final RequestTamaraSource source = new RequestTamaraSource();
+        source.setBillingAddress(billingAddress);
+
+        final PaymentRequest request = PaymentRequest.builder()
+                .source(source)
+                .currency(Currency.SAR)
+                .amount(10000L)
+                .capture(true)
+                .successUrl("https://testing.checkout.com/sucess")
+                .failureUrl("https://testing.checkout.com/failure")
+                .reference("ORD-5023-4E89")
+                .processing(ProcessingSettings.builder().taxAmount(500L).shippingAmount(1000L).build())
+                .processingChannelId("pc_zs5fqhybzc2e3jmq3efvybybpq")
+                .customer(new CustomerRequest(null, "c.chapman@example.com", "Cecilia Chapman",
+                        Phone.builder().countryCode("+966").number("113 496 0000").build()))
+                .items(Collections.singletonList(Product.builder()
+                        .name("Item name")
+                        .quantity(3L)
+                        .unitPrice(100L)
+                        .totalAmount(100L)
+                        .taxAmount(19L)
+                        .discountAmount(2L)
+                        .reference("some description about item")
+                        .imageUrl("https://some_s3bucket.com")
+                        .url("https://some.website.com/item")
+                        .sku("123687000111")
+                        .build()))
+                .build();
+
+        final PaymentResponse response = blocking(() -> previewApi.paymentsClient().requestPayment(request));
+        assertNotNull(response);
+        assertNotNull(response.getId());
+        assertNotNull(response.getReference());
+        assertNotNull(response.getLinks());
+        assertNotNull(response.getCustomer());
+        assertNotNull(response.getCustomer().getId());
+        assertNotNull(response.getCustomer().getName());
+        assertNotNull(response.getCustomer().getEmail());
+        assertNotNull(response.getCustomer().getPhone());
+        assertEquals(PaymentStatus.PENDING, response.getStatus());
+
+    }
+
+}

--- a/src/test/java/com/checkout/payments/AbstractPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/AbstractPaymentsTestIT.java
@@ -163,7 +163,7 @@ public abstract class AbstractPaymentsTestIT extends SandboxTestFixture {
                 .source(source)
                 .capture(false)
                 .reference(UUID.randomUUID().toString())
-                .customer(new CustomerRequest(null, TestHelper.generateRandomEmail(), null))
+                .customer(new CustomerRequest(null, TestHelper.generateRandomEmail(), null, null))
                 .amount(10L)
                 .currency(Currency.USD)
                 .threeDS(threeDSRequest)

--- a/src/test/java/com/checkout/payments/four/hosted/HostedPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/four/hosted/HostedPaymentsTestIT.java
@@ -8,7 +8,6 @@ import com.checkout.payments.hosted.HostedPaymentDetailsResponse;
 import com.checkout.payments.hosted.HostedPaymentRequest;
 import com.checkout.payments.hosted.HostedPaymentResponse;
 import com.checkout.payments.hosted.HostedPaymentStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,7 +23,6 @@ class HostedPaymentsTestIT extends SandboxTestFixture {
     }
 
     @Test
-    @Disabled("not available")
     void shouldCreateAndGetHostedPayments() {
         final HostedPaymentRequest request = TestHelper.createHostedPaymentRequest(REFERENCE);
         final HostedPaymentResponse response = blocking(() -> fourApi.hostedPaymentsClient().createAsync(request));

--- a/src/test/java/com/checkout/payments/four/links/PaymentLinksTestIT.java
+++ b/src/test/java/com/checkout/payments/four/links/PaymentLinksTestIT.java
@@ -7,7 +7,6 @@ import com.checkout.payments.links.PaymentLinkDetailsResponse;
 import com.checkout.payments.links.PaymentLinkRequest;
 import com.checkout.payments.links.PaymentLinkResponse;
 import com.checkout.payments.links.PaymentLinkStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -26,7 +25,6 @@ class PaymentLinksTestIT extends SandboxTestFixture {
     }
 
     @Test
-    @Disabled("not available")
     void shouldCreateAndGetPaymentsLink() {
 
         final PaymentLinkRequest paymentLinksRequest = TestHelper.createPaymentLinksRequest(REFERENCE);

--- a/src/test/java/com/checkout/risk/PreAuthenticationCaptureTestIT.java
+++ b/src/test/java/com/checkout/risk/PreAuthenticationCaptureTestIT.java
@@ -153,7 +153,7 @@ class PreAuthenticationCaptureTestIT extends SandboxTestFixture {
         final PreAuthenticationAssessmentRequest request = PreAuthenticationAssessmentRequest.builder()
                 .date(Instant.now())
                 .source(requestSource)
-                .customer(new CustomerRequest("id", TestHelper.generateRandomEmail(), "name"))
+                .customer(new CustomerRequest("id", TestHelper.generateRandomEmail(), "name", null))
                 .payment(RiskPayment.builder().psp("CheckoutSdk.com").id("78453878").build())
                 .shipping(RiskShippingDetails.builder().address(
                         Address.builder()
@@ -205,7 +205,7 @@ class PreAuthenticationCaptureTestIT extends SandboxTestFixture {
         final PreCaptureAssessmentRequest request = PreCaptureAssessmentRequest.builder()
                 .date(Instant.now())
                 .source(requestSource)
-                .customer(new CustomerRequest("id", TestHelper.generateRandomEmail(), "name"))
+                .customer(new CustomerRequest("id", TestHelper.generateRandomEmail(), "name", null))
                 .payment(RiskPayment.builder().psp("CheckoutSdk.com").id("78453878").build())
                 .shipping(RiskShippingDetails.builder().address(
                         Address.builder()

--- a/src/test/java/com/checkout/risk/four/PreAuthenticationCaptureTestIT.java
+++ b/src/test/java/com/checkout/risk/four/PreAuthenticationCaptureTestIT.java
@@ -155,7 +155,7 @@ class PreAuthenticationCaptureTestIT extends SandboxTestFixture {
         final PreAuthenticationAssessmentRequest request = PreAuthenticationAssessmentRequest.builder()
                 .date(Instant.now())
                 .source(requestSource)
-                .customer(new CustomerRequest("id", TestHelper.generateRandomEmail(), "name"))
+                .customer(new CustomerRequest("id", TestHelper.generateRandomEmail(), "name", null))
                 .payment(RiskPayment.builder().psp("CheckoutSdk.com").id("78453878").build())
                 .shipping(RiskShippingDetails.builder().address(
                         Address.builder()
@@ -208,7 +208,7 @@ class PreAuthenticationCaptureTestIT extends SandboxTestFixture {
         final PreCaptureAssessmentRequest request = PreCaptureAssessmentRequest.builder()
                 .date(Instant.now())
                 .source(requestSource)
-                .customer(new CustomerRequest("id", TestHelper.generateRandomEmail(), "name"))
+                .customer(new CustomerRequest("id", TestHelper.generateRandomEmail(), "name", null))
                 .payment(RiskPayment.builder().psp("CheckoutSdk.com").id("78453878").build())
                 .shipping(RiskShippingDetails.builder().address(
                         Address.builder()

--- a/src/test/java/com/checkout/tokens/TokensTestIT.java
+++ b/src/test/java/com/checkout/tokens/TokensTestIT.java
@@ -3,6 +3,8 @@ package com.checkout.tokens;
 import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestCardSource;
+import com.checkout.common.CardCategory;
+import com.checkout.common.CardType;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -39,8 +41,8 @@ class TokensTestIT extends SandboxTestFixture {
         //assertEquals("Visa", response.getScheme());
         assertEquals("4242", response.getLast4());
         assertEquals("424242", response.getBin());
-        //assertEquals(CardType.CREDIT, response.getCardType());
-        //assertEquals(CardCategory.CONSUMER, response.getCardCategory());
+        assertEquals(CardType.CREDIT, response.getCardType());
+        assertEquals(CardCategory.CONSUMER, response.getCardCategory());
         //assertEquals("JPMORGAN CHASE BANK NA", response.getIssuer());
         //assertEquals(CountryCode.US, response.getIssuerCountry());
         //assertEquals("A", response.getProductId());


### PR DESCRIPTION
Support for `RequestTamaraSource` was added along with the necessary properties at `PaymentRequest` and `CustomerRequest` to allow this kind of payments. The class `Payments` (four) and certain utility methods at `default.PaymentRequest` were marked as deprecated.