### PR TITLE
feature/INT-1635 -  Mastercard Transaction Link Identifier update (scheme_transaction_link_id)

### DIFF
--- a/src/main/java/com/checkout/handlepaymentsandpayouts/payments/postpayments/responses/requestapaymentorpayoutresponsecreated/processing/Processing.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/payments/postpayments/responses/requestapaymentorpayoutresponsecreated/processing/Processing.java
@@ -148,4 +148,13 @@ public final class Processing {
     @SerializedName("cko_network_token_available")
     private Boolean ckoNetworkTokenAvailable;
 
+    /**
+     * The scheme transaction link identifier. Returned for Mastercard transactions when the scheme
+     * provides a link identifier that ties together related transactions on the network
+     * (see Mastercard Transaction Link Identifier documentation).
+     * [Optional]
+     */
+    @SerializedName("scheme_transaction_link_id")
+    private String schemeTransactionLinkId;
+
 }

--- a/src/main/java/com/checkout/payments/PaymentProcessing.java
+++ b/src/main/java/com/checkout/payments/PaymentProcessing.java
@@ -202,4 +202,12 @@ public final class PaymentProcessing {
      */
     private Aggregator aggregator;
 
+    /**
+     * The scheme transaction link identifier. Returned for Mastercard transactions when the scheme
+     * provides a link identifier that ties together related transactions on the network
+     * (see Mastercard Transaction Link Identifier documentation).
+     * [Optional]
+     */
+    private String schemeTransactionLinkId;
+
 }

--- a/src/main/java/com/checkout/payments/response/ProcessingData.java
+++ b/src/main/java/com/checkout/payments/response/ProcessingData.java
@@ -151,4 +151,13 @@ public final class ProcessingData {
     @SerializedName("airline_data")
     private List<AirlineData> airlineData;
 
+    /**
+     * The scheme transaction link identifier. Returned for Mastercard transactions when the scheme
+     * provides a link identifier that ties together related transactions on the network
+     * (see Mastercard Transaction Link Identifier documentation).
+     * [Optional]
+     */
+    @SerializedName("scheme_transaction_link_id")
+    private String schemeTransactionLinkId;
+
 }

--- a/src/test/java/com/checkout/handlepaymentsandpayouts/payments/postpayments/responses/requestapaymentorpayoutresponsecreated/RequestAPaymentOrPayoutResponseCreatedSerializationTest.java
+++ b/src/test/java/com/checkout/handlepaymentsandpayouts/payments/postpayments/responses/requestapaymentorpayoutresponsecreated/RequestAPaymentOrPayoutResponseCreatedSerializationTest.java
@@ -12,6 +12,7 @@ import com.checkout.handlepaymentsandpayouts.payments.common.source.currencyacco
 import com.checkout.handlepaymentsandpayouts.payments.common.source.klarnasource.KlarnaSource;
 import com.checkout.handlepaymentsandpayouts.payments.common.source.paypalsource.PaypalSource;
 import com.checkout.handlepaymentsandpayouts.payments.common.source.sepasource.SepaSource;
+import com.checkout.handlepaymentsandpayouts.payments.postpayments.responses.requestapaymentorpayoutresponsecreated.processing.Processing;
 
 public final  class RequestAPaymentOrPayoutResponseCreatedSerializationTest {
 
@@ -147,6 +148,34 @@ public final  class RequestAPaymentOrPayoutResponseCreatedSerializationTest {
         assertInstanceOf(SepaSource.class, response.getSource());
         SepaSource sepaSource = (SepaSource) response.getSource();
         assertEquals("src_sepa_123", sepaSource.getId());
+    }
+
+    @Test
+    void shouldDeserializeProcessingSchemeTransactionLinkId() {
+        String json = "{\n" +
+                "  \"id\": \"pay_123\",\n" +
+                "  \"amount\": 1000,\n" +
+                "  \"currency\": \"USD\",\n" +
+                "  \"approved\": true,\n" +
+                "  \"status\": \"Authorized\",\n" +
+                "  \"processed_on\": \"2021-06-08T12:25:01Z\",\n" +
+                "  \"processing\": {\n" +
+                "    \"retrieval_reference_number\": \"RRN001\",\n" +
+                "    \"acquirer_transaction_id\": \"ACQ001\",\n" +
+                "    \"scheme\": \"Mastercard\",\n" +
+                "    \"scheme_transaction_link_id\": \"MTL-XYZ-789\"\n" +
+                "  }\n" +
+                "}";
+
+        RequestAPaymentOrPayoutResponseCreated response = serializer.fromJson(json, RequestAPaymentOrPayoutResponseCreated.class);
+
+        assertNotNull(response);
+        Processing processing = response.getProcessing();
+        assertNotNull(processing);
+        assertEquals("RRN001", processing.getRetrievalReferenceNumber());
+        assertEquals("ACQ001", processing.getAcquirerTransactionId());
+        assertEquals("Mastercard", processing.getScheme());
+        assertEquals("MTL-XYZ-789", processing.getSchemeTransactionLinkId());
     }
 
 }

