### PR TITLE
Release 6.9.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.checkout
-version=6.9.1
+version=6.9.2
 
 project_name=Checkout SDK Java
 project_description=Checkout SDK for Java https://checkout.com


### PR DESCRIPTION
- fix: correct spelling of driving license in identification type