### PR TITLE
fix(sessions): restore exemption values on ChallengeIndicator enum

### DIFF
--- a/src/main/java/com/checkout/common/ChallengeIndicator.java
+++ b/src/main/java/com/checkout/common/ChallengeIndicator.java
@@ -2,6 +2,19 @@ package com.checkout.common;
 
 import com.google.gson.annotations.SerializedName;
 
+/**
+ * Indicates whether a challenge is requested for an authentication.
+ * <p>
+ * The first four values are valid for all endpoints that accept a challenge indicator
+ * (e.g. {@code POST /payments} {@code three_ds.challenge_indicator}, {@code POST /sessions},
+ * and their responses).
+ * <p>
+ * The remaining values ({@link #LOW_VALUE}, {@link #TRUSTED_LISTING},
+ * {@link #TRUSTED_LISTING_PROMPT}, {@link #TRANSACTION_RISK_ASSESSMENT}, {@link #DATA_SHARE})
+ * represent requests for exemption and are only valid for {@code POST /sessions}
+ * (3DS Standalone Authentication). If an exemption cannot be applied, the value
+ * {@link #NO_CHALLENGE_REQUESTED} will be used instead.
+ */
 public enum ChallengeIndicator {
 
     @SerializedName("challenge_requested")
@@ -12,5 +25,31 @@ public enum ChallengeIndicator {
     NO_CHALLENGE_REQUESTED,
     @SerializedName("no_preference")
     NO_PREFERENCE,
+    /**
+     * Request a low-value exemption. Only valid for {@code POST /sessions}.
+     */
+    @SerializedName("low_value")
+    LOW_VALUE,
+    /**
+     * Request a trusted listing exemption. Only valid for {@code POST /sessions}.
+     */
+    @SerializedName("trusted_listing")
+    TRUSTED_LISTING,
+    /**
+     * Request a trusted listing prompt to add the merchant to the cardholder's trusted list.
+     * Only valid for {@code POST /sessions}.
+     */
+    @SerializedName("trusted_listing_prompt")
+    TRUSTED_LISTING_PROMPT,
+    /**
+     * Request a transaction risk analysis (TRA) exemption. Only valid for {@code POST /sessions}.
+     */
+    @SerializedName("transaction_risk_assessment")
+    TRANSACTION_RISK_ASSESSMENT,
+    /**
+     * Indicates a data-share authentication request. Only valid for {@code POST /sessions}.
+     */
+    @SerializedName("data_share")
+    DATA_SHARE,
 
 }

--- a/src/test/java/com/checkout/common/ChallengeIndicatorTest.java
+++ b/src/test/java/com/checkout/common/ChallengeIndicatorTest.java
@@ -1,0 +1,52 @@
+package com.checkout.common;
+
+import com.checkout.GsonSerializer;
+import com.checkout.Serializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ChallengeIndicatorTest {
+
+    private final Serializer serializer = new GsonSerializer();
+
+    private static Stream<Arguments> challengeIndicators() {
+        return Stream.of(
+                Arguments.of(ChallengeIndicator.NO_PREFERENCE, "\"no_preference\""),
+                Arguments.of(ChallengeIndicator.NO_CHALLENGE_REQUESTED, "\"no_challenge_requested\""),
+                Arguments.of(ChallengeIndicator.CHALLENGE_REQUESTED, "\"challenge_requested\""),
+                Arguments.of(ChallengeIndicator.CHALLENGE_REQUESTED_MANDATE, "\"challenge_requested_mandate\""),
+                Arguments.of(ChallengeIndicator.LOW_VALUE, "\"low_value\""),
+                Arguments.of(ChallengeIndicator.TRUSTED_LISTING, "\"trusted_listing\""),
+                Arguments.of(ChallengeIndicator.TRUSTED_LISTING_PROMPT, "\"trusted_listing_prompt\""),
+                Arguments.of(ChallengeIndicator.TRANSACTION_RISK_ASSESSMENT, "\"transaction_risk_assessment\""),
+                Arguments.of(ChallengeIndicator.DATA_SHARE, "\"data_share\"")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("challengeIndicators")
+    void shouldSerializeChallengeIndicatorToSnakeCase(final ChallengeIndicator value, final String expectedJson) {
+        assertEquals(expectedJson, serializer.toJson(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("challengeIndicators")
+    void shouldDeserializeChallengeIndicatorFromSnakeCase(final ChallengeIndicator expected, final String json) {
+        assertEquals(expected, serializer.fromJson(json, ChallengeIndicator.class));
+    }
+
+    @Test
+    void shouldRoundTripAllValues() {
+        for (final ChallengeIndicator value : ChallengeIndicator.values()) {
+            final String json = serializer.toJson(value);
+            assertEquals(value, serializer.fromJson(json, ChallengeIndicator.class));
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

- Adds the five exemption values (`LOW_VALUE`, `TRUSTED_LISTING`, `TRUSTED_LISTING_PROMPT`, `TRANSACTION_RISK_ASSESSMENT`, `DATA_SHARE`) back to `com.checkout.common.ChallengeIndicator`, matching the named `ChallengeIndicator` schema used by `POST /sessions` (3DS Standalone Authentication).
- Adds `ChallengeIndicatorTest` covering serialization, deserialization and round-trip for all nine values via the Gson serializer.

## Why

A prior refactor moved these values out of `ChallengeIndicator` into a separate `Exemption` enum, but `SessionRequest.challengeIndicator` was never updated to accept exemptions through any other field. That broke merchant code such as:

```java
SessionRequest.builder()
    .challengeIndicator(ChallengeIndicator.TRANSACTION_RISK_ASSESSMENT)
    .build();
```

A merchant on the Standalone Authentication product is currently blocked from upgrading the SDK because of this.

The new values carry a JavaDoc note indicating they are only valid for POST /sessions. The inline challenge_indicator used by POST /payments three_ds and by session responses still only accepts the original four values — the API rejects the others at runtime.

## Follow-up (separate PR)

A cleaner split is still pending: introduce com.checkout.sessions.SessionChallengeIndicator (9 values) and mark the five new values on common.ChallengeIndicator as @Deprecated so the swagger-level distinction (named schema for /sessions vs inline 4-value enum for /payments) is reflected in the SDK type system. Keeping this PR minimal to unblock the merchant first.

## Test plan

- [ ] CI: ./gradlew compileJava compileTestJava passes
- [ ] CI: ./gradlew javadoc passes (no broken JavaDoc tags)
- [ ] CI: ./gradlew test --tests ChallengeIndicatorTest passes
- [ ] Sanity: build a SessionRequest with each of the five new values and confirm the JSON body has the expected snake_case string for challenge_indicator