### PR TITLE
Enums adjustment, PaymentStatus.java Added RETRY_SCHEDULED ("Retry Sc…

### DIFF
--- a/src/main/java/com/checkout/common/Exemption.java
+++ b/src/main/java/com/checkout/common/Exemption.java
@@ -26,7 +26,7 @@ public enum Exemption {
     DATA_SHARE,
     @SerializedName("other")
     OTHER,
-    @SerializedName(value = "None", alternate = {"NONE", "none"})
+    @SerializedName(value = "none", alternate = {"None", "NONE"})
     NONE,
     @SerializedName("secure_corporate_payment")
     SECURE_CORPORATE_PAYMENT,

--- a/src/main/java/com/checkout/payments/PaymentStatus.java
+++ b/src/main/java/com/checkout/payments/PaymentStatus.java
@@ -34,6 +34,8 @@ public enum PaymentStatus {
     REFUNDED,
     @SerializedName("Authentication Requested")
     AUTHENTICATION_REQUESTED,
+    @SerializedName("Retry Scheduled")
+    RETRY_SCHEDULED,
 
 }
 

--- a/src/main/java/com/checkout/payments/PaymentType.java
+++ b/src/main/java/com/checkout/payments/PaymentType.java
@@ -7,7 +7,7 @@ public enum PaymentType {
     @SerializedName("Installment")
     INSTALLMENT,
 
-    @SerializedName(value = "Moto", alternate = "MOTO")
+    @SerializedName(value = "MOTO", alternate = "Moto")
     MOTO,
 
     @SerializedName("PayLater")


### PR DESCRIPTION
This pull request updates enum definitions to improve serialization consistency and support new payment status values. The most important changes are grouped below:

New payment status support:

* In `PaymentStatus`, a new enum value `RETRY_SCHEDULED` with serialized name `"Retry Scheduled"` has been added to represent payments scheduled for retry.

Enum serialization improvements:

* In `Exemption`, the `@SerializedName` annotation for the `NONE` value now uses `"none"` as the primary value, with `"None"` and `"NONE"` as alternates, ensuring consistent lowercase serialization and swagger definition.
* In `PaymentType`, the `@SerializedName` annotation for the `MOTO` value now uses `"MOTO"` as the primary value, with `"Moto"` as an alternate, standardizing the serialized output with the swagger definition.

