### PR TITLE
Fix payment response deserialization config

### DIFF
--- a/src/main/java/com/checkout/GsonSerializer.java
+++ b/src/main/java/com/checkout/GsonSerializer.java
@@ -3,30 +3,9 @@ package com.checkout;
 import com.checkout.common.CheckoutUtils;
 import com.checkout.common.InstrumentType;
 import com.checkout.common.PaymentSourceType;
-import com.checkout.instruments.four.create.CreateInstrumentBankAccountResponse;
-import com.checkout.instruments.four.create.CreateInstrumentResponse;
-import com.checkout.instruments.four.create.CreateInstrumentTokenResponse;
-import com.checkout.instruments.four.get.GetBankAccountInstrumentResponse;
-import com.checkout.instruments.four.get.GetCardInstrumentResponse;
-import com.checkout.instruments.four.get.GetInstrumentResponse;
-import com.checkout.instruments.four.update.UpdateInstrumentBankAccountResponse;
-import com.checkout.instruments.four.update.UpdateInstrumentCardResponse;
-import com.checkout.instruments.four.update.UpdateInstrumentResponse;
 import com.checkout.payments.PaymentDestinationType;
-import com.checkout.payments.four.response.destination.PaymentResponseAlternativeDestination;
-import com.checkout.payments.four.response.destination.PaymentResponseBankAccountDestination;
-import com.checkout.payments.four.response.destination.PaymentResponseDestination;
-import com.checkout.payments.four.response.source.CurrencyAccountResponseSource;
-import com.checkout.payments.response.source.AlternativePaymentSourceResponse;
-import com.checkout.payments.response.source.ResponseSource;
 import com.checkout.workflows.four.actions.WorkflowActionType;
-import com.checkout.workflows.four.actions.response.WebhookWorkflowActionResponse;
-import com.checkout.workflows.four.actions.response.WorkflowActionResponse;
 import com.checkout.workflows.four.conditions.WorkflowConditionType;
-import com.checkout.workflows.four.conditions.response.EntityWorkflowConditionResponse;
-import com.checkout.workflows.four.conditions.response.EventWorkflowConditionResponse;
-import com.checkout.workflows.four.conditions.response.ProcessingChannelWorkflowConditionResponse;
-import com.checkout.workflows.four.conditions.response.WorkflowConditionResponse;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -57,35 +36,35 @@ class GsonSerializer implements Serializer {
             .registerTypeAdapter(Instant.class, (JsonDeserializer<Instant>) (JsonElement json, Type typeOfSrc, JsonDeserializationContext context) ->
                     Instant.parse(json.getAsString()))
             // Payments DEFAULT - source
-            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(ResponseSource.class, CheckoutUtils.TYPE, true, AlternativePaymentSourceResponse.class)
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.payments.response.source.ResponseSource.class, CheckoutUtils.TYPE, true, com.checkout.payments.response.source.AlternativePaymentSourceResponse.class)
                     .registerSubtype(com.checkout.payments.response.source.CardResponseSource.class, identifier(PaymentSourceType.CARD)))
             // Payments DEFAULT - destination
-            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(PaymentResponseDestination.class, CheckoutUtils.TYPE, true, PaymentResponseAlternativeDestination.class)
-                    .registerSubtype(PaymentResponseBankAccountDestination.class, identifier(PaymentDestinationType.BANK_ACCOUNT)))
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.payments.response.destination.PaymentResponseDestination.class, CheckoutUtils.TYPE, true, com.checkout.payments.response.destination.PaymentResponseAlternativeDestination.class)
+                    .registerSubtype(com.checkout.payments.response.destination.PaymentResponseCardDestination.class, identifier(PaymentDestinationType.CARD)))
             // Payments FOUR - source
             .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.payments.four.response.source.ResponseSource.class, CheckoutUtils.TYPE, true, com.checkout.payments.four.response.source.AlternativePaymentSourceResponse.class)
                     .registerSubtype(com.checkout.payments.four.response.source.CardResponseSource.class, identifier(PaymentSourceType.CARD))
-                    .registerSubtype(CurrencyAccountResponseSource.class, identifier(PaymentSourceType.CURRENCY_ACCOUNT)))
+                    .registerSubtype(com.checkout.payments.four.response.source.CurrencyAccountResponseSource.class, identifier(PaymentSourceType.CURRENCY_ACCOUNT)))
             // Payments FOUR - destination
             .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.payments.four.response.destination.PaymentResponseDestination.class, CheckoutUtils.TYPE, true, com.checkout.payments.four.response.destination.PaymentResponseAlternativeDestination.class)
