### PR TITLE
New product Id for card testing

### DIFF
--- a/src/test/java/com/checkout/issuing/BaseIssuingTestIT.java
+++ b/src/test/java/com/checkout/issuing/BaseIssuingTestIT.java
@@ -22,6 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public abstract class BaseIssuingTestIT extends SandboxTestFixture {
 
+    // currently not used: Sandbox card product account range is full error (card_product_account_range_full)
+    protected String oldProductId = "pro_3fn6pv2ikshurn36dbd3iysyha";
+
+    // new product with available account range created for testing purposes
+    protected String newProductId = "pro_gfp2kpog3ztutpgtpu4jj36n7i";
+    
     protected CheckoutApi issuingApi;
 
     public BaseIssuingTestIT() {
@@ -78,7 +84,7 @@ public abstract class BaseIssuingTestIT extends SandboxTestFixture {
     protected CardResponse createCard(final String cardholderId, final Boolean active) {
         final VirtualCardRequest request = VirtualCardRequest.builder()
                 .cardholderId(cardholderId)
-                .cardProductId("pro_3fn6pv2ikshurn36dbd3iysyha")
+                .cardProductId(newProductId)
                 .lifetime(CardLifetime.builder()
                         .unit(LifetimeUnit.MONTHS)
                         .value(6)

--- a/src/test/java/com/checkout/issuing/IssuingTransactionsTestIT.java
+++ b/src/test/java/com/checkout/issuing/IssuingTransactionsTestIT.java
@@ -6,15 +6,15 @@ import com.checkout.issuing.transactions.requests.TransactionsQuery;
 import com.checkout.issuing.transactions.responses.TransactionsListResponse;
 import com.checkout.issuing.transactions.responses.TransactionsSingleResponse;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
-@Disabled("Sandbox card product account range is full (card_product_account_range_full); " +
-            "requires a card product with available account range")
+//@Disabled("Sandbox card product account range is full (card_product_account_range_full); " +
+//            "requires a card product with available account range")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class IssuingTransactionsTestIT extends BaseIssuingTestIT {
 


### PR DESCRIPTION
This pull request updates the test infrastructure for issuing cards by switching to a new card product with available account range, allowing previously disabled integration tests to run again. The main changes involve updating test configuration and enabling tests that were blocked due to resource exhaustion.

**Test infrastructure updates:**

* Added a new `newProductId` field in `BaseIssuingTestIT` for a card product with available account range and updated the `createCard` method to use this new product instead of the old one. [[1]](diffhunk://#diff-c3f2136dc5525f15662964e2bdfcc62b9545c6a634ad12cbbae466d6a2f1af4dR25-R30) [[2]](diffhunk://#diff-c3f2136dc5525f15662964e2bdfcc62b9545c6a634ad12cbbae466d6a2f1af4dL81-R87)

**Test enablement:**

* Re-enabled the `IssuingTransactionsTestIT` integration test by commenting out the `@Disabled` annotation, since the account range issue has been resolved with the new product.