### PR TITLE
Release 7.7.3 - SDK enum updates and improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.checkout
-version=7.7.2
+version=7.7.3
 
 project_name=Checkout SDK Java
 project_description=Checkout SDK for Java https://checkout.com


### PR DESCRIPTION
## Summary

This release updates enum definitions to improve serialization consistency and support new payment status values. The most important changes are grouped below:

New payment status support:

* In `PaymentStatus`, a new enum value `RETRY_SCHEDULED` with serialized name `"Retry Scheduled"` has been added to represent payments scheduled for retry.

Enum serialization improvements:

* In `Exemption`, the `@SerializedName` annotation for the `NONE` value now uses `"none"` as the primary value, with `"None"` and `"NONE"` as alternates, ensuring consistent lowercase serialization and swagger definition.
* In `PaymentType`, the `@SerializedName` annotation for the `MOTO` value now uses `"MOTO"` as the primary value, with `"Moto"` as an alternate, standardizing the serialized output with the swagger definition.

and 
## Summary

- Adds the five exemption values (`LOW_VALUE`, `TRUSTED_LISTING`, `TRUSTED_LISTING_PROMPT`, `TRANSACTION_RISK_ASSESSMENT`, `DATA_SHARE`) back to `com.checkout.common.ChallengeIndicator`, matching the named `ChallengeIndicator` schema used by `POST /sessions` (3DS Standalone Authentication).
- Adds `ChallengeIndicatorTest` covering serialization, deserialization and round-trip for all nine values via the Gson serializer.

## Why

A prior refactor moved these values out of `ChallengeIndicator` into a separate `Exemption` enum, but `SessionRequest.challengeIndicator` was never updated to accept exemptions through any other field. That broke merchant code such as:

```java
SessionRequest.builder()
    .challengeIndicator(ChallengeIndicator.TRANSACTION_RISK_ASSESSMENT)
    .build();
```

A merchant on the Standalone Authentication product is currently blocked from upgrading the SDK because of this.

The new values carry a JavaDoc note indicating they are only valid for POST /sessions. The inline challenge_indicator used by POST /payments three_ds and by session responses still only accepts the original four values — the API rejects the others at runtime.

## Follow-up (separate PR)

A cleaner split is still pending: introduce com.checkout.sessions.SessionChallengeIndicator (9 values) and mark the five new values on common.ChallengeIndicator as @Deprecated so the swagger-level distinction (named schema for /sessions vs inline 4-value enum for /payments) is reflected in the SDK type system. Keeping this PR minimal to unblock the merchant first.

## Test plan

- [ ] CI: ./gradlew compileJava compileTestJava passes
- [ ] CI: ./gradlew javadoc passes (no broken JavaDoc tags)
- [ ] CI: ./gradlew test --tests ChallengeIndicatorTest passes
- [ ] Sanity: build a SessionRequest with each of the five new values and confirm the JSON body has the expected snake_case string for challenge_indicator