### PR TITLE
Fix `sender` deserialization (Four)

### DIFF
--- a/src/main/java/com/checkout/GsonSerializer.java
+++ b/src/main/java/com/checkout/GsonSerializer.java
@@ -9,6 +9,8 @@ import com.checkout.marketplace.payout.schedule.response.CurrencySchedule;
 import com.checkout.marketplace.payout.schedule.response.GetScheduleResponseDeserializer;
 import com.checkout.marketplace.payout.schedule.response.ScheduleFrequencyMonthlyResponse;
 import com.checkout.payments.PaymentDestinationType;
+import com.checkout.payments.four.sender.Sender;
+import com.checkout.payments.four.sender.SenderType;
 import com.checkout.workflows.four.actions.WorkflowActionType;
 import com.checkout.workflows.four.conditions.WorkflowConditionType;
 import com.google.gson.FieldNamingPolicy;
@@ -56,6 +58,11 @@ class GsonSerializer implements Serializer {
             // Payments FOUR - destination
             .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.payments.four.response.destination.PaymentResponseDestination.class, CheckoutUtils.TYPE, true, com.checkout.payments.four.response.destination.PaymentResponseAlternativeDestination.class)
                     .registerSubtype(com.checkout.payments.four.response.destination.PaymentResponseBankAccountDestination.class, identifier(PaymentDestinationType.BANK_ACCOUNT)))
+            // Payments FOUR - sender
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(Sender.class, CheckoutUtils.TYPE, true, com.checkout.payments.four.sender.ResponseAlternativeSender.class)
+                    .registerSubtype(com.checkout.payments.four.sender.PaymentCorporateSender.class, identifier(SenderType.CORPORATE))
+                    .registerSubtype(com.checkout.payments.four.sender.PaymentIndividualSender.class, identifier(SenderType.INDIVIDUAL))
+                    .registerSubtype(com.checkout.payments.four.sender.PaymentInstrumentSender.class, identifier(SenderType.INSTRUMENT)))
             // Instruments CS2
             .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.instruments.four.create.CreateInstrumentResponse.class, CheckoutUtils.TYPE)
                     .registerSubtype(com.checkout.instruments.four.create.CreateInstrumentBankAccountResponse.class, identifier(InstrumentType.BANK_ACCOUNT))

--- a/src/main/java/com/checkout/payments/four/response/GetPaymentResponse.java
+++ b/src/main/java/com/checkout/payments/four/response/GetPaymentResponse.java
@@ -14,7 +14,7 @@ import com.checkout.payments.ShippingDetails;
 import com.checkout.payments.ThreeDSData;
 import com.checkout.payments.four.response.destination.PaymentResponseDestination;
 import com.checkout.payments.four.response.source.ResponseSource;
