### PR TITLE
Release 6.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.checkout
-version=5.9.8
+version=6.0.0
 
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
** Version 6.0.0 is here! **

* We improved the initialization of SDK making it easier to understand the available options.
* Now `NAS` accounts are the default instance for the SDK and `ABC` structure was moved to a previous prefixes.
* If you have been using this SDK before, you may find the following important changes:
  ** Marketplace module was moved to Accounts module, same for classes and references.
  ** In most cases, IDE can help you determine from where to import, but if you’re still having issues don't hesitate to open a ticket.