### PR TITLE
feature/INT-1631 - updates the handling file purposes in the codebase

### DIFF
--- a/src/main/java/com/checkout/common/FileDetailsResponse.java
+++ b/src/main/java/com/checkout/common/FileDetailsResponse.java
@@ -11,7 +11,7 @@ public final class FileDetailsResponse extends Resource {
 
     private String id;
     private String filename;
-    private String purpose;
+    private FilePurpose purpose;
     private Integer size;
     private String uploadedOn;
 

--- a/src/main/java/com/checkout/common/FilePurpose.java
+++ b/src/main/java/com/checkout/common/FilePurpose.java
@@ -1,10 +1,18 @@
 package com.checkout.common;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 
 public enum FilePurpose {
 
-    DISPUTE_EVIDENCE("dispute_evidence");
+    @SerializedName("dispute_evidence")
+    DISPUTE_EVIDENCE("dispute_evidence"),
+
+    @SerializedName("arbitration_evidence")
+    ARBITRATION_EVIDENCE("arbitration_evidence"),
+
+    @SerializedName("submitted_evidence")
+    SUBMITTED_EVIDENCE("submitted_evidence");
 
     @Getter
     private final String purpose;

--- a/src/test/java/com/checkout/disputes/DisputesTestIT.java
+++ b/src/test/java/com/checkout/disputes/DisputesTestIT.java
@@ -332,7 +332,7 @@ class DisputesTestIT extends AbstractPaymentsTestIT {
     private void validateFileDetailsResponse(FileRequest fileRequest, FileDetailsResponse fileDetailsResponse) {
         assertNotNull(fileDetailsResponse);
         assertEquals(fileRequest.getFile().getName(), fileDetailsResponse.getFilename());
-        assertEquals(fileRequest.getPurpose().getPurpose(), fileDetailsResponse.getPurpose());
+        assertEquals(fileRequest.getPurpose(), fileDetailsResponse.getPurpose());
     }
 
     private void validateEvidenceResponse(DisputeEvidenceRequest evidenceRequest, DisputeEvidenceResponse evidenceResponse) {

--- a/src/test/java/com/checkout/disputes/previous/DisputesTestIT.java
+++ b/src/test/java/com/checkout/disputes/previous/DisputesTestIT.java
@@ -184,7 +184,7 @@ class DisputesTestIT extends SandboxTestFixture {
         final FileDetailsResponse fileDetailsResponse = blocking(() -> previousApi.disputesClient().getFileDetails(fileResponse.getId()));
         assertNotNull(fileDetailsResponse);
         assertEquals(fileRequest.getFile().getName(), fileDetailsResponse.getFilename());
-        assertEquals(fileRequest.getPurpose().getPurpose(), fileDetailsResponse.getPurpose());
+        assertEquals(fileRequest.getPurpose(), fileDetailsResponse.getPurpose());
         //Provide dispute evidence
         final DisputeEvidenceRequest evidenceRequest = DisputeEvidenceRequest.builder()
                 .proofOfDeliveryOrServiceFile(fileDetailsResponse.getId())


### PR DESCRIPTION
This pull request updates the handling of file purposes in the codebase to use a type-safe enum instead of raw strings, and adds support for additional file purposes. The changes improve code reliability and clarity by enforcing the use of the `FilePurpose` enum throughout the code and by expanding the recognized file purposes.

**File Purpose Handling Improvements:**

* Changed the `purpose` field in `FileDetailsResponse` from a `String` to the `FilePurpose` enum, ensuring type safety and consistency.
* Updated the `FilePurpose` enum to include new purposes: `ARBITRATION_EVIDENCE` and `SUBMITTED_EVIDENCE`, with appropriate serialization annotations for JSON mapping.

**Test Adjustments:**

* Updated test assertions in `DisputesTestIT.java` and `previous/DisputesTestIT.java` to compare `FilePurpose` enum values directly instead of comparing strings, reflecting the new type-safe approach. [[1]](diffhunk://#diff-fdff009bea596cc59930d4ab942e9cad40761ffe69a90d6b58ae8fafaa62fcf9L335-R335) [[2]](diffhunk://#diff-3c292595b731fc1d1d5ed037feb90a750bd823c70fd0d462c6ea059527394050L187-R187)