### PR TITLE
Release/7.7.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.checkout
-version=7.7.0
+version=7.7.1
 
 project_name=Checkout SDK Java
 project_description=Checkout SDK for Java https://checkout.com

--- a/src/test/java/com/checkout/payments/RequestApmPaymentsIT.java
+++ b/src/test/java/com/checkout/payments/RequestApmPaymentsIT.java
@@ -139,6 +139,7 @@ class RequestApmPaymentsIT extends AbstractPaymentsTestIT {
     }
 
     @Test
+    @Disabled("APM is currently unavailable, temporary skipping the qpay failing test")
     void shouldMakeQPayPayment() throws ExecutionException, InterruptedException {
         final PaymentRequest paymentRequest = createQPayPaymentRequest();
         checkErrorItem(() -> paymentsClient.requestPayment(paymentRequest), PAYEE_NOT_ONBOARDED);
@@ -351,6 +352,7 @@ class RequestApmPaymentsIT extends AbstractPaymentsTestIT {
     }
 
     @Test
+    @Disabled("APM is currently unavailable, temporary skipping the qpay failing test")
     void shouldMakeQPayPaymentSync() {
         final PaymentRequest paymentRequest = createQPayPaymentRequest();
         checkErrorItemSync(() -> paymentsClient.requestPaymentSync(paymentRequest), PAYEE_NOT_ONBOARDED);


### PR DESCRIPTION
Version update:

* New "blik" paymentMethodType was added

Test maintenance:

* Added the `@Disabled` annotation to `shouldMakeQPayPayment` and `shouldMakeQPayPaymentSync` tests in `RequestApmPaymentsIT.java` to temporarily skip these tests while APM is unavailable. [[1]](diffhunk://#diff-a7087b9991275440d1c89f5862bbba838d029e13c01dd45d9dbdc7d7b405039fR142) [[2]](diffhunk://#diff-a7087b9991275440d1c89f5862bbba838d029e13c01dd45d9dbdc7d7b405039fR355)