### PR TITLE
Release 7.12.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.checkout
-version=7.12.0
+version=7.12.1
 
 project_name=Checkout SDK Java
 project_description=Checkout SDK for Java https://checkout.com


### PR DESCRIPTION
- fix(setups): rename confirm payment method path parameter to paymentMethodName per spec (payment_method_name), so integrators pass the payment method name (for example, card, klarna, tabby) instead of an option id