### PR TITLE
Deprecate unnecessary APM clients.

### DIFF
--- a/src/main/java/com/checkout/CheckoutApmApi.java
+++ b/src/main/java/com/checkout/CheckoutApmApi.java
@@ -11,18 +11,38 @@ import com.checkout.apm.sepa.SepaClient;
 
 public interface CheckoutApmApi {
 
+    /**
+     * @deprecated Won't be supported anymore on further versions
+     */
+    @Deprecated
     BalotoClient balotoClient();
 
+    /**
+     * @deprecated Won't be supported anymore on further versions
+     */
+    @Deprecated
     FawryClient fawryClient();
 
     IdealClient idealClient();
 
     KlarnaClient klarnaClient();
 
+    /**
+     * @deprecated Won't be supported anymore on further versions
+     */
+    @Deprecated
     OxxoClient oxxoClient();
 
+    /**
+     * @deprecated Won't be supported anymore on further versions
+     */
+    @Deprecated
     PagoFacilClient pagoFacilClient();
 
+    /**
+     * @deprecated Won't be supported anymore on further versions
+     */
+    @Deprecated
     RapiPagoClient rapiPagoClient();
 
     SepaClient sepaClient();

--- a/src/main/java/com/checkout/apm/baloto/BalotoClient.java
+++ b/src/main/java/com/checkout/apm/baloto/BalotoClient.java
@@ -2,6 +2,10 @@ package com.checkout.apm.baloto;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * @deprecated Won't be supported anymore on further versions
+ */
+@Deprecated
 public interface BalotoClient {
 
     CompletableFuture<Void> succeed(String id);

--- a/src/main/java/com/checkout/apm/fawry/FawryClient.java
+++ b/src/main/java/com/checkout/apm/fawry/FawryClient.java
@@ -2,6 +2,10 @@ package com.checkout.apm.fawry;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * @deprecated  Won't be supported anymore on further versions
+ */
+@Deprecated
 public interface FawryClient {
 
     CompletableFuture<Void> approve(String reference);

--- a/src/main/java/com/checkout/apm/oxxo/OxxoClient.java
+++ b/src/main/java/com/checkout/apm/oxxo/OxxoClient.java
@@ -2,6 +2,10 @@ package com.checkout.apm.oxxo;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * @deprecated Won't be supported anymore on further versions
+ */
+@Deprecated
 public interface OxxoClient {
 
     CompletableFuture<Void> succeed(String paymentId);

--- a/src/main/java/com/checkout/apm/pagofacil/PagoFacilClient.java
+++ b/src/main/java/com/checkout/apm/pagofacil/PagoFacilClient.java
@@ -2,6 +2,10 @@ package com.checkout.apm.pagofacil;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * @deprecated Won't be supported anymore on further versions
+ */
+@Deprecated
 public interface PagoFacilClient {
 
     CompletableFuture<Void> succeed(String paymentId);

--- a/src/main/java/com/checkout/apm/rapipago/RapiPagoClient.java
+++ b/src/main/java/com/checkout/apm/rapipago/RapiPagoClient.java
@@ -2,6 +2,10 @@ package com.checkout.apm.rapipago;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * @deprecated Won't be supported anymore on further versions
+ */
+@Deprecated
 public interface RapiPagoClient {
 
     CompletableFuture<Void> succeed(String paymentId);


### PR DESCRIPTION
These clients are only supported on Sandbox, right now there is no need to expose these functionalities through the SDK