### PR TITLE
Bump Apache HttpClient to `4.5.13`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.8
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.12'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'javax.validation:validation-api:2.0.1.Final'
     implementation 'org.apache.httpcomponents:httpmime:4.5.13'


### PR DESCRIPTION
The latest version, solves vulnerability `CVE-2020-13956`.