-                    .registerSubtype(PaymentResponseBankAccountDestination.class, identifier(PaymentDestinationType.BANK_ACCOUNT)))
+                    .registerSubtype(com.checkout.payments.four.response.destination.PaymentResponseBankAccountDestination.class, identifier(PaymentDestinationType.BANK_ACCOUNT)))
             // Instruments CS2
-            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(CreateInstrumentResponse.class, CheckoutUtils.TYPE)
-                    .registerSubtype(CreateInstrumentBankAccountResponse.class, identifier(InstrumentType.BANK_ACCOUNT))
-                    .registerSubtype(CreateInstrumentTokenResponse.class, identifier(InstrumentType.CARD)))
-            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(GetInstrumentResponse.class, CheckoutUtils.TYPE)
-                    .registerSubtype(GetBankAccountInstrumentResponse.class, identifier(InstrumentType.BANK_ACCOUNT))
-                    .registerSubtype(GetCardInstrumentResponse.class, identifier(InstrumentType.CARD)))
-            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(UpdateInstrumentResponse.class, CheckoutUtils.TYPE)
-                    .registerSubtype(UpdateInstrumentBankAccountResponse.class, identifier(InstrumentType.BANK_ACCOUNT))
-                    .registerSubtype(UpdateInstrumentCardResponse.class, identifier(InstrumentType.CARD)))
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.instruments.four.create.CreateInstrumentResponse.class, CheckoutUtils.TYPE)
+                    .registerSubtype(com.checkout.instruments.four.create.CreateInstrumentBankAccountResponse.class, identifier(InstrumentType.BANK_ACCOUNT))
+                    .registerSubtype(com.checkout.instruments.four.create.CreateInstrumentTokenResponse.class, identifier(InstrumentType.CARD)))
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.instruments.four.get.GetInstrumentResponse.class, CheckoutUtils.TYPE)
+                    .registerSubtype(com.checkout.instruments.four.get.GetBankAccountInstrumentResponse.class, identifier(InstrumentType.BANK_ACCOUNT))
+                    .registerSubtype(com.checkout.instruments.four.get.GetCardInstrumentResponse.class, identifier(InstrumentType.CARD)))
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.instruments.four.update.UpdateInstrumentResponse.class, CheckoutUtils.TYPE)
+                    .registerSubtype(com.checkout.instruments.four.update.UpdateInstrumentBankAccountResponse.class, identifier(InstrumentType.BANK_ACCOUNT))
+                    .registerSubtype(com.checkout.instruments.four.update.UpdateInstrumentCardResponse.class, identifier(InstrumentType.CARD)))
             // Workflows CS2
-            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(WorkflowActionResponse.class, CheckoutUtils.TYPE)
-                    .registerSubtype(WebhookWorkflowActionResponse.class, identifier(WorkflowActionType.WEBHOOK)))
-            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(WorkflowConditionResponse.class, CheckoutUtils.TYPE)
-                    .registerSubtype(EventWorkflowConditionResponse.class, identifier(WorkflowConditionType.EVENT))
-                    .registerSubtype(EntityWorkflowConditionResponse.class, identifier(WorkflowConditionType.ENTITY))
-                    .registerSubtype(ProcessingChannelWorkflowConditionResponse.class, identifier(WorkflowConditionType.PROCESSING_CHANNEL)))
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.workflows.four.actions.response.WorkflowActionResponse.class, CheckoutUtils.TYPE)
+                    .registerSubtype(com.checkout.workflows.four.actions.response.WebhookWorkflowActionResponse.class, identifier(WorkflowActionType.WEBHOOK)))
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.workflows.four.conditions.response.WorkflowConditionResponse.class, CheckoutUtils.TYPE)
+                    .registerSubtype(com.checkout.workflows.four.conditions.response.EventWorkflowConditionResponse.class, identifier(WorkflowConditionType.EVENT))
+                    .registerSubtype(com.checkout.workflows.four.conditions.response.EntityWorkflowConditionResponse.class, identifier(WorkflowConditionType.ENTITY))
+                    .registerSubtype(com.checkout.workflows.four.conditions.response.ProcessingChannelWorkflowConditionResponse.class, identifier(WorkflowConditionType.PROCESSING_CHANNEL)))
             .create();
 
     private final Gson gson;

--- a/src/main/java/com/checkout/payments/response/destination/PaymentResponseAlternativeDestination.java
+++ b/src/main/java/com/checkout/payments/response/destination/PaymentResponseAlternativeDestination.java
@@ -2,7 +2,6 @@ package com.checkout.payments.response.destination;
 
 import com.checkout.common.CheckoutUtils;
 import com.checkout.payments.PaymentDestinationType;
