### PR TITLE
Adds support for Card Controls operations [Issuing] (CS2)

### DIFF
--- a/src/main/java/com/checkout/ApiClient.java
+++ b/src/main/java/com/checkout/ApiClient.java
@@ -26,6 +26,8 @@ public interface ApiClient {
 
     CompletableFuture<EmptyResponse> deleteAsync(String path, SdkAuthorization authorization);
 
+    <T extends HttpMetadata> CompletableFuture<T> deleteAsync(String path, SdkAuthorization authorization, Class<T> responseType);
+
     <T extends HttpMetadata> CompletableFuture<T> queryAsync(String path, SdkAuthorization authorization, Object filter, Class<T> responseType);
 
     CompletableFuture<ContentResponse> queryCsvContentAsync(String path, SdkAuthorization authorization, Object filter, String targetFile);

--- a/src/main/java/com/checkout/ApiClientImpl.java
+++ b/src/main/java/com/checkout/ApiClientImpl.java
@@ -85,6 +85,12 @@ public class ApiClientImpl implements ApiClient {
     }
 
     @Override
+    public <T extends HttpMetadata> CompletableFuture<T> deleteAsync(String path, SdkAuthorization authorization, Class<T> responseType) {
+        validateParams(PATH, path, AUTHORIZATION, authorization);
+        return sendRequestAsync(DELETE, path, authorization, null, null, responseType);
+    }
+
+    @Override
     public CompletableFuture<? extends HttpMetadata> postAsync(final String path, final SdkAuthorization authorization, final Map<Integer, Class<? extends HttpMetadata>> resultTypeMappings, final Object request, final String idempotencyKey) {
         validateParams(PATH, path, AUTHORIZATION, authorization, "resultTypeMappings", resultTypeMappings);
         return transport.invoke(POST, path, authorization, serializer.toJson(request), idempotencyKey, null)

--- a/src/main/java/com/checkout/GsonSerializer.java
+++ b/src/main/java/com/checkout/GsonSerializer.java
@@ -13,6 +13,10 @@ import com.checkout.issuing.cards.CardType;
 import com.checkout.issuing.cards.responses.AbstractCardDetailsResponse;
 import com.checkout.issuing.cards.responses.PhysicalCardDetailsResponse;
 import com.checkout.issuing.cards.responses.VirtualCardDetailsResponse;
+import com.checkout.issuing.controls.requests.ControlType;
+import com.checkout.issuing.controls.responses.create.AbstractCardControlResponse;
+import com.checkout.issuing.controls.responses.create.MccCardControlResponse;
+import com.checkout.issuing.controls.responses.create.VelocityCardControlResponse;
 import com.checkout.payments.PaymentDestinationType;
 import com.checkout.payments.previous.PaymentAction;
 import com.checkout.payments.sender.Sender;
@@ -119,6 +123,10 @@ public class GsonSerializer implements Serializer {
             .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(AbstractCardDetailsResponse.class, CheckoutUtils.TYPE)
                     .registerSubtype(PhysicalCardDetailsResponse.class, identifier(CardType.PHYSICAL))
                     .registerSubtype(VirtualCardDetailsResponse.class, identifier(CardType.VIRTUAL)))
+            // Issuing CS2 - CardControlsResponse
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(AbstractCardControlResponse.class, "control_type")
+                    .registerSubtype(VelocityCardControlResponse.class, identifier(ControlType.VELOCITY_LIMIT))
+                    .registerSubtype(MccCardControlResponse.class, identifier(ControlType.MCC_LIMIT)))
             // Adapters when API returns an array
             .registerTypeAdapter(EVENT_TYPES_TYPE, eventTypesResponseDeserializer())
             .registerTypeAdapter(WORKFLOWS_EVENT_TYPES_TYPE, workflowEventTypesResponseDeserializer())

--- a/src/main/java/com/checkout/issuing/IssuingClient.java
+++ b/src/main/java/com/checkout/issuing/IssuingClient.java
@@ -1,5 +1,6 @@
 package com.checkout.issuing;
 
+import com.checkout.common.IdResponse;
 import com.checkout.issuing.cardholders.CardholderCardsResponse;
 import com.checkout.issuing.cardholders.CardholderDetailsResponse;
 import com.checkout.issuing.cardholders.CardholderRequest;
@@ -16,6 +17,11 @@ import com.checkout.issuing.cards.responses.credentials.CardCredentialsResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSEnrollmentDetailsResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSEnrollmentResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSUpdateResponse;
+import com.checkout.issuing.controls.requests.create.AbstractCardControlRequest;
+import com.checkout.issuing.controls.requests.query.CardControlsQuery;
+import com.checkout.issuing.controls.requests.update.UpdateCardControlRequest;
+import com.checkout.issuing.controls.responses.create.AbstractCardControlResponse;
+import com.checkout.issuing.controls.responses.query.CardControlsQueryResponse;
 import com.checkout.payments.VoidResponse;
 
 import java.util.concurrent.CompletableFuture;
@@ -45,4 +51,14 @@ public interface IssuingClient {
     CompletableFuture<VoidResponse> revokeCard(final String cardId, final RevokeCardRequest revokeCardRequest);
 
     CompletableFuture<VoidResponse> suspendCard(final String cardId, final SuspendCardRequest suspendCardRequest);
+
+    CompletableFuture<AbstractCardControlResponse> createControl(final AbstractCardControlRequest cardControlRequest);
+
+    CompletableFuture<CardControlsQueryResponse> getCardControls(final CardControlsQuery queryFilter);
+
+    CompletableFuture<AbstractCardControlResponse> getCardControlDetails(final String controlId);
+
+    CompletableFuture<AbstractCardControlResponse> updateCardControl(final String controlId, final UpdateCardControlRequest updateCardControlRequest);
+
+    CompletableFuture<IdResponse> removeCardControl(final String controlId);
 }

--- a/src/main/java/com/checkout/issuing/IssuingClientImpl.java
+++ b/src/main/java/com/checkout/issuing/IssuingClientImpl.java
@@ -4,6 +4,7 @@ import com.checkout.AbstractClient;
 import com.checkout.ApiClient;
 import com.checkout.CheckoutConfiguration;
 import com.checkout.SdkAuthorizationType;
+import com.checkout.common.IdResponse;
 import com.checkout.issuing.cardholders.CardholderCardsResponse;
 import com.checkout.issuing.cardholders.CardholderDetailsResponse;
 import com.checkout.issuing.cardholders.CardholderRequest;
@@ -20,6 +21,11 @@ import com.checkout.issuing.cards.responses.credentials.CardCredentialsResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSEnrollmentDetailsResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSEnrollmentResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSUpdateResponse;
+import com.checkout.issuing.controls.requests.create.AbstractCardControlRequest;
+import com.checkout.issuing.controls.requests.query.CardControlsQuery;
+import com.checkout.issuing.controls.requests.update.UpdateCardControlRequest;
+import com.checkout.issuing.controls.responses.create.AbstractCardControlResponse;
+import com.checkout.issuing.controls.responses.query.CardControlsQueryResponse;
 import com.checkout.payments.VoidResponse;
 
 import java.util.concurrent.CompletableFuture;
@@ -43,6 +49,8 @@ public class IssuingClientImpl extends AbstractClient implements IssuingClient {
     private static final String REVOKE_PATH = "revoke";
 
     private static final String SUSPEND_PATH = "suspend";
+
+    private static final String CONTROLS_PATH = "controls";
 
     public IssuingClientImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
         super(apiClient, configuration, SdkAuthorizationType.SECRET_KEY_OR_OAUTH);
@@ -191,6 +199,66 @@ public class IssuingClientImpl extends AbstractClient implements IssuingClient {
                 VoidResponse.class,
                 suspendCardRequest,
                 null
+        );
+    }
+
+    @Override
+    public CompletableFuture<AbstractCardControlResponse> createControl(
+            final AbstractCardControlRequest cardControlRequest
+    ) {
+        validateParams("cardControlRequest", cardControlRequest);
+        return apiClient.postAsync(
+                buildPath(ISSUING_PATH, CONTROLS_PATH),
+                sdkAuthorization(),
+                AbstractCardControlResponse.class,
+                cardControlRequest,
+                null
+        );
+    }
+
+    @Override
+    public CompletableFuture<CardControlsQueryResponse> getCardControls(
+            final CardControlsQuery queryFilter
+    ) {
+        validateParams("queryFilter", queryFilter);
+        return apiClient.queryAsync(
+                buildPath(ISSUING_PATH, CONTROLS_PATH),
+                sdkAuthorization(),
+                queryFilter,
+                CardControlsQueryResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<AbstractCardControlResponse> getCardControlDetails(final String controlId) {
+        validateParams("controlId", controlId);
+        return apiClient.getAsync(
+                buildPath(ISSUING_PATH, CONTROLS_PATH, controlId),
+                sdkAuthorization(),
+                AbstractCardControlResponse.class
+        );
+    }
+
+    @Override
+    public CompletableFuture<AbstractCardControlResponse> updateCardControl(
+            final String controlId,
+            final UpdateCardControlRequest updateCardControlRequest
+    ) {
+        validateParams("controlId", controlId, "updateCardControlRequest", updateCardControlRequest);
+        return apiClient.putAsync(
+                buildPath(ISSUING_PATH, CONTROLS_PATH, controlId),
+                sdkAuthorization(),
+                AbstractCardControlResponse.class,
+                updateCardControlRequest
+        );
+    }
+
+    @Override
+    public CompletableFuture<IdResponse> removeCardControl(final String controlId) {
+        validateParams("controlId", controlId);
+        return apiClient.deleteAsync(
+                buildPath(ISSUING_PATH, CONTROLS_PATH, controlId),
+                sdkAuthorization(),
+                IdResponse.class
         );
     }
 }

--- a/src/main/java/com/checkout/issuing/cards/requests/enrollment/SecurityQuestionThreeDSEnrollmentRequest.java
+++ b/src/main/java/com/checkout/issuing/cards/requests/enrollment/SecurityQuestionThreeDSEnrollmentRequest.java
@@ -2,7 +2,11 @@ package com.checkout.issuing.cards.requests.enrollment;
 
 import com.checkout.common.Phone;
 import com.google.gson.annotations.SerializedName;
-import lombok.*;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter

--- a/src/main/java/com/checkout/issuing/controls/requests/ControlType.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/ControlType.java
@@ -1,0 +1,12 @@
+package com.checkout.issuing.controls.requests;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum ControlType {
+
+    @SerializedName("velocity_limit")
+    VELOCITY_LIMIT,
+    @SerializedName("mcc_limit")
+    MCC_LIMIT
+
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/MccControlType.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/MccControlType.java
@@ -1,0 +1,12 @@
+package com.checkout.issuing.controls.requests;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum MccControlType {
+
+    @SerializedName("allow")
+    ALLOW,
+    @SerializedName("block")
+    BLOCK
+
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/MccLimit.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/MccLimit.java
@@ -1,0 +1,17 @@
+package com.checkout.issuing.controls.requests;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class MccLimit {
+
+    private MccControlType type;
+
+    @SerializedName("mcc_list")
+    private List<String> mccList;
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/VelocityLimit.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/VelocityLimit.java
@@ -1,0 +1,21 @@
+package com.checkout.issuing.controls.requests;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class VelocityLimit {
+
+    @SerializedName("amount_limit")
+    private Integer amountLimit;
+
+    @SerializedName("velocity_window")
+    private VelocityWindow velocityWindow;
+
+    @SerializedName("mcc_list")
+    private List<String> mccList;
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/VelocityWindow.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/VelocityWindow.java
@@ -1,0 +1,11 @@
+package com.checkout.issuing.controls.requests;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class VelocityWindow {
+
+    private VelocityWindowType type;
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/VelocityWindowType.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/VelocityWindowType.java
@@ -1,0 +1,16 @@
+package com.checkout.issuing.controls.requests;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum VelocityWindowType {
+
+    @SerializedName("daily")
+    DAILY,
+    @SerializedName("weekly")
+    WEEKLY,
+    @SerializedName("monthly")
+    MONTHLY,
+    @SerializedName("all_time")
+    ALL_TIME
+
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/create/AbstractCardControlRequest.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/create/AbstractCardControlRequest.java
@@ -1,0 +1,23 @@
+package com.checkout.issuing.controls.requests.create;
+
+import com.checkout.issuing.controls.requests.ControlType;
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public abstract class AbstractCardControlRequest {
+
+    @SerializedName("control_type")
+    private final ControlType controlType;
+
+    private String description;
+
+    @SerializedName("target_id")
+    private String targetId;
+
+    protected AbstractCardControlRequest(final ControlType controlType) {
+        this.controlType = controlType;
+    }
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/create/MccCardControlRequest.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/create/MccCardControlRequest.java
@@ -1,0 +1,34 @@
+package com.checkout.issuing.controls.requests.create;
+
+import com.checkout.issuing.controls.requests.ControlType;
+import com.checkout.issuing.controls.requests.MccLimit;
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class MccCardControlRequest extends AbstractCardControlRequest {
+
+    @SerializedName("mcc_limit")
+    private MccLimit mccLimit;
+
+    @Builder
+    public MccCardControlRequest(
+            MccLimit mccLimit,
+            String description,
+            String targetId
+    ) {
+        super(ControlType.MCC_LIMIT, description, targetId);
+        this.mccLimit = mccLimit;
+    }
+
+    public MccCardControlRequest() {
+        super(ControlType.MCC_LIMIT);
+    }
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/create/VelocityCardControlRequest.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/create/VelocityCardControlRequest.java
@@ -1,0 +1,34 @@
+package com.checkout.issuing.controls.requests.create;
+
+import com.checkout.issuing.controls.requests.ControlType;
+import com.checkout.issuing.controls.requests.VelocityLimit;
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class VelocityCardControlRequest extends AbstractCardControlRequest {
+
+    @SerializedName("velocity_limit")
+    private VelocityLimit velocityLimit;
+
+    @Builder
+    public VelocityCardControlRequest(
+            VelocityLimit velocityLimit,
+            String description,
+            String targetId
+    ) {
+        super(ControlType.VELOCITY_LIMIT, description, targetId);
+        this.velocityLimit = velocityLimit;
+    }
+
+    public VelocityCardControlRequest() {
+        super(ControlType.VELOCITY_LIMIT);
+    }
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/query/CardControlsQuery.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/query/CardControlsQuery.java
@@ -1,0 +1,13 @@
+package com.checkout.issuing.controls.requests.query;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CardControlsQuery {
+
+    @SerializedName("target_id")
+    private String targetId;
+}

--- a/src/main/java/com/checkout/issuing/controls/requests/update/UpdateCardControlRequest.java
+++ b/src/main/java/com/checkout/issuing/controls/requests/update/UpdateCardControlRequest.java
@@ -1,0 +1,20 @@
+package com.checkout.issuing.controls.requests.update;
+
+import com.checkout.issuing.controls.requests.MccLimit;
+import com.checkout.issuing.controls.requests.VelocityLimit;
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UpdateCardControlRequest {
+
+    private String description;
+
+    @SerializedName("velocity_limit")
+    private VelocityLimit velocityLimit;
+
+    @SerializedName("mcc_limit")
+    private MccLimit mccLimit;
+}

--- a/src/main/java/com/checkout/issuing/controls/responses/create/AbstractCardControlResponse.java
+++ b/src/main/java/com/checkout/issuing/controls/responses/create/AbstractCardControlResponse.java
@@ -1,0 +1,37 @@
+package com.checkout.issuing.controls.responses.create;
+
+import com.checkout.HttpMetadata;
+import com.checkout.issuing.controls.requests.ControlType;
+import com.google.gson.annotations.SerializedName;
+import lombok.*;
+
+import java.time.Instant;
+
+@Data
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public abstract class AbstractCardControlResponse extends HttpMetadata {
+
+    @SerializedName("control_type")
+    private final ControlType controlType;
+
+    private String id;
+
+    private String description;
+
+    @SerializedName("target_id")
+    private String targetId;
+
+    @SerializedName("created_date")
+    private Instant createdDate;
+
+    @SerializedName("last_modified_date")
+    private Instant lastModifiedDate;
+
+    protected AbstractCardControlResponse(final ControlType controlType) {
+        this.controlType = controlType;
+    }
+
+}

--- a/src/main/java/com/checkout/issuing/controls/responses/create/MccCardControlResponse.java
+++ b/src/main/java/com/checkout/issuing/controls/responses/create/MccCardControlResponse.java
@@ -1,0 +1,25 @@
+package com.checkout.issuing.controls.responses.create;
+
+import com.checkout.issuing.controls.requests.ControlType;
+import com.checkout.issuing.controls.requests.MccLimit;
+import com.google.gson.annotations.SerializedName;
+import lombok.*;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class MccCardControlResponse extends AbstractCardControlResponse {
+
+    @SerializedName("mcc_limit")
+    private MccLimit mccLimit;
+
+    public MccCardControlResponse(ControlType controlType) {
+        super(controlType);
+    }
+
+    public MccCardControlResponse(MccLimit mccLimit) {
+        super(ControlType.MCC_LIMIT);
+        this.mccLimit = mccLimit;
+    }
+}

--- a/src/main/java/com/checkout/issuing/controls/responses/create/VelocityCardControlResponse.java
+++ b/src/main/java/com/checkout/issuing/controls/responses/create/VelocityCardControlResponse.java
@@ -1,0 +1,28 @@
+package com.checkout.issuing.controls.responses.create;
+
+import com.checkout.issuing.controls.requests.ControlType;
+import com.checkout.issuing.controls.requests.VelocityLimit;
+import com.google.gson.annotations.SerializedName;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class VelocityCardControlResponse extends AbstractCardControlResponse {
+
+    @SerializedName("velocity_limit")
+    private VelocityLimit velocityLimit;
+
+    public VelocityCardControlResponse() {
+        super(ControlType.VELOCITY_LIMIT);
+    }
+
+    public VelocityCardControlResponse(VelocityLimit velocityLimit) {
+        super(ControlType.VELOCITY_LIMIT);
+        this.velocityLimit = velocityLimit;
+    }
+}

--- a/src/main/java/com/checkout/issuing/controls/responses/query/CardControlsQueryResponse.java
+++ b/src/main/java/com/checkout/issuing/controls/responses/query/CardControlsQueryResponse.java
@@ -1,0 +1,17 @@
+package com.checkout.issuing.controls.responses.query;
+
+import com.checkout.HttpMetadata;
+import com.checkout.issuing.controls.responses.create.AbstractCardControlResponse;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class CardControlsQueryResponse extends HttpMetadata {
+
+    private List<AbstractCardControlResponse> controls;
+}

--- a/src/test/java/com/checkout/issuing/IssuingClientImplTest.java
+++ b/src/test/java/com/checkout/issuing/IssuingClientImplTest.java
@@ -5,6 +5,8 @@ import com.checkout.CheckoutConfiguration;
 import com.checkout.SdkAuthorization;
 import com.checkout.SdkAuthorizationType;
 import com.checkout.SdkCredentials;
+import com.checkout.common.IdResponse;
+import com.checkout.issuing.cardholders.CardholderCardsResponse;
 import com.checkout.issuing.cardholders.CardholderDetailsResponse;
 import com.checkout.issuing.cardholders.CardholderRequest;
 import com.checkout.issuing.cardholders.CardholderResponse;
@@ -20,6 +22,11 @@ import com.checkout.issuing.cards.responses.credentials.CardCredentialsResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSEnrollmentDetailsResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSEnrollmentResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSUpdateResponse;
+import com.checkout.issuing.controls.requests.create.AbstractCardControlRequest;
+import com.checkout.issuing.controls.requests.query.CardControlsQuery;
+import com.checkout.issuing.controls.requests.update.UpdateCardControlRequest;
+import com.checkout.issuing.controls.responses.create.AbstractCardControlResponse;
+import com.checkout.issuing.controls.responses.query.CardControlsQueryResponse;
 import com.checkout.payments.VoidResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -101,15 +108,15 @@ public class IssuingClientImplTest {
 
         @Test
         void shouldGetCardholderCards() throws ExecutionException, InterruptedException {
-            final CardholderDetailsResponse response = mock(CardholderDetailsResponse.class);
+            final CardholderCardsResponse response = mock(CardholderCardsResponse.class);
 
             when(apiClient.getAsync(
-                    "issuing/cardholders/cardholder_id",
+                    "issuing/cardholders/cardholder_id/cards",
                     authorization,
-                    CardholderDetailsResponse.class))
+                    CardholderCardsResponse.class))
                     .thenReturn(CompletableFuture.completedFuture(response));
 
-            final CompletableFuture<CardholderDetailsResponse> future = client.getCardholder("cardholder_id");
+            final CompletableFuture<CardholderCardsResponse> future = client.getCardholderCards("cardholder_id");
 
             assertNotNull(future.get());
             assertEquals(response, future.get());
@@ -277,6 +284,96 @@ public class IssuingClientImplTest {
             )).thenReturn(CompletableFuture.completedFuture(response));
 
             final CompletableFuture<VoidResponse> future = client.suspendCard("card_id", request);
+
+            assertNotNull(future.get());
+            assertEquals(response, future.get());
+        }
+    }
+
+    @Nested
+    @DisplayName("Controls")
+    class Controls {
+        @Test
+        void shouldCreateControl() throws ExecutionException, InterruptedException {
+            final AbstractCardControlRequest request = mock(AbstractCardControlRequest.class);
+            final AbstractCardControlResponse response = mock(AbstractCardControlResponse.class);
+
+            when(apiClient.postAsync(
+                    "issuing/controls",
+                    authorization,
+                    AbstractCardControlResponse.class,
+                    request,
+                    null
+            )).thenReturn(CompletableFuture.completedFuture(response));
+
+            final CompletableFuture<AbstractCardControlResponse> future = client.createControl(request);
+
+            assertNotNull(future.get());
+            assertEquals(response, future.get());
+        }
+
+        @Test
+        void shouldGetCardControls() throws ExecutionException, InterruptedException {
+            final CardControlsQuery query = mock(CardControlsQuery.class);
+            final CardControlsQueryResponse response = mock(CardControlsQueryResponse.class);
+
+            when(apiClient.queryAsync(
+                    "issuing/controls",
+                    authorization,
+                    query,
+                    CardControlsQueryResponse.class
+            )).thenReturn(CompletableFuture.completedFuture(response));
+
+            final CompletableFuture<CardControlsQueryResponse> future = client.getCardControls(query);
+
+            assertNotNull(future.get());
+            assertEquals(response, future.get());
+        }
+
+        @Test
+        void shouldGetCardControlDetails() throws ExecutionException, InterruptedException {
+            final AbstractCardControlResponse response = mock(AbstractCardControlResponse.class);
+
+            when(apiClient.getAsync(
+                    "issuing/controls/control_id",
+                    authorization,
+                    AbstractCardControlResponse.class
+            )).thenReturn(CompletableFuture.completedFuture(response));
+
+            final CompletableFuture<AbstractCardControlResponse> future = client.getCardControlDetails("control_id");
+
+            assertNotNull(future.get());
+            assertEquals(response, future.get());
+        }
+
+        void shouldUpdateCardControl() throws ExecutionException, InterruptedException {
+            final UpdateCardControlRequest request = mock(UpdateCardControlRequest.class);
+            final AbstractCardControlResponse response = mock(AbstractCardControlResponse.class);
+
+            when(apiClient.putAsync(
+                    "issuing/controls/control_id",
+                    authorization,
+                    AbstractCardControlResponse.class,
+                    request
+            )).thenReturn(CompletableFuture.completedFuture(response));
+
+            final CompletableFuture<AbstractCardControlResponse> future = client.updateCardControl("control_id", request);
+
+            assertNotNull(future.get());
+            assertEquals(response, future.get());
+        }
+
+        @Test
+        void shouldRemoveCardControlDetails() throws ExecutionException, InterruptedException {
+            final IdResponse response = mock(IdResponse.class);
+
+            when(apiClient.deleteAsync(
+                    "issuing/controls/control_id",
+                    authorization,
+                    IdResponse.class
+            )).thenReturn(CompletableFuture.completedFuture(response));
+
+            final CompletableFuture<IdResponse> future = client.removeCardControl("control_id");
 
             assertNotNull(future.get());
             assertEquals(response, future.get());

--- a/src/test/java/com/checkout/issuing/IssuingTestIT.java
+++ b/src/test/java/com/checkout/issuing/IssuingTestIT.java
@@ -8,6 +8,7 @@ import com.checkout.PlatformType;
 import com.checkout.SandboxTestFixture;
 import com.checkout.TestHelper;
 import com.checkout.common.DocumentType;
+import com.checkout.common.IdResponse;
 import com.checkout.issuing.cardholders.CardholderCardsResponse;
 import com.checkout.issuing.cardholders.CardholderDetailsResponse;
 import com.checkout.issuing.cardholders.CardholderDocument;
@@ -33,12 +34,28 @@ import com.checkout.issuing.cards.responses.credentials.CardCredentialsResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSEnrollmentDetailsResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSEnrollmentResponse;
 import com.checkout.issuing.cards.responses.enrollment.ThreeDSUpdateResponse;
+import com.checkout.issuing.controls.requests.ControlType;
+import com.checkout.issuing.controls.requests.VelocityLimit;
+import com.checkout.issuing.controls.requests.VelocityWindow;
+import com.checkout.issuing.controls.requests.VelocityWindowType;
+import com.checkout.issuing.controls.requests.create.AbstractCardControlRequest;
+import com.checkout.issuing.controls.requests.create.VelocityCardControlRequest;
+import com.checkout.issuing.controls.requests.query.CardControlsQuery;
+import com.checkout.issuing.controls.requests.update.UpdateCardControlRequest;
+import com.checkout.issuing.controls.responses.create.AbstractCardControlResponse;
+import com.checkout.issuing.controls.responses.query.CardControlsQueryResponse;
 import com.checkout.payments.VoidResponse;
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -48,12 +65,15 @@ public class IssuingTestIT extends SandboxTestFixture {
 
     private CardResponse card;
 
+    private AbstractCardControlResponse control;
+
     public IssuingTestIT() { super(PlatformType.DEFAULT_OAUTH); }
 
     @BeforeAll
     void setUp() {
         cardholder = createCardholder();
         card = createCard(cardholder.getId());
+        control = createCardControl(card.getId());
     }
 
     @Nested
@@ -300,6 +320,102 @@ public class IssuingTestIT extends SandboxTestFixture {
         }
     }
 
+    @Nested
+    @DisplayName("Controls")
+    class Controls {
+        @Test
+        void shouldCreateControl() {
+            final CardholderResponse cardholder = createCardholder();
+            final CardResponse card = createCard(cardholder.getId());
+
+            final AbstractCardControlRequest request = VelocityCardControlRequest.builder()
+                    .description("Max spend of 500€ per week for restaurants")
+                    .targetId(card.getId())
+                    .velocityLimit(VelocityLimit.builder()
+                            .amountLimit(500)
+                            .velocityWindow(VelocityWindow.builder()
+                                    .type(VelocityWindowType.WEEKLY)
+                                    .build())
+                            .build())
+                    .build();
+
+            final AbstractCardControlResponse cardControlResponse = blocking(() ->
+                    getIssuingCheckoutApi()
+                            .issuingClient()
+                            .createControl(request));
+
+            assertNotNull(cardControlResponse);
+            assertEquals(card.getId(), cardControlResponse.getTargetId());
+            assertEquals(ControlType.VELOCITY_LIMIT, cardControlResponse.getControlType());
+        }
+
+        @Test
+        void shouldGetCardControls() {
+            final CardControlsQuery query = CardControlsQuery.builder()
+                    .targetId(card.getId())
+                    .build();
+
+            final CardControlsQueryResponse response = blocking(() ->
+                    getIssuingCheckoutApi()
+                            .issuingClient()
+                            .getCardControls(query));
+
+            assertNotNull(response);
+            for (AbstractCardControlResponse control : response.getControls()) {
+                assertEquals(card.getId(), control.getTargetId());
+            }
+        }
+
+        @Test
+        @Disabled("not-found")
+        void shouldGetCardControlDetails() {
+            final AbstractCardControlResponse response = blocking(() ->
+                    getIssuingCheckoutApi()
+                            .issuingClient()
+                            .getCardControlDetails(control.getId()));
+
+            assertNotNull(response);
+            assertEquals(control.getId(), response.getId());
+            assertEquals(card.getId(), response.getTargetId());
+            assertEquals(ControlType.VELOCITY_LIMIT, response.getControlType());
+        }
+
+        @Test
+        @Disabled("not-found")
+        void shouldUpdateCardControl() {
+            final UpdateCardControlRequest request = UpdateCardControlRequest.builder()
+                    .description("New max spend of 1000€ per month for restaurants")
+                    .velocityLimit(VelocityLimit.builder()
+                            .amountLimit(1000)
+                            .velocityWindow(VelocityWindow.builder()
+                                    .type(VelocityWindowType.MONTHLY)
+                                    .build())
+                            .build())
+                    .build();
+
+            final AbstractCardControlResponse response = blocking(() ->
+                    getIssuingCheckoutApi()
+                            .issuingClient()
+                            .updateCardControl(control.getId(), request));
+
+            assertNotNull(response);
+            assertEquals(control.getId(), response.getId());
+            assertEquals("New max spend of 1000€ per month for restaurants", request.getDescription());
+            assertEquals(ControlType.VELOCITY_LIMIT, response.getControlType());
+        }
+
+        @Test
+        void shouldRemoveCardControl() {
+            final IdResponse response = blocking(() ->
+                    getIssuingCheckoutApi()
+                            .issuingClient()
+                            .removeCardControl(control.getId()));
+
+            assertNotNull(response);
+            assertEquals(control.getId(), response.getId());
+        }
+    }
+
     private CardholderResponse createCardholder() {
         final CardholderRequest cardholderRequest = CardholderRequest.builder()
                 .type(CardholderType.INDIVIDUAL)
@@ -357,6 +473,28 @@ public class IssuingTestIT extends SandboxTestFixture {
         assertNotNull(cardResponse);
 
         return cardResponse;
+    }
+
+    private AbstractCardControlResponse createCardControl(String cardId) {
+        final AbstractCardControlRequest request = VelocityCardControlRequest.builder()
+                .description("Max spend of 500€ per week for restaurants")
+                .targetId(cardId)
+                .velocityLimit(VelocityLimit.builder()
+                        .amountLimit(500)
+                        .velocityWindow(VelocityWindow.builder()
+                                .type(VelocityWindowType.WEEKLY)
+                                .build())
+                        .build())
+                .build();
+
+        final AbstractCardControlResponse cardControlResponse = blocking(() ->
+                getIssuingCheckoutApi()
+                        .issuingClient()
+                        .createControl(request));
+
+        assertNotNull(cardControlResponse);
+
+        return cardControlResponse;
     }
 
     private CheckoutApi getIssuingCheckoutApi() {


### PR DESCRIPTION
### Changes
* Adds support for `createControl`
* Adds support for `getCardControls`
* Adds support for `getCardControlDetails`
* Adds support for `updateCardControl`
* Adds support for `removeCardControl`

### Related PRs
#332 
#333 

### API Reference
https://api-reference.checkout.com/#tag/Card-controls 