### PR TITLE
feat: align card metadata module with swagger spec

### DIFF
--- a/src/main/java/com/checkout/GsonSerializer.java
+++ b/src/main/java/com/checkout/GsonSerializer.java
@@ -219,6 +219,11 @@ public final class GsonSerializer implements Serializer {
                     .registerSubtype(com.checkout.handlepaymentsandpayouts.flow.responses.ApprovedPaymentSubmissionResponse.class, serializedName(PaymentSessionStatus.APPROVED))
                     .registerSubtype(com.checkout.handlepaymentsandpayouts.flow.responses.DeclinedPaymentSubmissionResponse.class, serializedName(PaymentSessionStatus.DECLINED))
                     .registerSubtype(com.checkout.handlepaymentsandpayouts.flow.responses.ActionRequiredPaymentSubmissionResponse.class, serializedName(PaymentSessionStatus.ACTION_REQUIRED)))
+            .registerTypeAdapterFactory(RuntimeTypeAdapterFactory.of(com.checkout.metadata.card.source.CardMetadataRequestSource.class, CheckoutUtils.TYPE, true)
+                    .registerSubtype(com.checkout.metadata.card.source.CardMetadataBinSource.class, identifier(com.checkout.metadata.card.CardMetadataSourceType.BIN))
+                    .registerSubtype(com.checkout.metadata.card.source.CardMetadataCardSource.class, identifier(com.checkout.metadata.card.CardMetadataSourceType.CARD))
+                    .registerSubtype(com.checkout.metadata.card.source.CardMetadataTokenSource.class, identifier(com.checkout.metadata.card.CardMetadataSourceType.TOKEN))
+                    .registerSubtype(com.checkout.metadata.card.source.CardMetadataIdSource.class, identifier(com.checkout.metadata.card.CardMetadataSourceType.ID)))
             // Adapters when API returns an array
             .registerTypeAdapter(EVENT_TYPES_TYPE, eventTypesResponseDeserializer())
             .registerTypeAdapter(WORKFLOWS_EVENT_TYPES_TYPE, workflowEventTypesResponseDeserializer())

--- a/src/main/java/com/checkout/common/SchemeLocalType.java
+++ b/src/main/java/com/checkout/common/SchemeLocalType.java
@@ -16,8 +16,14 @@ public enum SchemeLocalType {
     OMANNET,
     @SerializedName("pulse")
     PULSE,
+    @SerializedName("shazam")
+    SHAZAM,
     @SerializedName("star")
     STAR,
     @SerializedName("upi")
     UPI,
+    @SerializedName("paypak")
+    PAYPAK,
+    @SerializedName("maestro")
+    MAESTRO,
 }

--- a/src/main/java/com/checkout/metadata/MetadataClient.java
+++ b/src/main/java/com/checkout/metadata/MetadataClient.java
@@ -5,10 +5,30 @@ import com.checkout.metadata.card.CardMetadataResponse;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Client for the Card Metadata API (POST /metadata/card).
+ * Returns a single metadata record for the card specified by PAN, BIN, token, or instrument ID.
+ * <p>
+ * Beta endpoint — requires OAuth scope {@code vault:card-metadata} or a secret API key.
+ * </p>
+ */
 public interface MetadataClient {
 
+    /**
+     * Retrieves card metadata asynchronously for the specified card source.
+     *
+     * @param cardMetadataRequest the request identifying the card source (PAN, BIN, token, or instrument ID)
+     *                            and the desired response format
+     * @return a {@link CompletableFuture} containing the card metadata response
+     */
     CompletableFuture<CardMetadataResponse> requestCardMetadata(CardMetadataRequest cardMetadataRequest);
 
-    // Synchronous methods
+    /**
+     * Retrieves card metadata synchronously for the specified card source.
+     *
+     * @param cardMetadataRequest the request identifying the card source (PAN, BIN, token, or instrument ID)
+     *                            and the desired response format
+     * @return the card metadata response
+     */
     CardMetadataResponse requestCardMetadataSync(CardMetadataRequest cardMetadataRequest);
 }