-import com.checkout.payments.four.response.destination.PaymentResponseDestination;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/src/main/java/com/checkout/workflows/four/actions/response/WorkflowActionInvocationsResponse.java
+++ b/src/main/java/com/checkout/workflows/four/actions/response/WorkflowActionInvocationsResponse.java
@@ -5,10 +5,12 @@ import com.checkout.workflows.four.actions.WorkflowActionStatus;
 import com.checkout.workflows.four.actions.WorkflowActionType;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class WorkflowActionInvocationsResponse extends Resource {
 
     @SerializedName("workflow_id")

--- a/src/test/java/com/checkout/GsonSerializerTest.java
+++ b/src/test/java/com/checkout/GsonSerializerTest.java
@@ -1,0 +1,50 @@
+package com.checkout;
+
+import com.checkout.payments.response.GetPaymentResponse;
+import com.checkout.payments.response.destination.PaymentResponseAlternativeDestination;
+import com.checkout.payments.response.destination.PaymentResponseCardDestination;
+import org.junit.jupiter.api.Test;
+
+import static com.checkout.TestHelper.getMock;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GsonSerializerTest {
+
+    private final Serializer serializer = new GsonSerializer();
+
+    @Test
+    void shouldDeserialize_default_getPaymentResponse_cardDestination() {
+
+        final GetPaymentResponse paymentResponse = serializer.fromJson(getMock("/mocks/payments/response/destination/card/get_payment_response.json"), GetPaymentResponse.class);
+
+        assertNotNull(paymentResponse);
+        assertNotNull(paymentResponse.getDestination());
+        assertTrue(paymentResponse.getDestination() instanceof PaymentResponseCardDestination);
+        final PaymentResponseCardDestination cardDestination = (PaymentResponseCardDestination) paymentResponse.getDestination();
+        assertNotNull(cardDestination.getExpiryMonth());
+        assertNotNull(cardDestination.getExpiryYear());
+        assertNotNull(cardDestination.getName());
+        assertNotNull(cardDestination.getFingerprint());
+        assertNotNull(cardDestination.getCardType());
+        assertNotNull(cardDestination.getCardCategory());
+        assertNotNull(cardDestination.getProductId());
+        assertNotNull(cardDestination.getProductType());
+
+    }
+
+    @Test
+    void shouldDeserialize_default_getPaymentResponse_alternativeDestination() {
+
+        final GetPaymentResponse paymentResponse = serializer.fromJson(getMock("/mocks/payments/response/destination/alternative/get_payment_response.json"), GetPaymentResponse.class);
+
+        assertNotNull(paymentResponse);
+        assertNotNull(paymentResponse.getDestination());
+        assertTrue(paymentResponse.getDestination() instanceof PaymentResponseAlternativeDestination);
+        final PaymentResponseAlternativeDestination alternativeDestination = (PaymentResponseAlternativeDestination) paymentResponse.getDestination();
+        assertFalse(alternativeDestination.keySet().isEmpty());
+
+    }
+
+}

--- a/src/test/java/com/checkout/TestHelper.java
+++ b/src/test/java/com/checkout/TestHelper.java
@@ -18,7 +18,10 @@ import com.checkout.payments.ShippingDetails;
 import com.checkout.payments.ThreeDSRequest;
 import com.checkout.payments.hosted.HostedPaymentRequest;
 import com.checkout.payments.links.PaymentLinkRequest;
+import lombok.SneakyThrows;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -42,6 +45,11 @@ public final class TestHelper {
     public static final String VALID_FOUR_PK = "pk_sbox_pkhpdtvmkgf7hdnpwnbhw7r2uic";
     public static final String INVALID_FOUR_SK = "sk_sbox_m73dzbpy7c-f3gfd46xr4yj5xo4e";
     public static final String INVALID_FOUR_PK = "pk_sbox_pkh";
+
+    @SneakyThrows
+    public static String getMock(final String mock) {
+        return new String(Files.readAllBytes(Paths.get(TestHelper.class.getResource(mock).toURI())));
+    }
 
     public static String generateRandomEmail() {
         return UUID.randomUUID().toString() + "@checkout-sdk-java.com";

--- a/src/test/resources/mocks/payments/response/destination/alternative/get_payment_response.json
+++ b/src/test/resources/mocks/payments/response/destination/alternative/get_payment_response.json
@@ -1,0 +1,79 @@
+{
+  "id": "pay_mbabizu24mvu3mela5njyhpit4",
+  "action_id": "act_mbabizu24mvu3mela5njyhpit4",
+  "amount": 6540,
+  "currency": "USD",
+  "approved": true,
+  "status": "Authorized",
+  "auth_code": "770687",
+  "response_code": "10000",
+  "response_summary": "Approved",
+  "3ds": {
+    "downgraded": true,
+    "enrolled": "N"
+  },
+  "risk": {
+    "flagged": true
+  },
+  "source": {
+    "type": "card",
+    "id": "src_nwd3m4in3hkuddfpjsaevunhdy",
+    "billing_address": {
+      "address_line1": "Checkout.com",
+      "address_line2": "90 Tottenham Court Road",
+      "city": "London",
+      "state": "London",
+      "zip": "W1T 4TJ",
+      "country": "GB"
+    },
+    "phone": {
+      "country_code": "+1",
+      "number": "415 555 2671"
+    },
+    "last4": "4242",
+    "fingerprint": "F31828E2BDABAE63EB694903825CDD36041CC6ED461440B81415895855502832",
+    "bin": "424242"
+  },
+  "destination": {
+    "type": "other",
+    "expiry_month": "12",
+    "expiry_year": "2022",
+    "name": "name",
+    "last4": "424242",
+    "fingerprint": "fp123",
+    "bin": "bin123",
+    "card_type": "credit",
+    "card_category": "CONSUMER",
+    "issuer_country": "AX",
+    "product_id": "456",
+    "product_type": "ptype"
+  },
+  "customer": {
+    "id": "cus_udst2tfldj6upmye2reztkmm4i",
+    "email": "brucewayne@gmail.com",
+    "name": "Bruce Wayne"
+  },
+  "processed_on": "2019-09-10T10:11:12Z",
+  "reference": "ORD-5023-4E89",
+  "processing": {
+    "retrieval_reference_number": "909913440644",
+    "acquirer_transaction_id": "440644309099499894406",
+    "recommendation_code": "02"
+  },
+  "eci": "06",
+  "scheme_id": "489341065491658",
+  "_links": {
+    "self": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4"
+    },
+    "action": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions"
+    },
+    "void": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids"
+    },
+    "capture": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures"
+    }
+  }
+}

