### PR TITLE
Add missing enum authorized signatory in EntityRoles

### DIFF
--- a/src/main/java/com/checkout/accounts/EntityRoles.java
+++ b/src/main/java/com/checkout/accounts/EntityRoles.java
@@ -7,5 +7,7 @@ public enum EntityRoles {
     @SerializedName("ubo")
     UBO,
     @SerializedName("legal_representative")
-    LEGAL_REPRESENTATIVE
+    LEGAL_REPRESENTATIVE,
+    @SerializedName("authorised_signatory")
+    AUTHORISED_SIGNATORY
 }


### PR DESCRIPTION
Hello, it seems like there is a missing enum value in EntityRoles which is authorised_signatory. Is it possible to add it ? Thanks.