### PR TITLE
feat(setups): add missing fields to PaymentSetupsRequest

### DIFF
--- a/src/main/java/com/checkout/handlepaymentsandpayouts/setups/requests/PaymentSetupsRequest.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/setups/requests/PaymentSetupsRequest.java
@@ -8,7 +8,10 @@ import com.checkout.handlepaymentsandpayouts.setups.entities.customer.Customer;
 import com.checkout.handlepaymentsandpayouts.setups.entities.industry.Industry;
 import com.checkout.handlepaymentsandpayouts.setups.entities.order.Order;
 import com.checkout.handlepaymentsandpayouts.setups.entities.paymentMethods.PaymentMethods;
+import com.checkout.handlepaymentsandpayouts.setups.entities.billingDescriptor.PaymentSetupBillingDescriptor;
+import com.checkout.handlepaymentsandpayouts.setups.entities.presentmentDetails.PaymentSetupPresentmentDetails;
 import com.checkout.handlepaymentsandpayouts.setups.entities.settings.Settings;
+import com.checkout.handlepaymentsandpayouts.setups.entities.terminal.PaymentSetupTerminal;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -104,4 +107,23 @@ public final class PaymentSetupsRequest {
      * [Optional]
      */
     private PaymentSetupAccountFundingTransaction accountFundingTransaction;
+
+    /**
+     * The billing descriptor for the payment.
+     * [Optional]
+     */
+    private PaymentSetupBillingDescriptor billingDescriptor;
+
+    /**
+     * The amount and currency to present to the customer, when the settlement currency differs from the
+     * customer-facing currency.
+     * [Optional]
+     */
+    private PaymentSetupPresentmentDetails presentmentDetails;
+
+    /**
+     * Terminal details.
+     * [Optional]
+     */
+    private PaymentSetupTerminal terminal;
 }


### PR DESCRIPTION
## What

Add the `billingDescriptor`, `presentmentDetails` and `terminal` fields to `PaymentSetupsRequest`.

## Why

The `PaymentSetup` schema defines these as writable fields, and they are already present in `PaymentSetupsResponse`, but they were missing from the request. This left the request unable to set a billing descriptor, presentment details, or terminal details when creating a Payment Setup.

Surfaced by a full request/response audit of the payment setups endpoint against the swagger spec (follow-up to the confirm-response alignment in 7.12.0/7.12.1).

## Verification

- `./gradlew compileJava` — passes.
- The three types already exist under `setups.entities` (used by the response).