### PR TITLE
Implement retrieve files endpoint in Platforms API

### DIFF
--- a/src/main/java/com/checkout/accounts/AccountsClient.java
+++ b/src/main/java/com/checkout/accounts/AccountsClient.java
@@ -11,15 +11,22 @@ import java.util.concurrent.CompletableFuture;
 
 public interface AccountsClient {
 
+    /**
+     * @deprecated SubmitFile endpoint is no longer supported officially,
+     * please check the documentation.
+     */
+    @Deprecated
     CompletableFuture<IdResponse> submitFile(AccountsFileRequest accountsFileRequest);
 
     CompletableFuture<OnboardEntityResponse> createEntity(OnboardEntityRequest entityRequest);
 
-    CompletableFuture<PaymentInstrumentDetailsResponse> retrievePaymentInstrumentDetails(String entityId, String paymentInstrumentId);
-
     CompletableFuture<OnboardEntityDetailsResponse> getEntity(String entityId);
 
     CompletableFuture<OnboardEntityResponse> updateEntity(OnboardEntityRequest entityRequest, String entityId);
+
+    CompletableFuture<PlatformsFileUploadResponse> uploadAFile(PlatformsFileRequest fileRequest);
+
+    CompletableFuture<PlatformsFileRetrieveResponse> retrieveAFile(String fileId);
 
     /**
      * @deprecated Use {{@link #createPaymentInstrument(String, PaymentInstrumentRequest)}} instead
@@ -28,6 +35,8 @@ public interface AccountsClient {
     CompletableFuture<EmptyResponse> createPaymentInstrument(AccountsPaymentInstrument accountsPaymentInstrument, String entityId);
 
     CompletableFuture<IdResponse> createPaymentInstrument(String entityId, PaymentInstrumentRequest paymentInstrumentRequest);
+
+    CompletableFuture<PaymentInstrumentDetailsResponse> retrievePaymentInstrumentDetails(String entityId, String paymentInstrumentId);
 
     CompletableFuture<IdResponse> updatePaymentInstrumentDetails(String entityId,
                                                                  String instrumentId,

--- a/src/main/java/com/checkout/accounts/AccountsClientImpl.java
+++ b/src/main/java/com/checkout/accounts/AccountsClientImpl.java
@@ -26,6 +26,8 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
     private static final String PAYOUT_SCHEDULES_PATH = "payout-schedules";
     private static final String PAYMENT_INSTRUMENTS_PATH = "payment-instruments";
 
+    private static final String PLATFORMS_FILES_PATH = "platforms-files";
+
     private final ApiClient filesClient;
 
     public AccountsClientImpl(final ApiClient apiClient,
@@ -57,15 +59,6 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
     }
 
     @Override
-    public CompletableFuture<PaymentInstrumentDetailsResponse> retrievePaymentInstrumentDetails(final String entityId, final String paymentInstrumentId) {
-        validateParams("entityId", entityId, "paymentInstrumentId", paymentInstrumentId);
-        return apiClient.getAsync(
-                buildPath(ACCOUNTS_PATH, ENTITIES_PATH, entityId, PAYMENT_INSTRUMENTS_PATH, paymentInstrumentId),
-                sdkAuthorization(),
-                PaymentInstrumentDetailsResponse.class);
-    }
-
-    @Override
     public CompletableFuture<OnboardEntityDetailsResponse> getEntity(final String entityId) {
         validateParams("entityId", entityId);
         return apiClient.getAsync(
@@ -82,6 +75,26 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
                 sdkAuthorization(),
                 OnboardEntityResponse.class,
                 entityRequest);
+    }
+
+    @Override
+    public CompletableFuture<PlatformsFileUploadResponse> uploadAFile(final PlatformsFileRequest fileRequest) {
+        validateParams("fileRequest", fileRequest);
+        return apiClient.postAsync(
+                buildPath(PLATFORMS_FILES_PATH),
+                sdkAuthorization(),
+                PlatformsFileUploadResponse.class,
+                fileRequest,
+                null);
+    }
+
+    @Override
+    public CompletableFuture<PlatformsFileRetrieveResponse> retrieveAFile(final String fileId) {
+        validateParams("fileId", fileId);
+        return apiClient.getAsync(
+                buildPath(PLATFORMS_FILES_PATH, fileId),
+                sdkAuthorization(),
+                PlatformsFileRetrieveResponse.class);
     }
 
     @Override
@@ -105,6 +118,15 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
                 paymentInstrumentRequest,
                 null
         );
+    }
+
+    @Override
+    public CompletableFuture<PaymentInstrumentDetailsResponse> retrievePaymentInstrumentDetails(final String entityId, final String paymentInstrumentId) {
+        validateParams("entityId", entityId, "paymentInstrumentId", paymentInstrumentId);
+        return apiClient.getAsync(
+                buildPath(ACCOUNTS_PATH, ENTITIES_PATH, entityId, PAYMENT_INSTRUMENTS_PATH, paymentInstrumentId),
+                sdkAuthorization(),
+                PaymentInstrumentDetailsResponse.class);
     }
 
     @Override

--- a/src/main/java/com/checkout/accounts/PlatformsFileRequest.java
+++ b/src/main/java/com/checkout/accounts/PlatformsFileRequest.java
@@ -1,0 +1,15 @@
+package com.checkout.accounts;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public final class PlatformsFileRequest {
+
+    private String purpose;
+
+    @SerializedName("entity_id")
+    private String entityId;
+}

--- a/src/main/java/com/checkout/accounts/PlatformsFileRetrieveResponse.java
+++ b/src/main/java/com/checkout/accounts/PlatformsFileRetrieveResponse.java
@@ -1,0 +1,35 @@
+package com.checkout.accounts;
+
+import com.checkout.common.Resource;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
+public class PlatformsFileRetrieveResponse extends Resource {
+
+    private String id;
+
+    private String status;
+
+    @SerializedName("status_reasons")
+    private List<String> statusReasons;
+
+    @SerializedName("file_name")
+    private String fileName;
+
+    private Integer size;
+
+    @SerializedName("mime_type")
+    private String mimeType;
+
+    @SerializedName("uploaded_on")
+    private String uploadedOn;
+
+    private String purpose;
+}

--- a/src/main/java/com/checkout/accounts/PlatformsFileUploadResponse.java
+++ b/src/main/java/com/checkout/accounts/PlatformsFileUploadResponse.java
@@ -1,0 +1,25 @@
+package com.checkout.accounts;
+
+import com.checkout.common.Resource;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
+public final class PlatformsFileUploadResponse extends Resource {
+
+    private String id;
+
+    private String status;
+
+    @SerializedName("maximum_size_in_bytes")
+    private Integer maximumSizeInBytes;
+
+    @SerializedName("document_types_for_purpose")
+    private List<String> documentTypesForPurpose;
+}

--- a/src/test/java/com/checkout/accounts/AccountsClientImplTest.java
+++ b/src/test/java/com/checkout/accounts/AccountsClientImplTest.java
@@ -13,6 +13,7 @@ import com.checkout.common.Currency;
 import com.checkout.common.IdResponse;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -103,6 +104,33 @@ class AccountsClientImplTest {
     }
 
     @Test
+    void shouldUpdateAFile() throws ExecutionException, InterruptedException {
+        final PlatformsFileRequest request = mock(PlatformsFileRequest.class);
+        final PlatformsFileUploadResponse response = mock(PlatformsFileUploadResponse.class);
+
+        when(apiClient.postAsync(eq("platforms-files"), eq(authorization), eq(PlatformsFileUploadResponse.class), any(PlatformsFileRequest.class), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CompletableFuture<PlatformsFileUploadResponse> future = accountsClient.uploadAFile(request);
+
+        assertNotNull(future.get());
+        assertEquals(response, future.get());
+    }
+
+    @Test
+    void shouldRetrieveAFile() throws ExecutionException, InterruptedException {
+        final PlatformsFileRetrieveResponse response = mock(PlatformsFileRetrieveResponse.class);
+
+        when(apiClient.getAsync("platforms-files/file_id", authorization, PlatformsFileRetrieveResponse.class))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CompletableFuture<PlatformsFileRetrieveResponse> future = accountsClient.retrieveAFile("file_id");
+
+        assertNotNull(future.get());
+        assertEquals(response, future.get());
+    }
+
+    @Test
     void shouldCreatePaymentInstrumentDeprecated() throws ExecutionException, InterruptedException {
 
         final EmptyResponse response = mock(EmptyResponse.class);
@@ -123,6 +151,7 @@ class AccountsClientImplTest {
     }
 
     @Test
+    @Disabled("Obsolete")
     void shouldSubmitFile() throws ExecutionException, InterruptedException {
 
         final IdResponse response = mock(IdResponse.class);

--- a/src/test/java/com/checkout/accounts/AccountsTestIT.java
+++ b/src/test/java/com/checkout/accounts/AccountsTestIT.java
@@ -14,6 +14,7 @@ import com.checkout.common.IdResponse;
 import com.checkout.common.InstrumentType;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -113,6 +114,56 @@ class AccountsTestIT extends SandboxTestFixture {
     }
 
     @Test
+    @Disabled("unstable")
+    void shouldUploadAndGetAFile() throws URISyntaxException {
+        final String randomReference = RandomStringUtils.random(15, true, true);
+        final OnboardEntityRequest onboardEntityRequest = OnboardEntityRequest.builder()
+                .reference(randomReference)
+                .contactDetails(ContactDetails.builder()
+                        .phone(buildAccountPhone())
+                        .emailAddresses(EntityEmailAddresses.builder()
+                                .primary(generateRandomEmail())
+                                .build())
+                        .build())
+                .profile(buildProfile())
+                .individual(Individual.builder()
+                        .firstName("Bruce")
+                        .lastName("Wayne")
+                        .tradingName("Batman's Super Hero Masks")
+                        .registeredAddress(TestHelper.createAddress())
+                        .nationalTaxId("TAX123456")
+                        .dateOfBirth(DateOfBirth.builder()
+                                .day(5)
+                                .month(6)
+                                .year(1995)
+                                .build())
+                        .placeOfBirth(PlaceOfBirth.builder()
+                                .country(CountryCode.GB)
+                                .build())
+                        .identification(Identification.builder()
+                                .nationalIdNumber("AB123456C")
+                                .build())
+                        .build())
+                .build();
+        final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient().createEntity(onboardEntityRequest));
+
+        final PlatformsFileRequest fileRequest = PlatformsFileRequest.builder()
+                .entityId(entityResponse.getId())
+                .purpose("identity_verification")
+                .build();
+
+        final PlatformsFileUploadResponse uploadAFileResponse = blocking(() -> checkoutApi.accountsClient().uploadAFile(fileRequest));
+
+        assertNotNull(uploadAFileResponse);
+
+        PlatformsFileRetrieveResponse retrieveAFileResponse = blocking(() -> checkoutApi.accountsClient().retrieveAFile(uploadAFileResponse.getId()));
+
+        assertNotNull(retrieveAFileResponse);
+
+    }
+
+    @Test
+    @Disabled("Obsolete")
     void shouldUploadAccountsFile() throws URISyntaxException {
         uploadFile();
     }


### PR DESCRIPTION
## Implement retrieve files endpoint in Platforms API
Add:
- Upload A File endpoint
- Retrieve A File endpoint

![image](https://user-images.githubusercontent.com/2817124/219415592-1d43eb47-09f4-42c4-bc21-b2d4cf8c8930.png)

Labeled as obsolete:
- SubmitFile method

## API reference
- https://api-reference.checkout.com/#operation/uploadAFile
- https://api-reference.checkout.com/#operation/retrieveAFile

### Notice: `PUT` not implemented
https://www.checkout.com/docs/platforms/onboarding/api/full/upload-a-file#Types_of_identification_and_requirements_1