--- a/src/main/java/com/checkout/metadata/MetadataClientImpl.java
+++ b/src/main/java/com/checkout/metadata/MetadataClientImpl.java
@@ -10,26 +10,42 @@ import com.checkout.metadata.card.CardMetadataResponse;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Default implementation of {@link MetadataClient}. Posts to POST /metadata/card
+ * using secret key or OAuth ({@code vault:card-metadata}) authorization.
+ */
 public class MetadataClientImpl extends AbstractClient implements MetadataClient {
 
+    private static final String METADATA_CARD_PATH = "metadata/card";
+
+    /**
+     * Constructs a new {@code MetadataClientImpl}.
+     *
+     * @param apiClient     the HTTP client used to perform API calls
+     * @param configuration the SDK configuration (credentials, environment, etc.)
+     */
     public MetadataClientImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
         super(apiClient, configuration, SdkAuthorizationType.SECRET_KEY_OR_OAUTH);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public CompletableFuture<CardMetadataResponse> requestCardMetadata(final CardMetadataRequest cardMetadataRequest) {
         validateCardMetadataRequest(cardMetadataRequest);
-        return apiClient.postAsync("metadata/card", sdkAuthorization(), CardMetadataResponse.class, cardMetadataRequest, null);
+        return apiClient.postAsync(METADATA_CARD_PATH, sdkAuthorization(), CardMetadataResponse.class, cardMetadataRequest, null);
     }
 
-    // Synchronous methods
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public CardMetadataResponse requestCardMetadataSync(final CardMetadataRequest cardMetadataRequest) {
         validateCardMetadataRequest(cardMetadataRequest);
-        return apiClient.post("metadata/card", sdkAuthorization(), CardMetadataResponse.class, cardMetadataRequest, null);
+        return apiClient.post(METADATA_CARD_PATH, sdkAuthorization(), CardMetadataResponse.class, cardMetadataRequest, null);
     }
 
-    // Common methods
     private void validateCardMetadataRequest(final CardMetadataRequest cardMetadataRequest) {
         CheckoutUtils.validateParams("cardMetadataRequest", cardMetadataRequest);
     }

--- a/src/main/java/com/checkout/metadata/card/AccountFundingTransaction.java
+++ b/src/main/java/com/checkout/metadata/card/AccountFundingTransaction.java
@@ -3,9 +3,17 @@ package com.checkout.metadata.card;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
+/**
+ * Account Funding Transaction (AFT) eligibility information for the card.
+ */
 @Data
 public final class AccountFundingTransaction {
 
+    /**
+     * Describes whether the card is eligible to take funds from different accounts
+     * to fund other non-merchant accounts.
+     * [Optional]
+     */
     @SerializedName("aft_indicator")
     private AftIndicator aftIndicator;
 }

--- a/src/main/java/com/checkout/metadata/card/AftIndicator.java
+++ b/src/main/java/com/checkout/metadata/card/AftIndicator.java
@@ -3,9 +3,18 @@ package com.checkout.metadata.card;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
+/**
+ * Account Funding Transaction (AFT) eligibility indicator. Describes whether the card can be
+ * used to take funds from different accounts to fund other non-merchant accounts.
+ */
 @Data
 public final class AftIndicator {
 
+    /**
+     * Pull funds eligibility details — whether the card can be used for domestic and
+     * cross-border Account Funding Transactions.
+     * [Optional]
+     */
     @SerializedName("pull_funds")
     private PullFunds pullFunds;
 }

--- a/src/main/java/com/checkout/metadata/card/CardMetadataPayouts.java
+++ b/src/main/java/com/checkout/metadata/card/CardMetadataPayouts.java
@@ -3,24 +3,58 @@ package com.checkout.metadata.card;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
+/**
+ * Card payout eligibility details. Present in the response only when the request
+ * {@code format} is {@code card_payouts}.
+ */
 @Data
 public final class CardMetadataPayouts {
 
+    /**
+     * Describes whether the card is eligible for domestic non-money transfer transactions.
+     * [Optional]
+     * Enum: "not_supported" "standard" "fast_funds" "unknown"
+     */
     @SerializedName("domestic_non_money_transfer")
     private PayoutsTransactionsType domesticNonMoneyTransfer;
 
+    /**
+     * Describes whether the card is eligible for cross-border non-money transfer transactions.
+     * [Optional]
+     * Enum: "not_supported" "standard" "fast_funds" "unknown"
+     */
     @SerializedName("cross_border_non_money_transfer")
     private PayoutsTransactionsType crossBorderNonMoneyTransfer;
 
+    /**
+     * Describes whether the card is eligible for domestic gambling transactions.
+     * [Optional]
+     * Enum: "not_supported" "standard" "fast_funds" "unknown"
+     */
     @SerializedName("domestic_gambling")
     private PayoutsTransactionsType domesticGambling;
 
+    /**
+     * Describes whether the card is eligible for cross-border gambling transactions.
+     * [Optional]
+     * Enum: "not_supported" "standard" "fast_funds" "unknown"
+     */
     @SerializedName("cross_border_gambling")
     private PayoutsTransactionsType crossBorderGambling;
 
+    /**
+     * Describes whether the card is eligible for domestic money transfer transactions.
+     * [Optional]
+     * Enum: "not_supported" "standard" "fast_funds" "unknown"
+     */
     @SerializedName("domestic_money_transfer")
     private PayoutsTransactionsType domesticMoneyTransfer;
 
+    /**
+     * Describes whether the card is eligible for cross-border money transfer transactions.
+     * [Optional]
+     * Enum: "not_supported" "standard" "fast_funds" "unknown"
+     */
     @SerializedName("cross_border_money_transfer")
     private PayoutsTransactionsType crossBorderMoneyTransfer;
 }

--- a/src/main/java/com/checkout/metadata/card/CardMetadataRequest.java
+++ b/src/main/java/com/checkout/metadata/card/CardMetadataRequest.java
@@ -4,12 +4,41 @@ import com.checkout.metadata.card.source.CardMetadataRequestSource;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * Request body for the POST /metadata/card endpoint.
+ * Returns a single metadata record for the card specified by PAN, BIN, token, or instrument ID.
+ * <p>
+ * Beta endpoint — subject to change.
+ * </p>
+ */
 @Data
 @Builder
 public final class CardMetadataRequest {
 
+    /**
+     * The card source to retrieve metadata for.
+     * [Required]
+     * Supported types: {@link com.checkout.metadata.card.source.CardMetadataCardSource},
+     * {@link com.checkout.metadata.card.source.CardMetadataBinSource},
+     * {@link com.checkout.metadata.card.source.CardMetadataTokenSource},
+     * {@link com.checkout.metadata.card.source.CardMetadataIdSource}
+     */
     private CardMetadataRequestSource source;
 
+    /**
+     * The format to provide the output in.
+     * {@code basic} returns only standard metadata.
+     * {@code card_payouts} also includes fields specific to card payouts.
+     * [Optional]
+     * Default: "basic"
+     * Enum: "basic" "card_payouts"
+     */
     private CardMetadataFormatType format;
+
+    /**
+     * A reference you can later use to identify this request. For example, an order number.
+     * [Optional]
+     */
+    private String reference;
 
 }

--- a/src/main/java/com/checkout/metadata/card/CardMetadataResponse.java
+++ b/src/main/java/com/checkout/metadata/card/CardMetadataResponse.java
@@ -13,63 +13,172 @@ import lombok.ToString;
 
 import java.util.List;
 
+/**
+ * Response from POST /metadata/card.
+ * Contains card metadata including BIN information, scheme details, card type, issuer data,
+ * and optionally card payout eligibility and scheme metadata.
+ */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public final class CardMetadataResponse extends HttpMetadata {
 
+    /**
+     * The issuer's Bank Identification Number (BIN). Supports 6, 8, or 11 digit BINs.
+     * [Required]
+     * >= 6 characters
+     * <= 11 characters
+     * Pattern: ^[0-9]{6}$|^[0-9]{8}$|^[0-9]{11}$
+     */
     private String bin;
 
+    /**
+     * The global card scheme. For example, {@code american_express}, {@code cartes_bancaires},
+     * {@code diners_club_international}, {@code discover}, {@code jcb}, {@code mastercard}, or {@code visa}.
+     * [Required]
+     */
     private String scheme;
 
     /**
-     * @deprecated This property will be removed in the future, and should be used
-     * {@link CardMetadataResponse#localSchemes} instead
+     * The local card scheme, if the card is co-branded.
+     * [Optional]
+     * Enum: "cartes_bancaires" "mada" "omannet"
+     *
+     * @deprecated Replaced by {@link #localSchemes}. Will be removed in a future release.
      */
     @Deprecated
     @SerializedName("scheme_local")
     private SchemeLocalType schemeLocal;
 
+    /**
+     * The local card scheme or schemes, if the card is co-branded.
+     * [Optional]
+     * Enum: "accel" "cartes_bancaires" "mada" "nyce" "omannet" "pulse" "shazam" "star" "upi" "paypak" "maestro"
+     */
     @SerializedName("local_schemes")
     private List<SchemeLocalType> localSchemes;
 
+    /**
+     * The card type.
+     * [Optional]
+     * Enum: "CREDIT" "DEBIT" "PREPAID" "CHARGE" "DEFERRED DEBIT"
+     */
     @SerializedName("card_type")
     private CardType cardType;
 
+    /**
+     * The card category.
+     * [Optional]
+     * Enum: "CONSUMER" "COMMERCIAL"
+     */
     @SerializedName("card_category")
     private CardCategory cardCategory;
 
+    /**
+     * The card billing currency, as a three-letter ISO-4217 currency code.
+     * [Optional]
+     */
     private Currency currency;
 
+    /**
+     * The card issuer.
+     * [Optional]
+     */
     private String issuer;
 
+    /**
+     * The card issuer's country, as an ISO-2 code.
+     * [Optional]
+     */
     @SerializedName("issuer_country")
     private CountryCode issuerCountry;
 
+    /**
+     * The card issuer's country name.
+     * [Optional]
+     */
     @SerializedName("issuer_country_name")
     private String issuerCountryName;
 
+    /**
+     * Indicates whether the card is a combo credit and debit card. Applicable to Visa and Mastercard.
+     * [Optional]
+     */
+    @SerializedName("is_combo_card")
+    private Boolean isComboCard;
+
+    /**
+     * The card issuer or scheme's product identifier.
+     * [Optional]
+     */
     @SerializedName("product_id")
     private String productId;
 
+    /**
+     * The card issuer or scheme's product type.
+     * [Optional]
+     */
     @SerializedName("product_type")
     private String productType;
 
+    /**
+     * The card issuer or scheme's sub-product identifier.
+     * [Optional]
+     */
     @SerializedName("subproduct_id")
     private String subproductId;
 
+    /**
+     * Specifies whether the card is assigned to an interchange regulated BIN range.
+     * [Optional]
+     */
     @SerializedName("regulated_indicator")
     private Boolean regulatedIndicator;
 
+    /**
+     * The type of the interchange regulated card BIN range.
+     * [Optional]
+     * Enum: "base_regulated" "fraud_protected_regulated"
+     */
     @SerializedName("regulated_type")
     private String regulatedType;
 
+    /**
+     * Indicates whether the prepaid bank identification number (BIN) is reloadable.
+     * [Optional]
+     */
+    @SerializedName("is_reloadable_prepaid")
+    private Boolean isReloadablePrepaid;
+
+    /**
+     * The description of the prepaid BIN, specifying if it is an anonymous prepaid card.
+     * [Optional]
+     * Enum: "Anonymous prepaid program and not AMLD5 compliant"
+     *       "Anonymous prepaid program and AMLD5 compliant"
+     *       "Not prepaid or non-anonymous prepaid program/default"
+     */
+    @SerializedName("anonymous_prepaid_description")
+    private String anonymousPrepaidDescription;
+
+    /**
+     * Card payout eligibility details. Only present when the request {@code format} is {@code card_payouts}.
+     * [Optional]
+     */
     @SerializedName("card_payouts")
     private CardMetadataPayouts payouts;
 
+    /**
+     * Additional information about scheme or local scheme capabilities for US-issued cards
+     * that can be used in a PINless debit network. Returned when a full card number or 11-digit BIN is provided.
+     * [Optional]
+     */
     @SerializedName("scheme_metadata")
     private SchemeMetadata schemeMetadata;
-    
+
+    /**
+     * Account Funding Transaction (AFT) eligibility information.
+     * [Optional]
+     */
     @SerializedName("account_funding_transaction")
     private AccountFundingTransaction accountFundingTransaction;
 }

--- a/src/main/java/com/checkout/metadata/card/PinlessDebitSchemeMetadata.java
+++ b/src/main/java/com/checkout/metadata/card/PinlessDebitSchemeMetadata.java
@@ -5,29 +5,61 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * PINless debit network metadata for a specific scheme. Describes the card's eligibility
+ * and capabilities within that network.
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public final class PinlessDebitSchemeMetadata {
 
+    /**
+     * The PINless debit network identifier.
+     * [Optional]
+     */
     @SerializedName("network_id")
     private String networkId;
 
+    /**
+     * The PINless debit network name.
+     * [Optional]
+     */
     @SerializedName("network_description")
     private String networkDescription;
 
+    /**
+     * Describes whether the card is eligible for bill payment transactions.
+     * [Optional]
+     */
     @SerializedName("bill_pay_indicator")
     private Boolean billPayIndicator;
 
+    /**
+     * Describes whether the card is eligible for e-commerce transactions.
+     * [Optional]
+     */
     @SerializedName("ecommerce_indicator")
     private Boolean ecommerceIndicator;
 
+    /**
+     * The type of interchange fee used for transactions.
+     * [Optional]
+     */
     @SerializedName("interchange_fee_indicator")
-    private String InterchangeFeeIndicator;
+    private String interchangeFeeIndicator;
 
+    /**
+     * Describes whether the card is eligible for money transfer transactions.
+     * [Optional]
+     */
     @SerializedName("money_transfer_indicator")
     private Boolean moneyTransferIndicator;
 
+    /**
+     * True indicates that the card PAN is a DPAN; false indicates it is a FPAN.
+     * [Optional]
+     */
     @SerializedName("token_indicator")
     private Boolean tokenIndicator;
 

--- a/src/main/java/com/checkout/metadata/card/PullFunds.java
+++ b/src/main/java/com/checkout/metadata/card/PullFunds.java
@@ -3,11 +3,25 @@ package com.checkout.metadata.card;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
+/**
+ * Describes whether the card is eligible to take funds from different accounts
+ * to fund other non-merchant accounts (Account Funding Transactions).
+ */
 @Data
 public final class PullFunds {
 
+    /**
+     * Describes whether the card is eligible for Account Funding Transactions between
+     * accounts in different countries.
+     * [Optional]
+     */
     @SerializedName("cross_border")
     private Boolean crossBorder;
 
+    /**
+     * Describes whether the card is eligible for Account Funding Transactions between
+     * accounts in the same country.
+     * [Optional]
+     */
     private Boolean domestic;
 }

--- a/src/main/java/com/checkout/metadata/card/SchemeMetadata.java
+++ b/src/main/java/com/checkout/metadata/card/SchemeMetadata.java
@@ -4,15 +4,41 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * Additional scheme or local scheme capabilities for US-issued cards that can be used in a
+ * PINless debit network. Returned when a full card number or 11-digit BIN is provided.
+ */
 @Data
 public final class SchemeMetadata {
 
+    /**
+     * PINless debit metadata for the Accel network.
+     * [Optional]
+     */
     private List<PinlessDebitSchemeMetadata> accel;
 
+    /**
+     * PINless debit metadata for the Pulse network.
+     * [Optional]
+     */
     private List<PinlessDebitSchemeMetadata> pulse;
 
+    /**
+     * PINless debit metadata for the NYCE network.
+     * [Optional]
+     */
     private List<PinlessDebitSchemeMetadata> nyce;
 
+    /**
+     * PINless debit metadata for the Shazam network.
+     * [Optional]
+     */
+    private List<PinlessDebitSchemeMetadata> shazam;
+
+    /**
+     * PINless debit metadata for the Star network.
+     * [Optional]
+     */
     private List<PinlessDebitSchemeMetadata> star;
 
 }

--- a/src/main/java/com/checkout/metadata/card/source/CardMetadataBinSource.java
+++ b/src/main/java/com/checkout/metadata/card/source/CardMetadataBinSource.java
@@ -7,12 +7,22 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * Card metadata source identified by a Bank Identification Number (BIN).
+ */
 @Getter
 @Setter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public final class CardMetadataBinSource extends CardMetadataRequestSource {
 
+    /**
+     * The issuer's Bank Identification Number (BIN).
+     * [Required]
+     * >= 6 characters
+     * <= 8 characters
+     * Pattern: ^[0-9]+$
+     */
     private String bin;
 
     @Builder

--- a/src/main/java/com/checkout/metadata/card/source/CardMetadataCardSource.java
+++ b/src/main/java/com/checkout/metadata/card/source/CardMetadataCardSource.java
@@ -7,12 +7,22 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * Card metadata source identified by a full Primary Account Number (PAN).
+ */
 @Getter
 @Setter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public final class CardMetadataCardSource extends CardMetadataRequestSource {
 
+    /**
+     * The Primary Account Number (PAN).
+     * [Required]
+     * >= 12 characters
+     * <= 19 characters
+     * Pattern: ^[0-9]+$
+     */
     private String number;
 
     @Builder

--- a/src/main/java/com/checkout/metadata/card/source/CardMetadataIdSource.java
+++ b/src/main/java/com/checkout/metadata/card/source/CardMetadataIdSource.java
@@ -7,12 +7,20 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * Card metadata source identified by a Checkout.com payment instrument ID.
+ */
 @Getter
 @Setter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public final class CardMetadataIdSource extends CardMetadataRequestSource {
 
+    /**
+     * The unique ID for the payment instrument created using the card's details.
+     * [Required]
+     * Pattern: ^(src)_(\w{26})$
+     */
     private String id;
 
     @Builder

--- a/src/main/java/com/checkout/metadata/card/source/CardMetadataTokenSource.java
+++ b/src/main/java/com/checkout/metadata/card/source/CardMetadataTokenSource.java
@@ -7,12 +7,20 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * Card metadata source identified by a Checkout.com card token.
+ */
 @Getter
 @Setter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public final class CardMetadataTokenSource extends CardMetadataRequestSource {
 
+    /**
+     * The Checkout.com unique token generated when the card's details were tokenized.
+     * [Required]
+     * Pattern: ^(tok)_(\w{26})$
+     */
     private String token;
 
     @Builder

--- a/src/test/java/com/checkout/metadata/CardMetadataClientImplTest.java
+++ b/src/test/java/com/checkout/metadata/CardMetadataClientImplTest.java
@@ -1,8 +1,17 @@
 package com.checkout.metadata;
 
-import com.checkout.*;
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SdkAuthorization;
+import com.checkout.SdkAuthorizationType;
+import com.checkout.SdkCredentials;
+import com.checkout.metadata.card.CardMetadataFormatType;
 import com.checkout.metadata.card.CardMetadataRequest;
 import com.checkout.metadata.card.CardMetadataResponse;
+import com.checkout.metadata.card.source.CardMetadataBinSource;
+import com.checkout.metadata.card.source.CardMetadataCardSource;
+import com.checkout.metadata.card.source.CardMetadataIdSource;
+import com.checkout.metadata.card.source.CardMetadataTokenSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,13 +23,17 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CardMetadataClientImplTest {
+
+    private static final String METADATA_CARD_PATH = "metadata/card";
 
     private MetadataClient client;
 
@@ -43,40 +56,190 @@ class CardMetadataClientImplTest {
         client = new MetadataClientImpl(apiClient, configuration);
     }
 
+    // ─── Async ──────────────────────────────────────────────────────────────
+
     @Test
-    void shouldRequestCardMetadata() throws ExecutionException, InterruptedException {
+    void shouldRequestCardMetadataWithBinSourceAsync() throws ExecutionException, InterruptedException {
+        final CardMetadataRequest request = buildBinRequest();
+        final CardMetadataResponse response = new CardMetadataResponse();
 
-        final CardMetadataRequest request = mock(CardMetadataRequest.class);
-        final CardMetadataResponse response = mock(CardMetadataResponse.class);
-
-        when(apiClient.postAsync(eq("metadata/card"), eq(authorization), eq(CardMetadataResponse.class),
+        when(apiClient.postAsync(eq(METADATA_CARD_PATH), eq(authorization), eq(CardMetadataResponse.class),
                 eq(request), isNull()))
                 .thenReturn(CompletableFuture.completedFuture(response));
 
-        final CompletableFuture<CardMetadataResponse> future = client.requestCardMetadata(request);
+        final CardMetadataResponse result = client.requestCardMetadata(request).get();
 
-        validateCardMetadataResponse(response, future.get());
+        assertNotNull(result);
+        assertEquals(response, result);
+        verify(apiClient).postAsync(eq(METADATA_CARD_PATH), eq(authorization),
+                eq(CardMetadataResponse.class), eq(request), isNull());
     }
 
-    // Synchronous methods
     @Test
-    void shouldRequestCardMetadataSync() throws ExecutionException, InterruptedException {
+    void shouldRequestCardMetadataWithCardSourceAsync() throws ExecutionException, InterruptedException {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataCardSource.builder().number("4543474002249996").build())
+                .format(CardMetadataFormatType.BASIC)
+                .build();
+        final CardMetadataResponse response = new CardMetadataResponse();
 
-        final CardMetadataRequest request = mock(CardMetadataRequest.class);
-        final CardMetadataResponse response = mock(CardMetadataResponse.class);
+        when(apiClient.postAsync(eq(METADATA_CARD_PATH), eq(authorization), eq(CardMetadataResponse.class),
+                eq(request), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(response));
 
-        when(apiClient.post(eq("metadata/card"), eq(authorization), eq(CardMetadataResponse.class),
+        final CardMetadataResponse result = client.requestCardMetadata(request).get();
+
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
+    void shouldRequestCardMetadataWithTokenSourceAsync() throws ExecutionException, InterruptedException {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataTokenSource.builder().token("tok_ubfj2q76miwundwlk72vxt2i7q").build())
+                .format(CardMetadataFormatType.BASIC)
+                .build();
+        final CardMetadataResponse response = new CardMetadataResponse();
+
+        when(apiClient.postAsync(eq(METADATA_CARD_PATH), eq(authorization), eq(CardMetadataResponse.class),
+                eq(request), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CardMetadataResponse result = client.requestCardMetadata(request).get();
+
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
+    void shouldRequestCardMetadataWithIdSourceAsync() throws ExecutionException, InterruptedException {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataIdSource.builder().id("src_wmlfc3zyhqzehihu7giusaaawu").build())
+                .format(CardMetadataFormatType.CARD_PAYOUTS)
+                .build();
+        final CardMetadataResponse response = new CardMetadataResponse();
+
+        when(apiClient.postAsync(eq(METADATA_CARD_PATH), eq(authorization), eq(CardMetadataResponse.class),
+                eq(request), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CardMetadataResponse result = client.requestCardMetadata(request).get();
+
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
+    void shouldIncludeReferenceFieldInRequestAsync() throws ExecutionException, InterruptedException {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataBinSource.builder().bin("454347").build())
+                .format(CardMetadataFormatType.BASIC)
+                .reference("ORD-5023-4E89")
+                .build();
+        final CardMetadataResponse response = new CardMetadataResponse();
+
+        when(apiClient.postAsync(eq(METADATA_CARD_PATH), eq(authorization), eq(CardMetadataResponse.class),
+                eq(request), isNull()))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CardMetadataResponse result = client.requestCardMetadata(request).get();
+
+        assertNotNull(result);
+        verify(apiClient).postAsync(eq(METADATA_CARD_PATH), eq(authorization),
+                eq(CardMetadataResponse.class), eq(request), isNull());
+    }
+
+    @Test
+    @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+    void shouldThrowWhenRequestIsNullAsync() {
+        assertThrows(Exception.class, () -> client.requestCardMetadata(null));
+    }
+
+    // ─── Sync ───────────────────────────────────────────────────────────────
+
+    @Test
+    void shouldRequestCardMetadataWithBinSourceSync() {
+        final CardMetadataRequest request = buildBinRequest();
+        final CardMetadataResponse response = new CardMetadataResponse();
+
+        when(apiClient.post(eq(METADATA_CARD_PATH), eq(authorization), eq(CardMetadataResponse.class),
                 eq(request), isNull()))
                 .thenReturn(response);
 
         final CardMetadataResponse result = client.requestCardMetadataSync(request);
 
-        validateCardMetadataResponse(response, result);
-    }
-
-    // Common methods
-    private void validateCardMetadataResponse(final CardMetadataResponse response, final CardMetadataResponse result) {
         assertNotNull(result);
         assertEquals(response, result);
+        verify(apiClient).post(eq(METADATA_CARD_PATH), eq(authorization),
+                eq(CardMetadataResponse.class), eq(request), isNull());
+    }
+
+    @Test
+    void shouldRequestCardMetadataWithCardSourceSync() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataCardSource.builder().number("4543474002249996").build())
+                .format(CardMetadataFormatType.CARD_PAYOUTS)
+                .build();
+        final CardMetadataResponse response = new CardMetadataResponse();
+
+        when(apiClient.post(eq(METADATA_CARD_PATH), eq(authorization), eq(CardMetadataResponse.class),
+                eq(request), isNull()))
+                .thenReturn(response);
+
+        final CardMetadataResponse result = client.requestCardMetadataSync(request);
+
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
+    void shouldRequestCardMetadataWithTokenSourceSync() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataTokenSource.builder().token("tok_ubfj2q76miwundwlk72vxt2i7q").build())
+                .format(CardMetadataFormatType.BASIC)
+                .build();
+        final CardMetadataResponse response = new CardMetadataResponse();
+
+        when(apiClient.post(eq(METADATA_CARD_PATH), eq(authorization), eq(CardMetadataResponse.class),
+                eq(request), isNull()))
+                .thenReturn(response);
+
+        final CardMetadataResponse result = client.requestCardMetadataSync(request);
+
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
+    void shouldRequestCardMetadataWithIdSourceSync() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataIdSource.builder().id("src_wmlfc3zyhqzehihu7giusaaawu").build())
+                .format(CardMetadataFormatType.CARD_PAYOUTS)
+                .build();
+        final CardMetadataResponse response = new CardMetadataResponse();
+
+        when(apiClient.post(eq(METADATA_CARD_PATH), eq(authorization), eq(CardMetadataResponse.class),
+                eq(request), isNull()))
+                .thenReturn(response);
+
+        final CardMetadataResponse result = client.requestCardMetadataSync(request);
+
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
+    @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+    void shouldThrowWhenRequestIsNullSync() {
+        assertThrows(Exception.class, () -> client.requestCardMetadataSync(null));
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private CardMetadataRequest buildBinRequest() {
+        return CardMetadataRequest.builder()
+                .source(CardMetadataBinSource.builder().bin("454347").build())
+                .format(CardMetadataFormatType.BASIC)
+                .build();
     }
 }

--- a/src/test/java/com/checkout/metadata/CardMetadataIT.java
+++ b/src/test/java/com/checkout/metadata/CardMetadataIT.java
@@ -22,116 +22,144 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class CardMetadataIT extends SandboxTestFixture {
+
     CardMetadataIT() {
         super(PlatformType.DEFAULT_OAUTH);
     }
 
+    // ─── BIN source ─────────────────────────────────────────────────────────
+
     @Test
     void shouldRequestMetadataCardForBinNumber() {
-
-        final CardMetadataRequest metadataCardRequest = CardMetadataRequest.builder()
+        final CardMetadataRequest request = CardMetadataRequest.builder()
                 .source(CardMetadataBinSource.builder()
                         .bin(CardSourceHelper.Visa.NUMBER.substring(0, 6))
                         .build())
                 .format(CardMetadataFormatType.BASIC)
                 .build();
 
-        final CardMetadataResponse cardMetadataResponse = blocking(
-                () -> checkoutApi.metadataClient().requestCardMetadata(metadataCardRequest));
-        
-        validateResponse(cardMetadataResponse);
+        final CardMetadataResponse response = blocking(
+                () -> checkoutApi.metadataClient().requestCardMetadata(request));
 
+        validateBasicResponse(response);
     }
 
     @Test
-    void shouldRequestCardMetadataForCardNumber() {
+    void shouldRequestMetadataCardForBinNumberWithCardPayoutsFormat() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataBinSource.builder()
+                        .bin(CardSourceHelper.Visa.NUMBER.substring(0, 6))
+                        .build())
+                .format(CardMetadataFormatType.CARD_PAYOUTS)
+                .build();
 
-        final CardMetadataRequest metadataCardRequest = CardMetadataRequest.builder()
+        final CardMetadataResponse response = blocking(
+                () -> checkoutApi.metadataClient().requestCardMetadata(request));
+
+        validateBasicResponse(response);
+    }
+
+    @Test
+    void shouldRequestMetadataCardForBinNumberWithReference() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataBinSource.builder()
+                        .bin(CardSourceHelper.Visa.NUMBER.substring(0, 6))
+                        .build())
+                .format(CardMetadataFormatType.BASIC)
+                .reference("ORD-5023-4E89")
+                .build();
+
+        final CardMetadataResponse response = blocking(
+                () -> checkoutApi.metadataClient().requestCardMetadata(request));
+
+        validateBasicResponse(response);
+    }
+
+    // ─── Card (PAN) source ───────────────────────────────────────────────────
+
+    @Test
+    void shouldRequestCardMetadataForCardNumber() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
                 .source(CardMetadataCardSource.builder()
                         .number(CardSourceHelper.Visa.NUMBER)
                         .build())
                 .format(CardMetadataFormatType.BASIC)
                 .build();
 
-        final CardMetadataResponse cardMetadataResponse = blocking(
-                () -> checkoutApi.metadataClient().requestCardMetadata(metadataCardRequest));
-        
-        validateResponse(cardMetadataResponse);
+        final CardMetadataResponse response = blocking(
+                () -> checkoutApi.metadataClient().requestCardMetadata(request));
+
+        validateBasicResponse(response);
     }
+
+    // ─── Token source ────────────────────────────────────────────────────────
 
     @Test
     void shouldRequestCardMetadataForToken() {
-        final CheckoutApi checkoutApi = createCheckoutApi();
-        final CardTokenRequest cardTokenRequest = createCardTokenRequest();
+        final CheckoutApi staticKeyApi = createStaticKeyApi();
+        final String token = blocking(
+                () -> staticKeyApi.tokensClient().requestCardToken(createCardTokenRequest())).getToken();
 
-        final String token = blocking(() -> checkoutApi.tokensClient().requestCardToken(cardTokenRequest)).getToken();
-
-        final CardMetadataRequest metadataCardRequest = CardMetadataRequest.builder()
-                .source(CardMetadataTokenSource.builder()
-                        .token(token)
-                        .build())
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataTokenSource.builder().token(token).build())
                 .format(CardMetadataFormatType.BASIC)
                 .build();
 
-        final CardMetadataResponse cardMetadataResponse = blocking(
-                () -> checkoutApi.metadataClient().requestCardMetadata(metadataCardRequest));
-        
-        validateResponse(cardMetadataResponse);
+        final CardMetadataResponse response = blocking(
+                () -> checkoutApi.metadataClient().requestCardMetadata(request));
+
+        validateBasicResponse(response);
     }
 
-    // Sync methods
+    // ─── Sync variants ──────────────────────────────────────────────────────
+
     @Test
     void shouldRequestMetadataCardForBinNumberSync() {
-
-        final CardMetadataRequest metadataCardRequest = CardMetadataRequest.builder()
+        final CardMetadataRequest request = CardMetadataRequest.builder()
                 .source(CardMetadataBinSource.builder()
                         .bin(CardSourceHelper.Visa.NUMBER.substring(0, 6))
                         .build())
                 .format(CardMetadataFormatType.BASIC)
                 .build();
 
-        final CardMetadataResponse cardMetadataResponse = checkoutApi.metadataClient().requestCardMetadataSync(metadataCardRequest);
-        
-        validateResponse(cardMetadataResponse);
+        final CardMetadataResponse response = checkoutApi.metadataClient().requestCardMetadataSync(request);
 
+        validateBasicResponse(response);
     }
 
     @Test
     void shouldRequestCardMetadataForCardNumberSync() {
-
-        final CardMetadataRequest metadataCardRequest = CardMetadataRequest.builder()
+        final CardMetadataRequest request = CardMetadataRequest.builder()
                 .source(CardMetadataCardSource.builder()
                         .number(CardSourceHelper.Visa.NUMBER)
                         .build())
                 .format(CardMetadataFormatType.BASIC)
                 .build();
 
-        final CardMetadataResponse cardMetadataResponse = checkoutApi.metadataClient().requestCardMetadataSync(metadataCardRequest);
-        
-        validateResponse(cardMetadataResponse);
+        final CardMetadataResponse response = checkoutApi.metadataClient().requestCardMetadataSync(request);
+
+        validateBasicResponse(response);
     }
 
     @Test
     void shouldRequestCardMetadataForTokenSync() {
-        final CheckoutApi checkoutApi = createCheckoutApi();
-        final CardTokenRequest cardTokenRequest = createCardTokenRequest();
+        final CheckoutApi staticKeyApi = createStaticKeyApi();
+        final String token = staticKeyApi.tokensClient()
+                .requestCardTokenSync(createCardTokenRequest()).getToken();
 
-        final String token = checkoutApi.tokensClient().requestCardTokenSync(cardTokenRequest).getToken();
-
-        final CardMetadataRequest metadataCardRequest = CardMetadataRequest.builder()
-                .source(CardMetadataTokenSource.builder()
-                        .token(token)
-                        .build())
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataTokenSource.builder().token(token).build())
                 .format(CardMetadataFormatType.BASIC)
                 .build();
 
-        final CardMetadataResponse cardMetadataResponse = checkoutApi.metadataClient().requestCardMetadataSync(metadataCardRequest);
-        
-        validateResponse(cardMetadataResponse);
+        final CardMetadataResponse response = checkoutApi.metadataClient().requestCardMetadataSync(request);
+
+        validateBasicResponse(response);
     }
 
-    // Common methods
-    private CheckoutApiImpl createCheckoutApi() {
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private CheckoutApiImpl createStaticKeyApi() {
         return CheckoutSdk.builder().staticKeys()
                 .publicKey(System.getenv("CHECKOUT_DEFAULT_PUBLIC_KEY"))
                 .secretKey(System.getenv("CHECKOUT_DEFAULT_SECRET_KEY"))
@@ -150,17 +178,16 @@ class CardMetadataIT extends SandboxTestFixture {
                 .build();
     }
 
-    private void validateResponse(final CardMetadataResponse cardMetadataResponse)
-    {
-        assertNotNull(cardMetadataResponse);
-        assertNotNull(cardMetadataResponse.getBin());
-        assertNotNull(cardMetadataResponse.getScheme());
-        assertNotNull(cardMetadataResponse.getCardType());
-        assertNotNull(cardMetadataResponse.getCardCategory());
-        assertNotNull(cardMetadataResponse.getIssuerCountry());
-        assertNotNull(cardMetadataResponse.getIssuerCountryName());
-        assertNotNull(cardMetadataResponse.getProductId());
-        assertNotNull(cardMetadataResponse.getProductType());
-        assertEquals(200, cardMetadataResponse.getHttpStatusCode());
+    private void validateBasicResponse(final CardMetadataResponse response) {
+        assertNotNull(response);
+        assertNotNull(response.getBin());
+        assertNotNull(response.getScheme());
+        assertNotNull(response.getCardType());
+        assertNotNull(response.getCardCategory());
+        assertNotNull(response.getIssuerCountry());
+        assertNotNull(response.getIssuerCountryName());
+        assertNotNull(response.getProductId());
+        assertNotNull(response.getProductType());
+        assertEquals(200, response.getHttpStatusCode());
     }
 }

--- a/src/test/java/com/checkout/metadata/CardMetadataSerializationTest.java
+++ b/src/test/java/com/checkout/metadata/CardMetadataSerializationTest.java
@@ -1,0 +1,413 @@
+package com.checkout.metadata;
+
+import com.checkout.GsonSerializer;
+import com.checkout.common.CardCategory;
+import com.checkout.common.CardType;
+import com.checkout.common.CountryCode;
+import com.checkout.common.Currency;
+import com.checkout.common.SchemeLocalType;
+import com.checkout.metadata.card.AccountFundingTransaction;
+import com.checkout.metadata.card.AftIndicator;
+import com.checkout.metadata.card.CardMetadataFormatType;
+import com.checkout.metadata.card.CardMetadataPayouts;
+import com.checkout.metadata.card.CardMetadataRequest;
+import com.checkout.metadata.card.CardMetadataResponse;
+import com.checkout.metadata.card.CardMetadataSourceType;
+import com.checkout.metadata.card.PayoutsTransactionsType;
+import com.checkout.metadata.card.PinlessDebitSchemeMetadata;
+import com.checkout.metadata.card.PullFunds;
+import com.checkout.metadata.card.SchemeMetadata;
+import com.checkout.metadata.card.source.CardMetadataBinSource;
+import com.checkout.metadata.card.source.CardMetadataCardSource;
+import com.checkout.metadata.card.source.CardMetadataIdSource;
+import com.checkout.metadata.card.source.CardMetadataTokenSource;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Schema validation tests for CardMetadataRequest and CardMetadataResponse.
+ * Validates serialization/deserialization correctness for all fields.
+ */
+class CardMetadataSerializationTest {
+
+    private final GsonSerializer serializer = new GsonSerializer();
+
+    // ─── CardMetadataRequest ────────────────────────────────────────────────
+
+    @Test
+    void shouldSerializeRequestWithBinSource() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataBinSource.builder().bin("454347").build())
+                .format(CardMetadataFormatType.BASIC)
+                .build();
+
+        final String json = serializer.toJson(request);
+
+        assertNotNull(json);
+        assertTrue(json.contains("\"type\":\"bin\""));
+        assertTrue(json.contains("\"bin\":\"454347\""));
+        assertTrue(json.contains("\"format\":\"basic\""));
+    }
+
+    @Test
+    void shouldSerializeRequestWithCardSource() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataCardSource.builder().number("4543474002249996").build())
+                .format(CardMetadataFormatType.CARD_PAYOUTS)
+                .build();
+
+        final String json = serializer.toJson(request);
+
+        assertNotNull(json);
+        assertTrue(json.contains("\"type\":\"card\""));
+        assertTrue(json.contains("\"number\":\"4543474002249996\""));
+        assertTrue(json.contains("\"format\":\"card_payouts\""));
+    }
+
+    @Test
+    void shouldSerializeRequestWithTokenSource() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataTokenSource.builder().token("tok_ubfj2q76miwundwlk72vxt2i7q").build())
+                .format(CardMetadataFormatType.BASIC)
+                .build();
+
+        final String json = serializer.toJson(request);
+
+        assertNotNull(json);
+        assertTrue(json.contains("\"type\":\"token\""));
+        assertTrue(json.contains("\"token\":\"tok_ubfj2q76miwundwlk72vxt2i7q\""));
+    }
+
+    @Test
+    void shouldSerializeRequestWithIdSource() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataIdSource.builder().id("src_wmlfc3zyhqzehihu7giusaaawu").build())
+                .format(CardMetadataFormatType.CARD_PAYOUTS)
+                .build();
+
+        final String json = serializer.toJson(request);
+
+        assertNotNull(json);
+        assertTrue(json.contains("\"type\":\"id\""));
+        assertTrue(json.contains("\"id\":\"src_wmlfc3zyhqzehihu7giusaaawu\""));
+    }
+
+    @Test
+    void shouldSerializeRequestWithReferenceField() {
+        final CardMetadataRequest request = CardMetadataRequest.builder()
+                .source(CardMetadataBinSource.builder().bin("454347").build())
+                .format(CardMetadataFormatType.BASIC)
+                .reference("ORD-5023-4E89")
+                .build();
+
+        final String json = serializer.toJson(request);
+
+        assertNotNull(json);
+        assertTrue(json.contains("\"reference\":\"ORD-5023-4E89\""));
+    }
+
+    @Test
+    void shouldRoundTripRequest() {
+        final CardMetadataRequest original = CardMetadataRequest.builder()
+                .source(CardMetadataCardSource.builder().number("4543474002249996").build())
+                .format(CardMetadataFormatType.CARD_PAYOUTS)
+                .reference("ORD-5023-4E89")
+                .build();
+
+        final String json = serializer.toJson(original);
+        final CardMetadataRequest deserialized = serializer.fromJson(json, CardMetadataRequest.class);
+
+        assertNotNull(deserialized);
+        assertEquals(CardMetadataFormatType.CARD_PAYOUTS, deserialized.getFormat());
+        assertEquals("ORD-5023-4E89", deserialized.getReference());
+    }
+
+    @Test
+    void shouldDeserializeRequestFromSwaggerCardExample() {
+        final String json = "{\"source\":{\"type\":\"card\",\"number\":\"4539467987109256\"},\"format\":\"basic\"}";
+
+        final CardMetadataRequest request = serializer.fromJson(json, CardMetadataRequest.class);
+
+        assertNotNull(request);
+        assertEquals(CardMetadataFormatType.BASIC, request.getFormat());
+        assertNotNull(request.getSource());
+        assertEquals(CardMetadataSourceType.CARD, request.getSource().getType());
+    }
+
+    @Test
+    void shouldDeserializeRequestFromSwaggerBinExample() {
+        final String json = "{\"source\":{\"type\":\"bin\",\"bin\":\"424242\"},\"format\":\"card_payouts\"}";
+
+        final CardMetadataRequest request = serializer.fromJson(json, CardMetadataRequest.class);
+
+        assertNotNull(request);
+        assertEquals(CardMetadataFormatType.CARD_PAYOUTS, request.getFormat());
+    }
+
+    // ─── CardMetadataResponse ───────────────────────────────────────────────
+
+    @Test
+    void shouldDeserializeBasicResponseFromSwaggerExample() {
+        final String json = "{"
+                + "\"bin\":\"45434720\","
+                + "\"scheme\":\"visa\","
+                + "\"local_schemes\":[\"cartes_bancaires\"],"
+                + "\"card_type\":\"CREDIT\","
+                + "\"card_category\":\"CONSUMER\","
+                + "\"currency\":\"MUR\","
+                + "\"issuer\":\"STATE BANK OF MAURITIUS\","
+                + "\"issuer_country\":\"MU\","
+                + "\"issuer_country_name\":\"Mauritius\","
+                + "\"is_combo_card\":false,"
+                + "\"product_id\":\"F\","
+                + "\"product_type\":\"Visa Classic\","
+                + "\"subproduct_id\":\"VA\","
+                + "\"regulated_indicator\":false,"
+                + "\"is_reloadable_prepaid\":false,"
+                + "\"anonymous_prepaid_description\":\"Anonymous prepaid program and not AMLD5 compliant\""
+                + "}";
+
+        final CardMetadataResponse response = serializer.fromJson(json, CardMetadataResponse.class);
+
+        assertNotNull(response);
+        assertEquals("45434720", response.getBin());
+        assertEquals("visa", response.getScheme());
+        assertNotNull(response.getLocalSchemes());
+        assertEquals(1, response.getLocalSchemes().size());
+        assertEquals(SchemeLocalType.CARTES_BANCAIRES, response.getLocalSchemes().get(0));
+        assertEquals(CardType.CREDIT, response.getCardType());
+        assertEquals(CardCategory.CONSUMER, response.getCardCategory());
+        assertEquals(Currency.MUR, response.getCurrency());
+        assertEquals("STATE BANK OF MAURITIUS", response.getIssuer());
+        assertEquals(CountryCode.MU, response.getIssuerCountry());
+        assertEquals("Mauritius", response.getIssuerCountryName());
+        assertFalse(response.getIsComboCard());
+        assertEquals("F", response.getProductId());
+        assertEquals("Visa Classic", response.getProductType());
+        assertEquals("VA", response.getSubproductId());
+        assertFalse(response.getRegulatedIndicator());
+        assertFalse(response.getIsReloadablePrepaid());
+        assertEquals("Anonymous prepaid program and not AMLD5 compliant", response.getAnonymousPrepaidDescription());
+    }
+
+    @Test
+    void shouldDeserializeCardPayoutsResponseFromSwaggerExample() {
+        final String json = "{"
+                + "\"bin\":\"45434720\","
+                + "\"scheme\":\"visa\","
+                + "\"card_payouts\":{"
+                + "\"domestic_non_money_transfer\":\"not_supported\","
+                + "\"cross_border_non_money_transfer\":\"standard\","
+                + "\"domestic_gambling\":\"fast_funds\","
+                + "\"cross_border_gambling\":\"unknown\","
+                + "\"domestic_money_transfer\":\"unknown\","
+                + "\"cross_border_money_transfer\":\"not_supported\""
+                + "}"
+                + "}";
+
+        final CardMetadataResponse response = serializer.fromJson(json, CardMetadataResponse.class);
+
+        assertNotNull(response);
+        assertNotNull(response.getPayouts());
+        assertEquals(PayoutsTransactionsType.NOT_SUPPORTED, response.getPayouts().getDomesticNonMoneyTransfer());
+        assertEquals(PayoutsTransactionsType.STANDARD, response.getPayouts().getCrossBorderNonMoneyTransfer());
+        assertEquals(PayoutsTransactionsType.FAST_FUNDS, response.getPayouts().getDomesticGambling());
+        assertEquals(PayoutsTransactionsType.UNKNOWN, response.getPayouts().getCrossBorderGambling());
+        assertEquals(PayoutsTransactionsType.UNKNOWN, response.getPayouts().getDomesticMoneyTransfer());
+        assertEquals(PayoutsTransactionsType.NOT_SUPPORTED, response.getPayouts().getCrossBorderMoneyTransfer());
+    }
+
+    @Test
+    void shouldDeserializeSchemeMetadataAndAftFields() {
+        final String json = "{"
+                + "\"bin\":\"45434720\","
+                + "\"scheme\":\"visa\","
+                + "\"regulated_type\":\"base_regulated\","
+                + "\"scheme_metadata\":{"
+                + "  \"accel\":[{\"network_id\":\"aam\",\"network_description\":\"Accel\","
+                + "    \"bill_pay_indicator\":true,\"ecommerce_indicator\":true,"
+                + "    \"interchange_fee_indicator\":\"00\",\"money_transfer_indicator\":true,"
+                + "    \"token_indicator\":false}],"
+                + "  \"shazam\":[{\"network_id\":\"shz\",\"network_description\":\"Shazam\","
+                + "    \"bill_pay_indicator\":false,\"ecommerce_indicator\":true,"
+                + "    \"interchange_fee_indicator\":\"01\",\"money_transfer_indicator\":false,"
+                + "    \"token_indicator\":true}]"
+                + "},"
+                + "\"account_funding_transaction\":{"
+                + "  \"aft_indicator\":{"
+                + "    \"pull_funds\":{\"cross_border\":true,\"domestic\":true}"
+                + "  }"
+                + "}"
+                + "}";
+
+        final CardMetadataResponse response = serializer.fromJson(json, CardMetadataResponse.class);
+
+        assertNotNull(response);
+        assertEquals("base_regulated", response.getRegulatedType());
+
+        final SchemeMetadata schemeMetadata = response.getSchemeMetadata();
+        assertNotNull(schemeMetadata);
+        assertNotNull(schemeMetadata.getAccel());
+        assertEquals(1, schemeMetadata.getAccel().size());
+        assertEquals("aam", schemeMetadata.getAccel().get(0).getNetworkId());
+        assertEquals("Accel", schemeMetadata.getAccel().get(0).getNetworkDescription());
+        assertTrue(schemeMetadata.getAccel().get(0).getBillPayIndicator());
+        assertTrue(schemeMetadata.getAccel().get(0).getEcommerceIndicator());
+        assertEquals("00", schemeMetadata.getAccel().get(0).getInterchangeFeeIndicator());
+        assertTrue(schemeMetadata.getAccel().get(0).getMoneyTransferIndicator());
+        assertFalse(schemeMetadata.getAccel().get(0).getTokenIndicator());
+
+        assertNotNull(schemeMetadata.getShazam());
+        assertEquals(1, schemeMetadata.getShazam().size());
+        assertEquals("shz", schemeMetadata.getShazam().get(0).getNetworkId());
+
+        final AccountFundingTransaction aft = response.getAccountFundingTransaction();
+        assertNotNull(aft);
+        assertNotNull(aft.getAftIndicator());
+        assertNotNull(aft.getAftIndicator().getPullFunds());
+        assertTrue(aft.getAftIndicator().getPullFunds().getCrossBorder());
+        assertTrue(aft.getAftIndicator().getPullFunds().getDomestic());
+    }
+
+    @Test
+    void shouldDeserializeDeprecatedSchemeLocalField() {
+        final String json = "{\"bin\":\"45434720\",\"scheme\":\"visa\",\"scheme_local\":\"cartes_bancaires\"}";
+
+        final CardMetadataResponse response = serializer.fromJson(json, CardMetadataResponse.class);
+
+        assertNotNull(response);
+        assertEquals(SchemeLocalType.CARTES_BANCAIRES, response.getSchemeLocal());
+    }
+
+    @Test
+    void shouldDeserializeNewSchemeLocalValues() {
+        final String json = "{\"bin\":\"45434720\",\"scheme\":\"visa\","
+                + "\"local_schemes\":[\"shazam\",\"paypak\",\"maestro\"]}";
+
+        final CardMetadataResponse response = serializer.fromJson(json, CardMetadataResponse.class);
+
+        assertNotNull(response);
+        assertNotNull(response.getLocalSchemes());
+        assertEquals(3, response.getLocalSchemes().size());
+        assertTrue(response.getLocalSchemes().contains(SchemeLocalType.SHAZAM));
+        assertTrue(response.getLocalSchemes().contains(SchemeLocalType.PAYPAK));
+        assertTrue(response.getLocalSchemes().contains(SchemeLocalType.MAESTRO));
+    }
+
+    @Test
+    void shouldHandleResponseWithNullOptionalFields() {
+        final String json = "{\"bin\":\"45434720\",\"scheme\":\"visa\"}";
+
+        final CardMetadataResponse response = serializer.fromJson(json, CardMetadataResponse.class);
+
+        assertNotNull(response);
+        assertEquals("45434720", response.getBin());
+        assertEquals("visa", response.getScheme());
+        assertNull(response.getLocalSchemes());
+        assertNull(response.getCardType());
+        assertNull(response.getPayouts());
+        assertNull(response.getSchemeMetadata());
+        assertNull(response.getAccountFundingTransaction());
+        assertNull(response.getIsComboCard());
+        assertNull(response.getIsReloadablePrepaid());
+        assertNull(response.getAnonymousPrepaidDescription());
+    }
+
+    @Test
+    void shouldRoundTripFullyPopulatedResponse() {
+        final PinlessDebitSchemeMetadata pinlessData = new PinlessDebitSchemeMetadata(
+                "aam", "Accel Money Transfer Advantage", true, true, "00", true, false);
+
+        final SchemeMetadata schemeMetadata = new SchemeMetadata();
+        schemeMetadata.setAccel(Arrays.asList(pinlessData));
+        schemeMetadata.setShazam(Arrays.asList(new PinlessDebitSchemeMetadata(
+                "shz", "Shazam", false, true, "01", false, true)));
+
+        final PullFunds pullFunds = new PullFunds();
+        pullFunds.setCrossBorder(true);
+        pullFunds.setDomestic(false);
+
+        final AftIndicator aftIndicator = new AftIndicator();
+        aftIndicator.setPullFunds(pullFunds);
+
+        final AccountFundingTransaction aft = new AccountFundingTransaction();
+        aft.setAftIndicator(aftIndicator);
+
+        final CardMetadataPayouts payouts = new CardMetadataPayouts();
+        payouts.setDomesticNonMoneyTransfer(PayoutsTransactionsType.NOT_SUPPORTED);
+        payouts.setCrossBorderNonMoneyTransfer(PayoutsTransactionsType.STANDARD);
+        payouts.setDomesticGambling(PayoutsTransactionsType.FAST_FUNDS);
+        payouts.setCrossBorderGambling(PayoutsTransactionsType.UNKNOWN);
+        payouts.setDomesticMoneyTransfer(PayoutsTransactionsType.UNKNOWN);
+        payouts.setCrossBorderMoneyTransfer(PayoutsTransactionsType.NOT_SUPPORTED);
+
+        final CardMetadataResponse original = new CardMetadataResponse();
+        original.setBin("45434720");
+        original.setScheme("visa");
+        original.setLocalSchemes(Arrays.asList(SchemeLocalType.CARTES_BANCAIRES, SchemeLocalType.SHAZAM));
+        original.setCardType(CardType.CREDIT);
+        original.setCardCategory(CardCategory.CONSUMER);
+        original.setCurrency(Currency.MUR);
+        original.setIssuer("STATE BANK OF MAURITIUS");
+        original.setIssuerCountry(CountryCode.MU);
+        original.setIssuerCountryName("Mauritius");
+        original.setIsComboCard(false);
+        original.setProductId("F");
+        original.setProductType("Visa Classic");
+        original.setSubproductId("VA");
+        original.setRegulatedIndicator(false);
+        original.setRegulatedType("base_regulated");
+        original.setIsReloadablePrepaid(false);
+        original.setAnonymousPrepaidDescription("Anonymous prepaid program and not AMLD5 compliant");
+        original.setPayouts(payouts);
+        original.setSchemeMetadata(schemeMetadata);
+        original.setAccountFundingTransaction(aft);
+
+        final String json = serializer.toJson(original);
+        final CardMetadataResponse deserialized = serializer.fromJson(json, CardMetadataResponse.class);
+
+        assertNotNull(deserialized);
+        assertEquals(original.getBin(), deserialized.getBin());
+        assertEquals(original.getScheme(), deserialized.getScheme());
+        assertEquals(2, deserialized.getLocalSchemes().size());
+        assertEquals(CardType.CREDIT, deserialized.getCardType());
+        assertEquals(CardCategory.CONSUMER, deserialized.getCardCategory());
+        assertEquals(Currency.MUR, deserialized.getCurrency());
+        assertEquals("STATE BANK OF MAURITIUS", deserialized.getIssuer());
+        assertEquals(CountryCode.MU, deserialized.getIssuerCountry());
+        assertEquals("Mauritius", deserialized.getIssuerCountryName());
+        assertFalse(deserialized.getIsComboCard());
+        assertEquals("F", deserialized.getProductId());
+        assertEquals("Visa Classic", deserialized.getProductType());
+        assertEquals("VA", deserialized.getSubproductId());
+        assertFalse(deserialized.getRegulatedIndicator());
+        assertEquals("base_regulated", deserialized.getRegulatedType());
+        assertFalse(deserialized.getIsReloadablePrepaid());
+        assertEquals("Anonymous prepaid program and not AMLD5 compliant", deserialized.getAnonymousPrepaidDescription());
+
+        assertNotNull(deserialized.getPayouts());
+        assertEquals(PayoutsTransactionsType.NOT_SUPPORTED, deserialized.getPayouts().getDomesticNonMoneyTransfer());
+        assertEquals(PayoutsTransactionsType.STANDARD, deserialized.getPayouts().getCrossBorderNonMoneyTransfer());
+        assertEquals(PayoutsTransactionsType.FAST_FUNDS, deserialized.getPayouts().getDomesticGambling());
+        assertEquals(PayoutsTransactionsType.UNKNOWN, deserialized.getPayouts().getCrossBorderGambling());
+        assertEquals(PayoutsTransactionsType.UNKNOWN, deserialized.getPayouts().getDomesticMoneyTransfer());
+        assertEquals(PayoutsTransactionsType.NOT_SUPPORTED, deserialized.getPayouts().getCrossBorderMoneyTransfer());
+
+        assertNotNull(deserialized.getSchemeMetadata());
+        assertNotNull(deserialized.getSchemeMetadata().getAccel());
+        assertEquals("aam", deserialized.getSchemeMetadata().getAccel().get(0).getNetworkId());
+        assertNotNull(deserialized.getSchemeMetadata().getShazam());
+
+        assertNotNull(deserialized.getAccountFundingTransaction());
+        assertNotNull(deserialized.getAccountFundingTransaction().getAftIndicator());
+        assertTrue(deserialized.getAccountFundingTransaction().getAftIndicator().getPullFunds().getCrossBorder());
+        assertFalse(deserialized.getAccountFundingTransaction().getAftIndicator().getPullFunds().getDomestic());
+    }
+}


### PR DESCRIPTION
- Add missing fields to CardMetadataRequest (reference) and CardMetadataResponse (is_combo_card, is_reloadable_prepaid, anonymous_prepaid_description)
- Add shazam to SchemeMetadata; add SHAZAM, PAYPAK, MAESTRO to SchemeLocalType enum
- Fix interchangeFeeIndicator field name typo in PinlessDebitSchemeMetadata
- Register RuntimeTypeAdapterFactory (maintainType=true) for CardMetadataRequestSource subtypes in GsonSerializer
- Complete JavaDoc on all metadata/card classes with swagger constraints
- Add CardMetadataSerializationTest (15 schema tests)
- Expand CardMetadataClientImplTest to cover all 4 source types (13 tests)
- Add card_payouts format and reference field tests to CardMetadataIT