--- a/src/test/resources/mocks/payments/response/destination/card/get_payment_response.json
+++ b/src/test/resources/mocks/payments/response/destination/card/get_payment_response.json
@@ -1,0 +1,79 @@
+{
+  "id": "pay_mbabizu24mvu3mela5njyhpit4",
+  "action_id": "act_mbabizu24mvu3mela5njyhpit4",
+  "amount": 6540,
+  "currency": "USD",
+  "approved": true,
+  "status": "Authorized",
+  "auth_code": "770687",
+  "response_code": "10000",
+  "response_summary": "Approved",
+  "3ds": {
+    "downgraded": true,
+    "enrolled": "N"
+  },
+  "risk": {
+    "flagged": true
+  },
+  "source": {
+    "type": "card",
+    "id": "src_nwd3m4in3hkuddfpjsaevunhdy",
+    "billing_address": {
+      "address_line1": "Checkout.com",
+      "address_line2": "90 Tottenham Court Road",
+      "city": "London",
+      "state": "London",
+      "zip": "W1T 4TJ",
+      "country": "GB"
+    },
+    "phone": {
+      "country_code": "+1",
+      "number": "415 555 2671"
+    },
+    "last4": "4242",
+    "fingerprint": "F31828E2BDABAE63EB694903825CDD36041CC6ED461440B81415895855502832",
+    "bin": "424242"
+  },
+  "destination": {
+    "type": "card",
+    "expiry_month": "12",
+    "expiry_year": "2022",
+    "name": "name",
+    "last4": "424242",
+    "fingerprint": "fp123",
+    "bin": "bin123",
+    "card_type": "credit",
+    "card_category": "CONSUMER",
+    "issuer_country": "AX",
+    "product_id": "456",
+    "product_type": "ptype"
+  },
+  "customer": {
+    "id": "cus_udst2tfldj6upmye2reztkmm4i",
+    "email": "brucewayne@gmail.com",
+    "name": "Bruce Wayne"
+  },
+  "processed_on": "2019-09-10T10:11:12Z",
+  "reference": "ORD-5023-4E89",
+  "processing": {
+    "retrieval_reference_number": "909913440644",
+    "acquirer_transaction_id": "440644309099499894406",
+    "recommendation_code": "02"
+  },
+  "eci": "06",
+  "scheme_id": "489341065491658",
+  "_links": {
+    "self": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4"
+    },
+    "action": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions"
+    },
+    "void": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids"
+    },
+    "capture": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures"
+    }
+  }
+}


### PR DESCRIPTION
In `GsonSerializer`, `PaymentResponseDestination` was being deserialized using the Four interface, hence no implementations were being provided. This commit aims to enforce the config to use the correct classes enforcing the correct package. A few additional improvements were also performed.