### PR TITLE
ProcessingData class fields update

### DIFF
--- a/src/main/java/com/checkout/payments/response/ProcessingData.java
+++ b/src/main/java/com/checkout/payments/response/ProcessingData.java
@@ -1,6 +1,8 @@
 package com.checkout.payments.response;
 
 import com.checkout.common.CountryCode;
+import com.checkout.payments.AccommodationData;
+import com.checkout.payments.AirlineData;
 import com.checkout.payments.PanProcessedType;
 import com.checkout.payments.PreferredSchema;
 import com.google.gson.annotations.SerializedName;
@@ -109,5 +111,44 @@ public final class ProcessingData {
      */
     @SerializedName("partner_response_code")
     private String partnerResponseCode;
+
+    /**
+     * The scheme on which the payment was authorized. This may differ from the card's scheme used
+     * for the payment if the card is co-badged and the payment was authorized on a different network.
+     * [Optional] readOnly
+     */
+    private String scheme;
+
+    /**
+     * Partner fraud status. If the status is {@code Pending}, and the merchant captures before it
+     * changes to {@code Accepted}, the risk of the transaction is solely on the merchant.
+     * [Optional]
+     */
+    @SerializedName("partner_fraud_status")
+    private String partnerFraudStatus;
+
+    /**
+     * The Mastercard Merchant Advice Code (MAC), which contains additional information about the
+     * transaction. For example, the MAC can inform you if the transaction was performed using a
+     * consumer non-reloadable prepaid card or a consumer single-use virtual card. For declined
+     * transactions, the MAC also indicates whether the payment can be retried and how long to wait.
+     * [Optional]
+     */
+    @SerializedName("partner_merchant_advice_code")
+    private String partnerMerchantAdviceCode;
+
+    /**
+     * Contains information about the accommodation booked by the customer.
+     * [Optional]
+     */
+    @SerializedName("accommodation_data")
+    private List<AccommodationData> accommodationData;
+
+    /**
+     * Contains information about the airline ticket and flights booked by the customer.
+     * [Optional]
+     */
+    @SerializedName("airline_data")
+    private List<AirlineData> airlineData;
 
 }

--- a/src/test/java/com/checkout/payments/response/ProcessingDataDeserializationTest.java
+++ b/src/test/java/com/checkout/payments/response/ProcessingDataDeserializationTest.java
@@ -1,0 +1,157 @@
+package com.checkout.payments.response;
+
+import com.checkout.GsonSerializer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Deserialization tests for {@link ProcessingData}, focused on fields recently aligned with
+ * the Checkout.com swagger spec (scheme, partner_fraud_status, partner_merchant_advice_code,
+ * accommodation_data, airline_data, fallback_source_used, failure_code, partner_code,
+ * partner_response_code).
+ */
+class ProcessingDataDeserializationTest {
+
+    private final GsonSerializer serializer = new GsonSerializer();
+
+    @Test
+    void shouldDeserializeScheme() {
+        final String json = "{\"scheme\":\"ACCEL\"}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals("ACCEL", data.getScheme());
+    }
+
+    @Test
+    void shouldDeserializePartnerFraudStatus() {
+        final String json = "{\"partner_fraud_status\":\"Pending\"}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals("Pending", data.getPartnerFraudStatus());
+    }
+
+    @Test
+    void shouldDeserializePartnerMerchantAdviceCode() {
+        final String json = "{\"partner_merchant_advice_code\":\"24\"}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals("24", data.getPartnerMerchantAdviceCode());
+    }
+
+    @Test
+    void shouldDeserializeAccommodationData() {
+        final String json = "{\"accommodation_data\":[{\"name\":\"Grand Hotel\"}]}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertNotNull(data.getAccommodationData());
+        assertEquals(1, data.getAccommodationData().size());
+        assertEquals("Grand Hotel", data.getAccommodationData().get(0).getName());
+    }
+
+    @Test
+    void shouldDeserializeAirlineData() {
+        final String json = "{\"airline_data\":[{\"ticket\":{\"number\":\"045-21351455613\"}}]}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertNotNull(data.getAirlineData());
+        assertEquals(1, data.getAirlineData().size());
+        assertNotNull(data.getAirlineData().get(0).getTicket());
+        assertEquals("045-21351455613", data.getAirlineData().get(0).getTicket().getNumber());
+    }
+
+    @Test
+    void shouldDeserializeFallbackSourceUsed() {
+        final String json = "{\"fallback_source_used\":true}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals(Boolean.TRUE, data.getFallbackSourceUsed());
+    }
+
+    @Test
+    void shouldDeserializeFailureCode() {
+        final String json = "{\"failure_code\":\"partner_error\"}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals("partner_error", data.getFailureCode());
+    }
+
+    @Test
+    void shouldDeserializePartnerCode() {
+        final String json = "{\"partner_code\":\"999111\"}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals("999111", data.getPartnerCode());
+    }
+
+    @Test
+    void shouldDeserializePartnerResponseCode() {
+        final String json = "{\"partner_response_code\":\"ER_WRONG_TICKET\"}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals("ER_WRONG_TICKET", data.getPartnerResponseCode());
+    }
+
+    @Test
+    void shouldDeserializeAllNewFieldsTogether() {
+        final String json = "{"
+                + "\"scheme\":\"VISA\","
+                + "\"partner_fraud_status\":\"Accepted\","
+                + "\"partner_merchant_advice_code\":\"24\","
+                + "\"fallback_source_used\":false,"
+                + "\"failure_code\":\"partner_error\","
+                + "\"partner_code\":\"902111\","
+                + "\"partner_response_code\":\"DECLINED\""
+                + "}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals("VISA", data.getScheme());
+        assertEquals("Accepted", data.getPartnerFraudStatus());
+        assertEquals("24", data.getPartnerMerchantAdviceCode());
+        assertEquals(Boolean.FALSE, data.getFallbackSourceUsed());
+        assertEquals("partner_error", data.getFailureCode());
+        assertEquals("902111", data.getPartnerCode());
+        assertEquals("DECLINED", data.getPartnerResponseCode());
+    }
+
+    @Test
+    void shouldLeaveNewFieldsNullWhenAbsent() {
+        final String json = "{\"locale\":\"en-GB\"}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals("en-GB", data.getLocale());
+        assertNull(data.getScheme());
+        assertNull(data.getPartnerFraudStatus());
+        assertNull(data.getPartnerMerchantAdviceCode());
+        assertNull(data.getAccommodationData());
+        assertNull(data.getAirlineData());
+        assertNull(data.getFallbackSourceUsed());
+        assertNull(data.getFailureCode());
+        assertNull(data.getPartnerCode());
+        assertNull(data.getPartnerResponseCode());
+    }
+}


### PR DESCRIPTION
This pull request enhances the `ProcessingData` model to align with the latest Checkout.com API specification, adding support for several new fields related to payment processing, and introduces comprehensive deserialization tests to ensure correct handling of these fields.

**Model enhancements:**

* Added new fields to `ProcessingData` to support additional payment processing information, including `scheme`, `partnerFraudStatus`, `partnerMerchantAdviceCode`, `accommodationData`, and `airlineData`. These fields provide more granular details about the payment, such as the network used, fraud status, merchant advice codes, and booking information for accommodations and airlines.
* Imported the necessary model classes (`AccommodationData` and `AirlineData`) to support the new list fields in `ProcessingData`.

**Test coverage:**

* Introduced a new test class `ProcessingDataDeserializationTest` that verifies deserialization of all newly added fields, as well as their correct handling when absent, ensuring robust compatibility with the updated API contract.