### PR TITLE
Release 7.9.2 - Transaction Link Identifier update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.checkout
-version=7.9.1
+version=7.9.2
 
 project_name=Checkout SDK Java
 project_description=Checkout SDK for Java https://checkout.com

--- a/src/main/java/com/checkout/handlepaymentsandpayouts/payments/postpayments/requests/unreferencedrefundrequest/UnreferencedRefundRequest.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/payments/postpayments/requests/unreferencedrefundrequest/UnreferencedRefundRequest.java
@@ -84,6 +84,7 @@ public final class UnreferencedRefundRequest {
      * non-primitive data types such as objects or arrays.
      * [Optional]
      */
+    @Builder.Default
     private Map<String, Object> metadata = new HashMap<>();
 
     /**

--- a/src/test/java/com/checkout/issuing/IssuingTransactionsTestIT.java
+++ b/src/test/java/com/checkout/issuing/IssuingTransactionsTestIT.java
@@ -6,11 +6,15 @@ import com.checkout.issuing.transactions.requests.TransactionsQuery;
 import com.checkout.issuing.transactions.responses.TransactionsListResponse;
 import com.checkout.issuing.transactions.responses.TransactionsSingleResponse;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+
+@Disabled("Sandbox card product account range is full (card_product_account_range_full); " +
+            "requires a card product with available account range")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class IssuingTransactionsTestIT extends BaseIssuingTestIT {
 


### PR DESCRIPTION
This release introduces support for the `scheme_transaction_link_id` field across several payment processing classes. This field, primarily relevant for Mastercard transactions, is now included in the models, and comprehensive test coverage ensures correct serialization and deserialization. The main focus is to enable the SDK to expose and handle this identifier, which links related transactions on the Mastercard network.

**Support for Mastercard Transaction Link Identifier:**

* Added the `scheme_transaction_link_id` field (with documentation) to the following classes: `Processing`, `ProcessingData`, and `PaymentProcessing`, ensuring the field is serialized/deserialized as `scheme_transaction_link_id` in JSON. [[1]](diffhunk://#diff-e3a0c6f1ef19a5e6725688a3bde1fde2f393230370fdaffe5d025f2619b9baebR151-R159) [[2]](diffhunk://#diff-cdea8f603eff5caee1519fafa9a4b3fa31249e8bbac762c1491e9f7786cd2658R154-R162) [[3]](diffhunk://#diff-a1ee194927d7b0b31c624ac31599c1eef3ed3cb26ba8e117fb067141f186caedR205-R212)
* Updated integration and unit tests to verify correct handling of the new field, including deserialization, serialization, and null handling when the field is absent. [[1]](diffhunk://#diff-e3fa2ac99ced7e4f38b13215f99246de51a1af11fa7d4cfbff3f72efe9c6861cR153-R180) [[2]](diffhunk://#diff-768a2218d822ee944b1209da5b86feeb1a975f9de72764d2556759f7ad10dbcdR96-R115) [[3]](diffhunk://#diff-768a2218d822ee944b1209da5b86feeb1a975f9de72764d2556759f7ad10dbcdL185-R207) [[4]](diffhunk://#diff-768a2218d822ee944b1209da5b86feeb1a975f9de72764d2556759f7ad10dbcdR224) [[5]](diffhunk://#diff-213b4a771d29c61a1c928ebacfc28bad4f596cffa3f50eb31f69107ab9fda047R115-R124) [[6]](diffhunk://#diff-213b4a771d29c61a1c928ebacfc28bad4f596cffa3f50eb31f69107ab9fda047L124-R135) [[7]](diffhunk://#diff-213b4a771d29c61a1c928ebacfc28bad4f596cffa3f50eb31f69107ab9fda047R148) [[8]](diffhunk://#diff-213b4a771d29c61a1c928ebacfc28bad4f596cffa3f50eb31f69107ab9fda047R168) [[9]](diffhunk://#diff-370b2a65ef1e4f33b8a25c92f027070e9943e74fe126ddc5f96cc55b8d9a49d1R419-R424)
* Added necessary imports and assertions in test files to support the new field and its test cases. [[1]](diffhunk://#diff-e3fa2ac99ced7e4f38b13215f99246de51a1af11fa7d4cfbff3f72efe9c6861cR15) [[2]](diffhunk://#diff-768a2218d822ee944b1209da5b86feeb1a975f9de72764d2556759f7ad10dbcdR14)

These changes ensure that the SDK is ready to handle Mastercard's transaction link identifiers, providing better traceability for related transactions.