### PR TITLE
chore: update Java version to 11 and Gradle to 8.14.3; refactor build configurations

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - id: validate-wrapper
         uses: gradle/wrapper-validation-action@v2
       - id: build

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - id: validate-wrapper
         uses: gradle/wrapper-validation-action@v2
       - id: cache-gradle-packages

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - id: read-version
         run: echo "CURRENT_VERSION=$( grep "version" gradle.properties | awk -F "=" '{print $2}' )" >> $GITHUB_ENV
       - id: print-version
@@ -43,7 +43,7 @@ jobs:
           GPG_PASSPHRASE: '${{ secrets.GPG_PASSPHRASE }}'
           SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASSWORD }}'
           SONATYPE_USERNAME: '${{ secrets.SONATYPE_USERNAME }}'
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-daemon --stacktrace
       - id: create-release
         uses: actions/create-release@v1
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,6 +42,12 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/dependency-check.yaml
+++ b/.github/workflows/dependency-check.yaml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - id: setup-java-8-build
+      - id: setup-java-11-build
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - id: validate-wrapper
         uses: gradle/wrapper-validation-action@v1
       - id: cache-gradle-packages

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,8 @@ plugins {
     id 'java-library'
     id 'signing'
     id 'maven-publish'
-    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'io.codearte.nexus-staging' version '0.21.2'
-    id 'com.gradle.build-scan' version '2.3'
-    id 'io.freefair.lombok' version '3.8.1'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
+    id 'io.freefair.lombok' version '8.10.2'
     id "org.sonarqube" version "3.3"
     id 'jacoco'
     id "org.owasp.dependencycheck" version "7.1.0.1"
@@ -18,32 +16,31 @@ allprojects {
     }
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
-dependencies {
-    implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'org.apache.commons:commons-lang3:3.11'
-    implementation 'javax.validation:validation-api:2.0.1.Final'
-    implementation 'org.apache.httpcomponents:httpmime:4.5.13'
-
-    testImplementation(platform('org.junit:junit-bom:5.7.2'))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testImplementation 'org.hamcrest:hamcrest:2.2'
-    testImplementation 'org.mockito:mockito-inline:3.11.2'
-    testImplementation 'org.mockito:mockito-junit-jupiter:3.11.2'
-    testImplementation 'org.apache.logging.log4j:log4j-api:2.17.1'
-    testImplementation 'org.apache.logging.log4j:log4j-core:2.17.1'
-    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
-    testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-buildScan {
-    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-    termsOfServiceAgree = 'yes'
+
+dependencies {
+    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'org.slf4j:slf4j-api:2.0.16'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+    implementation 'org.apache.commons:commons-lang3:3.17.0'
+    implementation 'javax.validation:validation-api:2.0.1.Final'
+    implementation 'org.apache.httpcomponents:httpmime:4.5.14'
+    implementation 'commons-codec:commons-codec:1.15'
+
+    testImplementation(platform('org.junit:junit-bom:5.11.0'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation 'org.hamcrest:hamcrest:3.0'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
+    testImplementation 'org.apache.logging.log4j:log4j-api:2.24.1'
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.24.1'
+    testImplementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.24.1'
+    testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }
 
 test {
@@ -59,47 +56,47 @@ test {
 jacocoTestReport {
     dependsOn test
     reports {
-        xml.enabled true
+        xml.required = true
     }
 }
 
-task sourcesJar(type: Jar) {
+tasks.register('sourcesJar', Jar) {
     from sourceSets.main.allJava
     archiveClassifier = 'sources'
 }
 
-task javadocJar(type: Jar) {
+tasks.register('javadocJar', Jar) {
     from javadoc
     archiveClassifier = 'javadoc'
 }
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
-            from(components.java)
+        maven(MavenPublication) {
+            from components.java
             artifact sourcesJar
             artifact javadocJar
 
             pom {
-                name = project_name
+                name.set(project_name)
                 packaging = 'jar'
-                description = project_description
-                url = project_url
+                description.set(project_description)
+                url.set(project_url)
                 scm {
-                    connection = project_scm
-                    developerConnection = project_scm
-                    url = project_url
+                    connection.set(project_scm)
+                    developerConnection.set(project_scm)
+                    url.set(project_url)
                 }
                 licenses {
                     license {
-                        name = project_license_slug
-                        url = project_license_url
+                        name.set(project_license_slug)
+                        url.set(project_license_url)
                     }
                 }
                 developers {
                     developer {
-                        id = project_developer
-                        name = project_developer
+                        id.set(project_developer)
+                        name.set(project_developer)
                     }
                 }
             }
@@ -107,26 +104,17 @@ publishing {
     }
 }
 
-nexusStaging {
-    username = System.getenv("SONATYPE_USERNAME")
-    password = System.getenv("SONATYPE_PASSWORD")
-    stagingProfileId = "57cde3b2433ed7"
-    packageGroup = "com.checkout"
-    numberOfRetries = 100
-    delayBetweenRetriesInMillis = 5000
-}
-
 nexusPublishing {
-    connectTimeout = Duration.ofMinutes(15)
-    clientTimeout = Duration.ofMinutes(15)
     repositories {
         sonatype {
-            packageGroup = rootProject.nexusStaging.packageGroup
-            stagingProfileId = rootProject.nexusStaging.stagingProfileId
-            username = rootProject.nexusStaging.username
-            password = rootProject.nexusStaging.password
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username = System.getenv("SONATYPE_USERNAME")
+            password = System.getenv("SONATYPE_PASSWORD")
         }
     }
+    connectTimeout = Duration.ofMinutes(3)
+    clientTimeout = Duration.ofMinutes(3)
 }
 
 signing {
@@ -134,7 +122,7 @@ signing {
     def signingPassword = System.getenv('GPG_PASSPHRASE')
     required { signingKey != null && signingPassword != null && gradle.taskGraph.hasTask("publish") }
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
+    sign publishing.publications.maven
 }
 
 jar {
@@ -152,7 +140,7 @@ sonarqube {
     }
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     // a collection to track failedTests
     ext.failedTests = []
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,6 @@
 group=com.checkout
-version=6.9.0
+version=6.9.1
 
-maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
-snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/
 project_name=Checkout SDK Java
 project_description=Checkout SDK for Java https://checkout.com
 project_url=https://github.com/checkout/checkout-sdk-java

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Aug 02 15:19:01 BST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,19 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id 'com.gradle.develocity' version '3.19.2'
+}
+
+develocity {
+    buildScan {
+        termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+        termsOfUseAgree = "yes"
+        publishing.onlyIf { true }
+    }
+}
+
 rootProject.name = 'checkout-sdk-java'

--- a/src/test/java/com/checkout/tokens/TokensTestIT.java
+++ b/src/test/java/com/checkout/tokens/TokensTestIT.java
@@ -41,7 +41,7 @@ class TokensTestIT extends SandboxTestFixture {
         assertEquals(2025, response.getExpiryYear().intValue());
         assertEquals("VISA", response.getScheme());
         assertEquals("4242", response.getLast4());
-        assertEquals("424242", response.getBin());
+        assertEquals("42424242", response.getBin());
         assertEquals(CardType.CREDIT, response.getCardType());
         assertEquals(CardCategory.CONSUMER, response.getCardCategory());
         //assertEquals("JPMORGAN CHASE BANK NA", response.getIssuer());


### PR DESCRIPTION
This pull request includes updates to the Java version, Gradle configuration, and build workflows, as well as changes to the `gradle.properties` file and test assertions. The updates aim to modernize the project dependencies and improve build reliability. **The project remains compatible with Java 8.**

### Build and workflow updates:
* `.github/workflows/build-master.yml`, `.github/workflows/build-pull-request.yml`, `.github/workflows/build-release.yml`, `.github/workflows/dependency-check.yaml`: Updated the Java version from 8 to 11 in all workflows to align with modern Java standards. [[1]](diffhunk://#diff-53f6a76fa86b1994f9da743d84e130a48058a0d0657949c412c203d5f0aedfe8L15-R15) [[2]](diffhunk://#diff-104c03339b92a1f7faaf8f4d9cb603bdf4765f6f6281cee6ece6cab1331aee30L17-R17) [[3]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L16-R16) [[4]](diffhunk://#diff-6f332ec8a720589fe22733bd0e0e0f081da104875be39b53bae3663919e94924L19-R19)
* [`.github/workflows/build-release.yml`](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L46-R46): Added `--no-daemon` and `--stacktrace` flags to the Gradle publish command for better debugging and reliability during release builds.

### Gradle configuration improvements:
* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL2-R2): Upgraded Gradle version from `5.5.1` to `8.14.3` to support newer features and improve performance.
* [`settings.gradle`](diffhunk://#diff-7f825392aa37acd1cee0c2e7b9bb7366ad6eac64f3e6cdd816e156bcb69d30deR1-R18): Added plugin management configuration and integrated the Gradle Develocity plugin for build scans and enhanced build insights.

### Project metadata updates:
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L2-L5): Updated the project version from `6.9.0` to `6.9.1` and removed obsolete Maven repository URLs.

### Test adjustments:
* [`src/test/java/com/checkout/tokens/TokensTestIT.java`](diffhunk://#diff-4a3ff7a1326e2ec005472500241ae488e7ce02f5da16a12cadef5767571c126cL44-R44): Modified the expected `bin` value in the `shouldRequestCardToken` test from `424242` to `42424242` to match updated data.