--- a/src/test/java/com/checkout/payments/GetPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/GetPaymentsTestIT.java
@@ -416,6 +416,12 @@ class GetPaymentsTestIT extends AbstractPaymentsTestIT {
     private void validateBasicGetPaymentResponse(GetPaymentResponse paymentReturned, PaymentStatus expectedStatus) {
         assertNotNull(paymentReturned);
         assertEquals(expectedStatus, paymentReturned.getStatus());
+        // Mastercard Transaction Link Identifier — optional, only populated for Mastercard
+        // transactions. Exercising the getter confirms the field is exposed by the SDK
+        // and deserializes without error even when absent from the response payload.
+        if (paymentReturned.getProcessing() != null) {
+            paymentReturned.getProcessing().getSchemeTransactionLinkId();
+        }
     }
 
     private void validatePaymentWithDigitalItem(GetPaymentResponse paymentReturned) {

--- a/src/test/java/com/checkout/payments/PaymentProcessingSerializationTest.java
+++ b/src/test/java/com/checkout/payments/PaymentProcessingSerializationTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PaymentProcessingSerializationTest {
 
@@ -90,6 +91,26 @@ class PaymentProcessingSerializationTest {
 
         assertNotNull(processing);
         assertEquals("recon_001", processing.getReconciliationId());
+    }
+
+    @Test
+    void shouldDeserializeSchemeTransactionLinkId() {
+        final String json = "{\"scheme_transaction_link_id\":\"MTL-001\"}";
+
+        final PaymentProcessing processing = serializer.fromJson(json, PaymentProcessing.class);
+
+        assertNotNull(processing);
+        assertEquals("MTL-001", processing.getSchemeTransactionLinkId());
+    }
+
+    @Test
+    void shouldSerializeSchemeTransactionLinkIdToSnakeCase() {
+        final PaymentProcessing processing = new PaymentProcessing();
+        processing.setSchemeTransactionLinkId("MTL-001");
+
+        final String json = serializer.toJson(processing);
+
+        assertTrue(json.contains("\"scheme_transaction_link_id\":\"MTL-001\""));
     }
 
     @Test
@@ -182,7 +203,8 @@ class PaymentProcessingSerializationTest {
                 + "\"merchant_category_code\":\"5812\","
                 + "\"aft\":false,"
                 + "\"bizum_payment_id\":\"biz_001\","
-                + "\"reconciliation_id\":\"rec_001\""
+                + "\"reconciliation_id\":\"rec_001\","
+                + "\"scheme_transaction_link_id\":\"MTL-XYZ-789\""
                 + "}";
 
         final PaymentProcessing processing = serializer.fromJson(json, PaymentProcessing.class);
@@ -199,6 +221,7 @@ class PaymentProcessingSerializationTest {
         assertEquals(100L, processing.getForeignRetailerAmount());
         assertEquals("biz_001", processing.getBizumPaymentId());
         assertEquals("rec_001", processing.getReconciliationId());
+        assertEquals("MTL-XYZ-789", processing.getSchemeTransactionLinkId());
     }
 
     @Test

--- a/src/test/java/com/checkout/payments/response/ProcessingDataDeserializationTest.java
+++ b/src/test/java/com/checkout/payments/response/ProcessingDataDeserializationTest.java
@@ -113,6 +113,16 @@ class ProcessingDataDeserializationTest {
     }
 
     @Test
+    void shouldDeserializeSchemeTransactionLinkId() {
+        final String json = "{\"scheme_transaction_link_id\":\"MTL-001\"}";
+
+        final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
+
+        assertNotNull(data);
+        assertEquals("MTL-001", data.getSchemeTransactionLinkId());
+    }
+
+    @Test
     void shouldDeserializeAllNewFieldsTogether() {
         final String json = "{"
                 + "\"scheme\":\"VISA\","
@@ -121,7 +131,8 @@ class ProcessingDataDeserializationTest {
                 + "\"fallback_source_used\":false,"
                 + "\"failure_code\":\"partner_error\","
                 + "\"partner_code\":\"902111\","
-                + "\"partner_response_code\":\"DECLINED\""
+                + "\"partner_response_code\":\"DECLINED\","
+                + "\"scheme_transaction_link_id\":\"MTL-XYZ-789\""
                 + "}";
 
         final ProcessingData data = serializer.fromJson(json, ProcessingData.class);
@@ -134,6 +145,7 @@ class ProcessingDataDeserializationTest {
         assertEquals("partner_error", data.getFailureCode());
         assertEquals("902111", data.getPartnerCode());
         assertEquals("DECLINED", data.getPartnerResponseCode());
+        assertEquals("MTL-XYZ-789", data.getSchemeTransactionLinkId());
     }
 
     @Test
@@ -153,5 +165,6 @@ class ProcessingDataDeserializationTest {
         assertNull(data.getFailureCode());
         assertNull(data.getPartnerCode());
         assertNull(data.getPartnerResponseCode());
+        assertNull(data.getSchemeTransactionLinkId());
     }
 }


### PR DESCRIPTION
This pull request introduces support for the `scheme_transaction_link_id` field across several payment processing classes. This field, primarily relevant for Mastercard transactions, is now included in the models, and comprehensive test coverage ensures correct serialization and deserialization. The main focus is to enable the SDK to expose and handle this identifier, which links related transactions on the Mastercard network.

**Support for Mastercard Transaction Link Identifier:**

* Added the `scheme_transaction_link_id` field (with documentation) to the following classes: `Processing`, `ProcessingData`, and `PaymentProcessing`, ensuring the field is serialized/deserialized as `scheme_transaction_link_id` in JSON. [[1]](diffhunk://#diff-e3a0c6f1ef19a5e6725688a3bde1fde2f393230370fdaffe5d025f2619b9baebR151-R159) [[2]](diffhunk://#diff-cdea8f603eff5caee1519fafa9a4b3fa31249e8bbac762c1491e9f7786cd2658R154-R162) [[3]](diffhunk://#diff-a1ee194927d7b0b31c624ac31599c1eef3ed3cb26ba8e117fb067141f186caedR205-R212)
* Updated integration and unit tests to verify correct handling of the new field, including deserialization, serialization, and null handling when the field is absent. [[1]](diffhunk://#diff-e3fa2ac99ced7e4f38b13215f99246de51a1af11fa7d4cfbff3f72efe9c6861cR153-R180) [[2]](diffhunk://#diff-768a2218d822ee944b1209da5b86feeb1a975f9de72764d2556759f7ad10dbcdR96-R115) [[3]](diffhunk://#diff-768a2218d822ee944b1209da5b86feeb1a975f9de72764d2556759f7ad10dbcdL185-R207) [[4]](diffhunk://#diff-768a2218d822ee944b1209da5b86feeb1a975f9de72764d2556759f7ad10dbcdR224) [[5]](diffhunk://#diff-213b4a771d29c61a1c928ebacfc28bad4f596cffa3f50eb31f69107ab9fda047R115-R124) [[6]](diffhunk://#diff-213b4a771d29c61a1c928ebacfc28bad4f596cffa3f50eb31f69107ab9fda047L124-R135) [[7]](diffhunk://#diff-213b4a771d29c61a1c928ebacfc28bad4f596cffa3f50eb31f69107ab9fda047R148) [[8]](diffhunk://#diff-213b4a771d29c61a1c928ebacfc28bad4f596cffa3f50eb31f69107ab9fda047R168) [[9]](diffhunk://#diff-370b2a65ef1e4f33b8a25c92f027070e9943e74fe126ddc5f96cc55b8d9a49d1R419-R424)
* Added necessary imports and assertions in test files to support the new field and its test cases. [[1]](diffhunk://#diff-e3fa2ac99ced7e4f38b13215f99246de51a1af11fa7d4cfbff3f72efe9c6861cR15) [[2]](diffhunk://#diff-768a2218d822ee944b1209da5b86feeb1a975f9de72764d2556759f7ad10dbcdR14)

These changes ensure that the SDK is ready to handle Mastercard's transaction link identifiers, providing better traceability for related transactions.