### PR TITLE
Eliminated deprecated country field from PaymentRecipient

### DIFF
--- a/src/main/java/com/checkout/payments/PaymentRecipient.java
+++ b/src/main/java/com/checkout/payments/PaymentRecipient.java
@@ -1,7 +1,6 @@
 package com.checkout.payments;
 
 import com.checkout.common.Address;
-import com.checkout.common.CountryCode;
 import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import lombok.Data;
@@ -25,7 +24,4 @@ public final class PaymentRecipient {
 
     @SerializedName("last_name")
     private String lastName;
-
-    private CountryCode country;
-
 }

--- a/src/test/java/com/checkout/TestHelper.java
+++ b/src/test/java/com/checkout/TestHelper.java
@@ -426,7 +426,6 @@ public final class TestHelper {
     public static PaymentRecipient createRecipient() {
         return PaymentRecipient.builder()
                 .accountNumber("1234567")
-                .country(CountryCode.ES)
                 .dateOfBirth("1985-05-15")
                 .firstName("IT")
                 .lastName("TESTING")

--- a/src/test/java/com/checkout/payments/GetPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/GetPaymentsTestIT.java
@@ -368,7 +368,6 @@ class GetPaymentsTestIT extends AbstractPaymentsTestIT {
     private PaymentRecipient createPaymentRecipient() {
         return PaymentRecipient.builder()
                 .accountNumber("1234567")
-                .country(CountryCode.ES)
                 .dateOfBirth("1985-05-15")
                 .firstName("IT")
                 .lastName("TESTING")


### PR DESCRIPTION
This pull request removes the `country` field of type `CountryCode` from the `PaymentRecipient` class and updates related test code to reflect this change. This simplifies the data model for payment recipients by eliminating the country information.

Model simplification:

* Removed the `country` field (of type `CountryCode`) from the `PaymentRecipient` class in `PaymentRecipient.java`.
* Removed the unused import of `CountryCode` from `PaymentRecipient.java`.

Test updates:

* Updated `TestHelper.java` and `GetPaymentsTestIT.java` to remove usage of the `country` field when creating `PaymentRecipient` instances in tests. [[1]](diffhunk://#diff-7eed3ab7caafd166ca7eeb0ca2651111f803f1a7cb2c00e1d9ec756f63795ab8L429) [[2]](diffhunk://#diff-370b2a65ef1e4f33b8a25c92f027070e9943e74fe126ddc5f96cc55b8d9a49d1L371)