### PR TITLE
fix(setups): rename confirm param to paymentMethodName per spec

### DIFF
--- a/src/main/java/com/checkout/handlepaymentsandpayouts/setups/PaymentSetupsClient.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/setups/PaymentSetupsClient.java
@@ -40,8 +40,8 @@ public interface PaymentSetupsClient {
      * Confirms a payment setup.
      *
      * @param id The payment setup ID
-     * @param paymentMethodOptionId The payment method option ID
+     * @param paymentMethodName The name of the payment method to process the payment with (for example, {@code tabby}, {@code klarna}, {@code card})
      * @return CompletableFuture containing the payment setup confirmation response
      */
-    CompletableFuture<PaymentSetupsConfirmResponse> confirmPaymentSetup(String id, String paymentMethodOptionId);
+    CompletableFuture<PaymentSetupsConfirmResponse> confirmPaymentSetup(String id, String paymentMethodName);
 }

--- a/src/main/java/com/checkout/handlepaymentsandpayouts/setups/PaymentSetupsClientImpl.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/setups/PaymentSetupsClientImpl.java
@@ -68,15 +68,15 @@ public class PaymentSetupsClientImpl extends AbstractClient implements PaymentSe
     /**
      * Confirms a payment setup.
      *
-     * @param id                    The payment setup ID
-     * @param paymentMethodOptionId The payment method option ID
+     * @param id                The payment setup ID
+     * @param paymentMethodName The name of the payment method to process the payment with (for example, {@code tabby}, {@code klarna}, {@code card})
      * @return CompletableFuture containing the payment setup confirmation response
      */
     @Override
     public CompletableFuture<PaymentSetupsConfirmResponse> confirmPaymentSetup(final String id,
-            final String paymentMethodOptionId) {
-        validateParams("id", id, "paymentMethodOptionId", paymentMethodOptionId);
-        return apiClient.postAsync(buildPath(PAYMENT_SETUPS_PATH, id, CONFIRM_PATH, paymentMethodOptionId),
+            final String paymentMethodName) {
+        validateParams("id", id, "paymentMethodName", paymentMethodName);
+        return apiClient.postAsync(buildPath(PAYMENT_SETUPS_PATH, id, CONFIRM_PATH, paymentMethodName),
                 sdkAuthorization(), PaymentSetupsConfirmResponse.class, null, null);
     }
 }

--- a/src/test/java/com/checkout/handlepaymentsandpayouts/setups/PaymentSetupsClientImplTest.java
+++ b/src/test/java/com/checkout/handlepaymentsandpayouts/setups/PaymentSetupsClientImplTest.java
@@ -95,15 +95,15 @@ class PaymentSetupsClientImplTest {
     @Test
     void shouldConfirmPaymentSetup() throws ExecutionException, InterruptedException {
         final String paymentSetupId = "ps_test_123456789";
-        final String paymentMethodOptionId = "pmo_test_987654321";
+        final String paymentMethodName = "card";
         final PaymentSetupsConfirmResponse response = mock(PaymentSetupsConfirmResponse.class);
 
-        when(apiClient.postAsync(eq("payments/setups/" + paymentSetupId + "/confirm/" + paymentMethodOptionId), 
+        when(apiClient.postAsync(eq("payments/setups/" + paymentSetupId + "/confirm/" + paymentMethodName),
                 eq(authorization), eq(PaymentSetupsConfirmResponse.class), isNull(), isNull()))
                 .thenReturn(CompletableFuture.completedFuture(response));
 
-        final CompletableFuture<PaymentSetupsConfirmResponse> future = 
-                client.confirmPaymentSetup(paymentSetupId, paymentMethodOptionId);
+        final CompletableFuture<PaymentSetupsConfirmResponse> future =
+                client.confirmPaymentSetup(paymentSetupId, paymentMethodName);
 
         assertNotNull(future.get());
         assertEquals(response, future.get());

--- a/src/test/java/com/checkout/handlepaymentsandpayouts/setups/PaymentSetupsTestIT.java
+++ b/src/test/java/com/checkout/handlepaymentsandpayouts/setups/PaymentSetupsTestIT.java
@@ -106,12 +106,12 @@ class PaymentSetupsTestIT extends SandboxTestFixture {
                 checkoutApi.paymentSetupsClient().createPaymentSetup(paymentSetupsRequest);
         final PaymentSetupsResponse createResponse = createFuture.join();
 
-        // This would require extracting a payment method option ID from the create response
-        final String paymentMethodOptionId = "opt_test_12345"; // This should come from the payment setup response
+        // The name of the payment method to process the payment with (for example, tabby, klarna, card)
+        final String paymentMethodName = "card";
 
         // Act
         final CompletableFuture<PaymentSetupsConfirmResponse> confirmFuture =
-                checkoutApi.paymentSetupsClient().confirmPaymentSetup(createResponse.getId(), paymentMethodOptionId);
+                checkoutApi.paymentSetupsClient().confirmPaymentSetup(createResponse.getId(), paymentMethodName);
         final PaymentSetupsConfirmResponse response = confirmFuture.join();
 
         // Assert


### PR DESCRIPTION
## Problem

The confirm endpoint path parameter is `payment_method_name` — the name of the payment method to process the payment with (for example, `tabby`, `klarna`, `card`) — not an option id. The `confirmPaymentSetup` client method named this argument `paymentMethodOptionId`, which misleads integrators into passing an id instead of a method name.

## Change

Rename the `paymentMethodOptionId` argument to `paymentMethodName` across the client interface, implementation, and tests, and update the doc comments with the spec's examples. The value is appended to the request path, so behaviour is unchanged — this is a naming/clarity fix.

Follow-up to #616, which aligned `PaymentSetupsConfirmResponse` with the `PaymentSetup` schema.

## Verification

- `./gradlew compileJava compileTestJava` — passes.
- Setups unit tests pass.