-import com.checkout.payments.four.sender.PaymentSender;
+import com.checkout.payments.four.sender.Sender;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -38,7 +38,7 @@ public final class GetPaymentResponse extends Resource {
 
     private PaymentResponseDestination destination;
 
-    private PaymentSender sender;
+    private Sender sender;
 
     private Long amount;
 

--- a/src/main/java/com/checkout/payments/four/sender/PaymentCorporateSender.java
+++ b/src/main/java/com/checkout/payments/four/sender/PaymentCorporateSender.java
@@ -21,13 +21,13 @@ public final class PaymentCorporateSender extends PaymentSender {
 
     @Builder
     private PaymentCorporateSender(final String companyName, final Address address) {
-        super(RequestSenderType.CORPORATE);
+        super(SenderType.CORPORATE);
         this.companyName = companyName;
         this.address = address;
     }
 
     public PaymentCorporateSender() {
-        super(RequestSenderType.CORPORATE);
+        super(SenderType.CORPORATE);
     }
 
 }

--- a/src/main/java/com/checkout/payments/four/sender/PaymentIndividualSender.java
+++ b/src/main/java/com/checkout/payments/four/sender/PaymentIndividualSender.java
@@ -30,7 +30,7 @@ public final class PaymentIndividualSender extends PaymentSender {
                                     final String lastName,
                                     final Address address,
                                     final SenderIdentification identification) {
-        super(RequestSenderType.INDIVIDUAL);
+        super(SenderType.INDIVIDUAL);
         this.firstName = firstName;
         this.lastName = lastName;
         this.address = address;
@@ -38,7 +38,7 @@ public final class PaymentIndividualSender extends PaymentSender {
     }
 
     public PaymentIndividualSender() {
-        super(RequestSenderType.INDIVIDUAL);
+        super(SenderType.INDIVIDUAL);
     }
 
 }

--- a/src/main/java/com/checkout/payments/four/sender/PaymentInstrumentSender.java
+++ b/src/main/java/com/checkout/payments/four/sender/PaymentInstrumentSender.java
@@ -12,7 +12,7 @@ public final class PaymentInstrumentSender extends PaymentSender {
 
     @Builder
     public PaymentInstrumentSender() {
-        super(RequestSenderType.INSTRUMENT);
+        super(SenderType.INSTRUMENT);
     }
 
 }

--- a/src/main/java/com/checkout/payments/four/sender/PaymentSender.java
+++ b/src/main/java/com/checkout/payments/four/sender/PaymentSender.java
@@ -3,13 +3,13 @@ package com.checkout.payments.four.sender;
 import lombok.Data;
 
 @Data
-public abstract class PaymentSender {
+public abstract class PaymentSender implements Sender {
 
-    protected final RequestSenderType type;
+    protected final SenderType type;
 
     protected String reference;
 
-    protected PaymentSender(final RequestSenderType type) {
+    protected PaymentSender(final SenderType type) {
         this.type = type;
     }
 

--- a/src/main/java/com/checkout/payments/four/sender/ResponseAlternativeSender.java
+++ b/src/main/java/com/checkout/payments/four/sender/ResponseAlternativeSender.java
@@ -1,0 +1,20 @@
+package com.checkout.payments.four.sender;
+
+import com.checkout.common.CheckoutUtils;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.commons.lang3.EnumUtils;
+
+import java.util.HashMap;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class ResponseAlternativeSender extends HashMap<String, Object> implements Sender {
+
+    public SenderType getType() {
+        return EnumUtils.getEnumIgnoreCase(SenderType.class, (String) get(CheckoutUtils.TYPE));
+    }
+
+}

--- a/src/main/java/com/checkout/payments/four/sender/Sender.java
+++ b/src/main/java/com/checkout/payments/four/sender/Sender.java
@@ -1,0 +1,7 @@
+package com.checkout.payments.four.sender;
+
+public interface Sender {
+
+    SenderType getType();
+
+}

--- a/src/main/java/com/checkout/payments/four/sender/SenderType.java
+++ b/src/main/java/com/checkout/payments/four/sender/SenderType.java
@@ -2,7 +2,7 @@ package com.checkout.payments.four.sender;
 
 import com.google.gson.annotations.SerializedName;
 
-public enum RequestSenderType {
+public enum SenderType {
 
     @SerializedName("instrument")
     INSTRUMENT,

--- a/src/test/java/com/checkout/GsonSerializerTest.java
+++ b/src/test/java/com/checkout/GsonSerializerTest.java
@@ -1,11 +1,15 @@
 package com.checkout;
 
+import com.checkout.payments.four.sender.PaymentCorporateSender;
+import com.checkout.payments.four.sender.ResponseAlternativeSender;
+import com.checkout.payments.four.sender.SenderType;
 import com.checkout.payments.response.GetPaymentResponse;
 import com.checkout.payments.response.destination.PaymentResponseAlternativeDestination;
 import com.checkout.payments.response.destination.PaymentResponseCardDestination;
 import org.junit.jupiter.api.Test;
 
 import static com.checkout.TestHelper.getMock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,6 +48,31 @@ class GsonSerializerTest {
         assertTrue(paymentResponse.getDestination() instanceof PaymentResponseAlternativeDestination);
         final PaymentResponseAlternativeDestination alternativeDestination = (PaymentResponseAlternativeDestination) paymentResponse.getDestination();
         assertFalse(alternativeDestination.keySet().isEmpty());
+
+    }
+
+    @Test
+    void shouldDeserialize_four_getPaymentResponse_corporateSender() {
+
+        final com.checkout.payments.four.response.GetPaymentResponse paymentResponse = serializer.fromJson(getMock("/mocks/payments/response/sender/corporate/get_payment_response.json"), com.checkout.payments.four.response.GetPaymentResponse.class);
+
+        assertNotNull(paymentResponse);
+        assertNotNull(paymentResponse.getSender());
+        assertTrue(paymentResponse.getSender() instanceof PaymentCorporateSender);
+        assertEquals("company", ((PaymentCorporateSender) paymentResponse.getSender()).getCompanyName());
+        assertEquals(SenderType.CORPORATE, paymentResponse.getSender().getType());
+
+    }
+
+    @Test
+    void shouldDeserialize_four_getPaymentResponse_alternativeSender() {
+
+        final com.checkout.payments.four.response.GetPaymentResponse paymentResponse = serializer.fromJson(getMock("/mocks/payments/response/sender/alternative/get_payment_response.json"), com.checkout.payments.four.response.GetPaymentResponse.class);
+
+        assertNotNull(paymentResponse);
+        assertNotNull(paymentResponse.getSender());
+        assertTrue(paymentResponse.getSender() instanceof ResponseAlternativeSender);
+        assertEquals("company", ((ResponseAlternativeSender) paymentResponse.getSender()).get("company_name"));
 
     }
 

--- a/src/test/resources/mocks/payments/response/sender/alternative/get_payment_response.json
+++ b/src/test/resources/mocks/payments/response/sender/alternative/get_payment_response.json
@@ -1,0 +1,69 @@
+{
+  "id": "pay_mbabizu24mvu3mela5njyhpit4",
+  "action_id": "act_mbabizu24mvu3mela5njyhpit4",
+  "amount": 6540,
+  "currency": "USD",
+  "approved": true,
+  "status": "Authorized",
+  "auth_code": "770687",
+  "response_code": "10000",
+  "response_summary": "Approved",
+  "3ds": {
+    "downgraded": true,
+    "enrolled": "N"
+  },
+  "risk": {
+    "flagged": true
+  },
+  "source": {
+    "type": "card",
+    "id": "src_nwd3m4in3hkuddfpjsaevunhdy",
+    "billing_address": {
+      "address_line1": "Checkout.com",
+      "address_line2": "90 Tottenham Court Road",
+      "city": "London",
+      "state": "London",
+      "zip": "W1T 4TJ",
+      "country": "GB"
+    },
+    "phone": {
+      "country_code": "+1",
+      "number": "415 555 2671"
+    },
+    "last4": "4242",
+    "fingerprint": "F31828E2BDABAE63EB694903825CDD36041CC6ED461440B81415895855502832",
+    "bin": "424242"
+  },
+  "sender": {
+    "type": "xyz",
+    "company_name": "company"
+  },
+  "customer": {
+    "id": "cus_udst2tfldj6upmye2reztkmm4i",
+    "email": "brucewayne@gmail.com",
+    "name": "Bruce Wayne"
+  },
+  "processed_on": "2019-09-10T10:11:12Z",
+  "reference": "ORD-5023-4E89",
+  "processing": {
+    "retrieval_reference_number": "909913440644",
+    "acquirer_transaction_id": "440644309099499894406",
+    "recommendation_code": "02"
+  },
+  "eci": "06",
+  "scheme_id": "489341065491658",
+  "_links": {
+    "self": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4"
+    },
+    "action": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions"
+    },
+    "void": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids"
+    },
+    "capture": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures"
+    }
+  }
+}

--- a/src/test/resources/mocks/payments/response/sender/corporate/get_payment_response.json
+++ b/src/test/resources/mocks/payments/response/sender/corporate/get_payment_response.json
@@ -1,0 +1,69 @@
+{
+  "id": "pay_mbabizu24mvu3mela5njyhpit4",
+  "action_id": "act_mbabizu24mvu3mela5njyhpit4",
+  "amount": 6540,
+  "currency": "USD",
+  "approved": true,
+  "status": "Authorized",
+  "auth_code": "770687",
+  "response_code": "10000",
+  "response_summary": "Approved",
+  "3ds": {
+    "downgraded": true,
+    "enrolled": "N"
+  },
+  "risk": {
+    "flagged": true
+  },
+  "source": {
+    "type": "card",
+    "id": "src_nwd3m4in3hkuddfpjsaevunhdy",
+    "billing_address": {
+      "address_line1": "Checkout.com",
+      "address_line2": "90 Tottenham Court Road",
+      "city": "London",
+      "state": "London",
+      "zip": "W1T 4TJ",
+      "country": "GB"
+    },
+    "phone": {
+      "country_code": "+1",
+      "number": "415 555 2671"
+    },
+    "last4": "4242",
+    "fingerprint": "F31828E2BDABAE63EB694903825CDD36041CC6ED461440B81415895855502832",
+    "bin": "424242"
+  },
+  "sender": {
+    "type": "corporate",
+    "company_name": "company"
+  },
+  "customer": {
+    "id": "cus_udst2tfldj6upmye2reztkmm4i",
+    "email": "brucewayne@gmail.com",
+    "name": "Bruce Wayne"
+  },
+  "processed_on": "2019-09-10T10:11:12Z",
+  "reference": "ORD-5023-4E89",
+  "processing": {
+    "retrieval_reference_number": "909913440644",
+    "acquirer_transaction_id": "440644309099499894406",
+    "recommendation_code": "02"
+  },
+  "eci": "06",
+  "scheme_id": "489341065491658",
+  "_links": {
+    "self": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4"
+    },
+    "action": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions"
+    },
+    "void": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids"
+    },
+    "capture": {
+      "href": "https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures"
+    }
+  }
+}


### PR DESCRIPTION
It was found that `sender` deserialization was not properly configured which could lead to a deserialization problem if the payment response returns sender information.