### PR TITLE
feature/INT-1659 - Support for negotiating Accounts API schema version via the Accept header

### DIFF
--- a/src/main/java/com/checkout/ApiClient.java
+++ b/src/main/java/com/checkout/ApiClient.java
@@ -12,7 +12,11 @@ public interface ApiClient {
 
     <T extends HttpMetadata> CompletableFuture<T> getAsync(String path, SdkAuthorization authorization, Type responseType);
 
+    <T extends HttpMetadata> CompletableFuture<T> getAsync(String path, SdkAuthorization authorization, Class<T> responseType, IHeaders headers);
+
     <T extends HttpMetadata> CompletableFuture<T> putAsync(String path, SdkAuthorization authorization, Class<T> responseType, Object request);
+
+    <T extends HttpMetadata> CompletableFuture<T> putAsync(String path, SdkAuthorization authorization, Class<T> responseType, Object request, IHeaders headers);
 
     <T extends HttpMetadata> CompletableFuture<T> postAsync(String path, SdkAuthorization authorization, Class<T> responseType, Object request, String idempotencyKey);
 
@@ -41,7 +45,11 @@ public interface ApiClient {
 
     <T extends HttpMetadata> T get(String path, SdkAuthorization authorization, Type responseType);
 
+    <T extends HttpMetadata> T get(String path, SdkAuthorization authorization, Class<T> responseType, IHeaders headers);
+
     <T extends HttpMetadata> T put(String path, SdkAuthorization authorization, Class<T> responseType, Object request);
+
+    <T extends HttpMetadata> T put(String path, SdkAuthorization authorization, Class<T> responseType, Object request, IHeaders headers);
 
     <T extends HttpMetadata> T patch(String path, SdkAuthorization authorization, Class<T> responseType, Object request, String idempotencyKey);
 

--- a/src/main/java/com/checkout/ApiClientImpl.java
+++ b/src/main/java/com/checkout/ApiClientImpl.java
@@ -60,11 +60,29 @@ public class ApiClientImpl implements ApiClient {
     }
 
     @Override
+    public <T extends HttpMetadata> CompletableFuture<T> getAsync(final String path, final SdkAuthorization authorization, final Class<T> responseType, final IHeaders headers) {
+        validateParams(PATH, path, AUTHORIZATION, authorization);
+        return executeAsyncOrSync(
+                () -> get(path, authorization, responseType, headers),
+                () -> sendRequestAsync(GET, path, authorization, null, null, responseType, headers)
+        );
+    }
+
+    @Override
     public <T extends HttpMetadata> CompletableFuture<T> putAsync(final String path, final SdkAuthorization authorization, final Class<T> responseType, final Object request) {
         validateParams(PATH, path, AUTHORIZATION, authorization);
         return executeAsyncOrSync(
                 () -> put(path, authorization, responseType, request),
                 () -> sendRequestAsync(PUT, path, authorization, request, null, responseType)
+        );
+    }
+
+    @Override
+    public <T extends HttpMetadata> CompletableFuture<T> putAsync(final String path, final SdkAuthorization authorization, final Class<T> responseType, final Object request, final IHeaders headers) {
+        validateParams(PATH, path, AUTHORIZATION, authorization);
+        return executeAsyncOrSync(
+                () -> put(path, authorization, responseType, request, headers),
+                () -> sendRequestAsync(PUT, path, authorization, request, null, responseType, headers)
         );
     }
 
@@ -327,9 +345,21 @@ public class ApiClientImpl implements ApiClient {
     }
 
     @Override
+    public <T extends HttpMetadata> T get(final String path, final SdkAuthorization authorization, final Class<T> responseType, final IHeaders headers) {
+        validateParams(PATH, path, AUTHORIZATION, authorization);
+        return sendRequestSync(GET, path, authorization, null, null, responseType, headers);
+    }
+
+    @Override
     public <T extends HttpMetadata> T put(final String path, final SdkAuthorization authorization, final Class<T> responseType, final Object request) {
         validateParams(PATH, path, AUTHORIZATION, authorization);
         return sendRequestSync(PUT, path, authorization, request, null, responseType);
+    }
+
+    @Override
+    public <T extends HttpMetadata> T put(final String path, final SdkAuthorization authorization, final Class<T> responseType, final Object request, final IHeaders headers) {
+        validateParams(PATH, path, AUTHORIZATION, authorization);
+        return sendRequestSync(PUT, path, authorization, request, null, responseType, headers);
     }
 
     @Override

--- a/src/main/java/com/checkout/accounts/AccountsClient.java
+++ b/src/main/java/com/checkout/accounts/AccountsClient.java
@@ -26,11 +26,17 @@ public interface AccountsClient {
 
     CompletableFuture<OnboardEntityResponse> createEntity(OnboardEntityRequest entityRequest);
 
+    CompletableFuture<OnboardEntityResponse> createEntity(OnboardEntityRequest entityRequest, String schemaVersion);
+
     CompletableFuture<PaymentInstrumentDetailsResponse> retrievePaymentInstrumentDetails(String entityId, String paymentInstrumentId);
 
     CompletableFuture<OnboardEntityDetailsResponse> getEntity(String entityId);
 
+    CompletableFuture<OnboardEntityDetailsResponse> getEntity(String entityId, String schemaVersion);
+
     CompletableFuture<OnboardEntityResponse> updateEntity(OnboardEntityRequest entityRequest, String entityId);
+
+    CompletableFuture<OnboardEntityResponse> updateEntity(OnboardEntityRequest entityRequest, String entityId, String schemaVersion);
 
     /**
      * @deprecated Use {{@link #createPaymentInstrument(String, PaymentInstrumentRequest)}} instead
@@ -71,6 +77,8 @@ public interface AccountsClient {
      */
     CompletableFuture<EntityRequirementListResponse> getEntityRequirements(String entityId);
 
+    CompletableFuture<EntityRequirementListResponse> getEntityRequirements(String entityId, String schemaVersion);
+
     /**
      * Retrieves detailed information for a single requirement.
      *
@@ -99,11 +107,17 @@ public interface AccountsClient {
         
     OnboardEntityResponse createEntitySync(final OnboardEntityRequest entityRequest);
 
+    OnboardEntityResponse createEntitySync(final OnboardEntityRequest entityRequest, final String schemaVersion);
+
     PaymentInstrumentDetailsResponse retrievePaymentInstrumentDetailsSync(final String entityId, final String paymentInstrumentId);
 
     OnboardEntityDetailsResponse getEntitySync(final String entityId);
 
+    OnboardEntityDetailsResponse getEntitySync(final String entityId, final String schemaVersion);
+
     OnboardEntityResponse updateEntitySync(final OnboardEntityRequest entityRequest, final String entityId);
+
+    OnboardEntityResponse updateEntitySync(final OnboardEntityRequest entityRequest, final String entityId, final String schemaVersion);
 
     EmptyResponse createPaymentInstrumentSync(final AccountsPaymentInstrument accountsPaymentInstrument, final String entityId);
 
@@ -134,6 +148,8 @@ public interface AccountsClient {
      * Synchronous variant of {@link #getEntityRequirements(String)}.
      */
     EntityRequirementListResponse getEntityRequirementsSync(final String entityId);
+
+    EntityRequirementListResponse getEntityRequirementsSync(final String entityId, final String schemaVersion);
 
     /**
      * Synchronous variant of {@link #getEntityRequirementDetails(String, String)}.

--- a/src/main/java/com/checkout/accounts/AccountsClientImpl.java
+++ b/src/main/java/com/checkout/accounts/AccountsClientImpl.java
@@ -36,7 +36,15 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
     private static final String RESERVE_RULES_PATH = "reserve-rules";
     private static final String REQUIREMENTS_PATH = "requirements";
 
+    private static final String DEFAULT_SCHEMA_VERSION = "3.0";
+
     private final ApiClient filesClient;
+
+    private static Headers buildSchemaVersionHeaders(final String schemaVersion) {
+        return Headers.builder()
+                .accept("application/json;schema_version=" + schemaVersion)
+                .build();
+    }
 
     public AccountsClientImpl(final ApiClient apiClient,
                               final ApiClient filesClient,
@@ -77,13 +85,19 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
 
     @Override
     public CompletableFuture<OnboardEntityResponse> createEntity(final OnboardEntityRequest entityRequest) {
+        return createEntity(entityRequest, DEFAULT_SCHEMA_VERSION);
+    }
+
+    @Override
+    public CompletableFuture<OnboardEntityResponse> createEntity(final OnboardEntityRequest entityRequest, final String schemaVersion) {
         validateEntityRequest(entityRequest);
         return apiClient.postAsync(
                 buildPath(ACCOUNTS_PATH, ENTITIES_PATH),
                 sdkAuthorization(),
                 OnboardEntityResponse.class,
                 entityRequest,
-                null);
+                null,
+                buildSchemaVersionHeaders(schemaVersion));
     }
 
     @Override
@@ -97,21 +111,33 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
 
     @Override
     public CompletableFuture<OnboardEntityDetailsResponse> getEntity(final String entityId) {
+        return getEntity(entityId, DEFAULT_SCHEMA_VERSION);
+    }
+
+    @Override
+    public CompletableFuture<OnboardEntityDetailsResponse> getEntity(final String entityId, final String schemaVersion) {
         validateEntityId(entityId);
         return apiClient.getAsync(
                 buildPath(ACCOUNTS_PATH, ENTITIES_PATH, entityId),
                 sdkAuthorization(),
-                OnboardEntityDetailsResponse.class);
+                OnboardEntityDetailsResponse.class,
+                buildSchemaVersionHeaders(schemaVersion));
     }
 
     @Override
     public CompletableFuture<OnboardEntityResponse> updateEntity(final OnboardEntityRequest entityRequest, final String entityId) {
+        return updateEntity(entityRequest, entityId, DEFAULT_SCHEMA_VERSION);
+    }
+
+    @Override
+    public CompletableFuture<OnboardEntityResponse> updateEntity(final OnboardEntityRequest entityRequest, final String entityId, final String schemaVersion) {
         validateEntityRequestAndId(entityRequest, entityId);
         return apiClient.putAsync(
                 buildPath(ACCOUNTS_PATH, ENTITIES_PATH, entityId),
                 sdkAuthorization(),
                 OnboardEntityResponse.class,
-                entityRequest);
+                entityRequest,
+                buildSchemaVersionHeaders(schemaVersion));
     }
 
     @Override
@@ -243,11 +269,17 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
 
     @Override
     public CompletableFuture<EntityRequirementListResponse> getEntityRequirements(final String entityId) {
+        return getEntityRequirements(entityId, DEFAULT_SCHEMA_VERSION);
+    }
+
+    @Override
+    public CompletableFuture<EntityRequirementListResponse> getEntityRequirements(final String entityId, final String schemaVersion) {
         validateEntityId(entityId);
         return apiClient.getAsync(
                 buildPath(ACCOUNTS_PATH, ENTITIES_PATH, entityId, REQUIREMENTS_PATH),
                 sdkAuthorization(),
-                EntityRequirementListResponse.class);
+                EntityRequirementListResponse.class,
+                buildSchemaVersionHeaders(schemaVersion));
     }
 
     @Override
@@ -302,13 +334,19 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
 
     @Override
     public OnboardEntityResponse createEntitySync(final OnboardEntityRequest entityRequest) {
+        return createEntitySync(entityRequest, DEFAULT_SCHEMA_VERSION);
+    }
+
+    @Override
+    public OnboardEntityResponse createEntitySync(final OnboardEntityRequest entityRequest, final String schemaVersion) {
         validateEntityRequest(entityRequest);
         return apiClient.post(
                 buildPath(ACCOUNTS_PATH, ENTITIES_PATH),
                 sdkAuthorization(),
                 OnboardEntityResponse.class,
                 entityRequest,
-                null);
+                null,
+                buildSchemaVersionHeaders(schemaVersion));
     }
 
     @Override
@@ -322,21 +360,33 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
 
     @Override
     public OnboardEntityDetailsResponse getEntitySync(final String entityId) {
+        return getEntitySync(entityId, DEFAULT_SCHEMA_VERSION);
+    }
+
+    @Override
+    public OnboardEntityDetailsResponse getEntitySync(final String entityId, final String schemaVersion) {
         validateEntityId(entityId);
         return apiClient.get(
                 buildPath(ACCOUNTS_PATH, ENTITIES_PATH, entityId),
                 sdkAuthorization(),
-                OnboardEntityDetailsResponse.class);
+                OnboardEntityDetailsResponse.class,
+                buildSchemaVersionHeaders(schemaVersion));
     }
 
     @Override
     public OnboardEntityResponse updateEntitySync(final OnboardEntityRequest entityRequest, final String entityId) {
+        return updateEntitySync(entityRequest, entityId, DEFAULT_SCHEMA_VERSION);
+    }
+
+    @Override
+    public OnboardEntityResponse updateEntitySync(final OnboardEntityRequest entityRequest, final String entityId, final String schemaVersion) {
         validateEntityRequestAndId(entityRequest, entityId);
         return apiClient.put(
                 buildPath(ACCOUNTS_PATH, ENTITIES_PATH, entityId),
                 sdkAuthorization(),
                 OnboardEntityResponse.class,
-                entityRequest);
+                entityRequest,
+                buildSchemaVersionHeaders(schemaVersion));
     }
 
     @Override
@@ -465,11 +515,17 @@ public class AccountsClientImpl extends AbstractClient implements AccountsClient
 
     @Override
     public EntityRequirementListResponse getEntityRequirementsSync(final String entityId) {
+        return getEntityRequirementsSync(entityId, DEFAULT_SCHEMA_VERSION);
+    }
+
+    @Override
+    public EntityRequirementListResponse getEntityRequirementsSync(final String entityId, final String schemaVersion) {
         validateEntityId(entityId);
         return apiClient.get(
                 buildPath(ACCOUNTS_PATH, ENTITIES_PATH, entityId, REQUIREMENTS_PATH),
                 sdkAuthorization(),
-                EntityRequirementListResponse.class);
+                EntityRequirementListResponse.class,
+                buildSchemaVersionHeaders(schemaVersion));
     }
 
     @Override

--- a/src/main/java/com/checkout/accounts/AgreedTerms.java
+++ b/src/main/java/com/checkout/accounts/AgreedTerms.java
@@ -9,12 +9,16 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public final class DateOfIncorporation {
+public final class AgreedTerms {
 
-    private Integer month;
+    private String date;
 
-    private Integer year;
+    private String ipAddress;
 
-    private Integer day;
+    private String name;
+
+    private String email;
+
+    private String version;
 
 }

--- a/src/main/java/com/checkout/accounts/BusinessType.java
+++ b/src/main/java/com/checkout/accounts/BusinessType.java
@@ -17,5 +17,29 @@ public enum BusinessType {
     @SerializedName("unincorporated_association")
     UNINCORPORATED_ASSOCIATION,
     @SerializedName("auto_entrepreneur")
-    AUTO_ENTREPRENEUR
+    AUTO_ENTREPRENEUR,
+    @SerializedName("individual_or_sole_proprietorship")
+    INDIVIDUAL_OR_SOLE_PROPRIETORSHIP,
+    @SerializedName("scottish_limited_partnership")
+    SCOTTISH_LIMITED_PARTNERSHIP,
+    @SerializedName("limited_liability_corporation")
+    LIMITED_LIABILITY_CORPORATION,
+    @SerializedName("private_corporation")
+    PRIVATE_CORPORATION,
+    @SerializedName("publicly_traded_corporation")
+    PUBLICLY_TRADED_CORPORATION,
+    @SerializedName("government_agency")
+    GOVERNMENT_AGENCY,
+    @SerializedName("non_profit_entity")
+    NON_PROFIT_ENTITY,
+    @SerializedName("trust")
+    TRUST,
+    @SerializedName("club_or_society")
+    CLUB_OR_SOCIETY,
+    @SerializedName("regulated_financial_institution")
+    REGULATED_FINANCIAL_INSTITUTION,
+    @SerializedName("cftc_registered_entity")
+    CFTC_REGISTERED_ENTITY,
+    @SerializedName("sec_registered_entity")
+    SEC_REGISTERED_ENTITY
 }

--- a/src/main/java/com/checkout/accounts/Citizenship.java
+++ b/src/main/java/com/checkout/accounts/Citizenship.java
@@ -1,0 +1,28 @@
+package com.checkout.accounts;
+
+import com.checkout.common.CountryCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A citizenship or legal status held by a company representative, as required by the
+ * Accounts API v3.0 individual schema.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public final class Citizenship {
+
+    /**
+     * The type of citizenship or legal status (for example, {@code citizenship} or {@code residency}).
+     */
+    private String type;
+
+    /**
+     * The two-letter ISO 3166-1 alpha-2 country code.
+     */
+    private CountryCode country;
+}

--- a/src/main/java/com/checkout/accounts/Company.java
+++ b/src/main/java/com/checkout/accounts/Company.java
@@ -36,4 +36,8 @@ public final class Company {
 
     private BusinessType businessType;
 
+    private List<String> additionalTradingNames;
+
+    private Boolean isRegisteredCompany;
+
 }

--- a/src/main/java/com/checkout/accounts/CompanyPosition.java
+++ b/src/main/java/com/checkout/accounts/CompanyPosition.java
@@ -1,0 +1,29 @@
+package com.checkout.accounts;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum CompanyPosition {
+
+    @SerializedName("ceo")
+    CEO,
+    @SerializedName("cfo")
+    CFO,
+    @SerializedName("coo")
+    COO,
+    @SerializedName("managing_member")
+    MANAGING_MEMBER,
+    @SerializedName("general_partner")
+    GENERAL_PARTNER,
+    @SerializedName("president")
+    PRESIDENT,
+    @SerializedName("vice_president")
+    VICE_PRESIDENT,
+    @SerializedName("treasurer")
+    TREASURER,
+    @SerializedName("other_senior_management")
+    OTHER_SENIOR_MANAGEMENT,
+    @SerializedName("other_executive_officer")
+    OTHER_EXECUTIVE_OFFICER,
+    @SerializedName("other_non_executive_non_senior")
+    OTHER_NON_EXECUTIVE_NON_SENIOR
+}

--- a/src/main/java/com/checkout/accounts/EntityRoles.java
+++ b/src/main/java/com/checkout/accounts/EntityRoles.java
@@ -9,5 +9,9 @@ public enum EntityRoles {
     @SerializedName("legal_representative")
     LEGAL_REPRESENTATIVE,
     @SerializedName("authorised_signatory")
-    AUTHORISED_SIGNATORY
+    AUTHORISED_SIGNATORY,
+    @SerializedName("director")
+    DIRECTOR,
+    @SerializedName("control_person")
+    CONTROL_PERSON
 }

--- a/src/main/java/com/checkout/accounts/FinancialStatements.java
+++ b/src/main/java/com/checkout/accounts/FinancialStatements.java
@@ -9,12 +9,10 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public final class DateOfIncorporation {
+public final class FinancialStatements {
 
-    private Integer month;
+    private FinancialStatementsType type;
 
-    private Integer year;
-
-    private Integer day;
+    private String front;
 
 }

--- a/src/main/java/com/checkout/accounts/FinancialStatementsType.java
+++ b/src/main/java/com/checkout/accounts/FinancialStatementsType.java
@@ -1,0 +1,9 @@
+package com.checkout.accounts;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum FinancialStatementsType {
+
+    @SerializedName("financial_statements")
+    FINANCIAL_STATEMENTS
+}

--- a/src/main/java/com/checkout/accounts/Headers.java
+++ b/src/main/java/com/checkout/accounts/Headers.java
@@ -20,11 +20,17 @@ public class Headers implements IHeaders {
     @SerializedName("if-match")
     private String ifMatch;
 
+    @SerializedName("accept")
+    private String accept;
+
     @Override
     public Map<String, String> getHeaders() {
         final Map<String, String> headers = new LinkedHashMap<>();
         if (ifMatch != null) {
             headers.put("if-match", ifMatch);
+        }
+        if (accept != null) {
+            headers.put("Accept", accept);
         }
         return headers;
     }

--- a/src/main/java/com/checkout/accounts/NationalIdType.java
+++ b/src/main/java/com/checkout/accounts/NationalIdType.java
@@ -1,0 +1,21 @@
+package com.checkout.accounts;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum NationalIdType {
+
+    @SerializedName("ssn")
+    SSN,
+    @SerializedName("itin")
+    ITIN,
+    @SerializedName("passport")
+    PASSPORT,
+    @SerializedName("driving_license")
+    DRIVING_LICENSE,
+    @SerializedName("national_id_card")
+    NATIONAL_ID_CARD,
+    @SerializedName("residence_permit")
+    RESIDENCE_PERMIT,
+    @SerializedName("other")
+    OTHER
+}

--- a/src/main/java/com/checkout/accounts/OnboardEntityRequest.java
+++ b/src/main/java/com/checkout/accounts/OnboardEntityRequest.java
@@ -32,6 +32,11 @@ public final class OnboardEntityRequest {
 
     private OnboardSubEntityDocuments documents;
 
+    /**
+     * @deprecated Not present in the current Accounts API schema
+     * retained for backwards compatibility only.
+     */
+    @Deprecated
     private AdditionalInfo additionalInfo;
 
     /**
@@ -47,7 +52,11 @@ public final class OnboardEntityRequest {
      * Captures evidence of the end-user's consent to onboarding.
      * Used for US ISV onboarding variants.
      * [Optional]
+     *
+     * @deprecated Not present in the current Accounts API schema
+     * retained for backwards compatibility only.
      */
+    @Deprecated
     private Submitter submitter;
 
     private AgreedTerms agreedTerms;

--- a/src/main/java/com/checkout/accounts/OnboardEntityRequest.java
+++ b/src/main/java/com/checkout/accounts/OnboardEntityRequest.java
@@ -23,6 +23,11 @@ public final class OnboardEntityRequest {
 
     private ProcessingDetails processingDetails;
 
+    /**
+     * @deprecated Not used by the Accounts API v3.0 schema; a sub-entity is represented via
+     * {@link #company} (with representatives). Retained for v2.0 compatibility.
+     */
+    @Deprecated
     private Individual individual;
 
     private OnboardSubEntityDocuments documents;
@@ -44,5 +49,7 @@ public final class OnboardEntityRequest {
      * [Optional]
      */
     private Submitter submitter;
+
+    private AgreedTerms agreedTerms;
 
 }

--- a/src/main/java/com/checkout/accounts/OnboardSubEntityDocuments.java
+++ b/src/main/java/com/checkout/accounts/OnboardSubEntityDocuments.java
@@ -26,13 +26,13 @@ public final class OnboardSubEntityDocuments {
 
     private ProofOfPrincipalAddress proofOfPrincipalAddress;
 
-    @SerializedName("additional_document_1")
+    @SerializedName("additional_document1")
     private AdditionalDocument additionalDocument1;
 
-    @SerializedName("additional_document_2")
+    @SerializedName("additional_document2")
     private AdditionalDocument additionalDocument2;
 
-    @SerializedName("additional_document_3")
+    @SerializedName("additional_document3")
     private AdditionalDocument additionalDocument3;
 
     private TaxVerification taxVerification;

--- a/src/main/java/com/checkout/accounts/OnboardSubEntityDocuments.java
+++ b/src/main/java/com/checkout/accounts/OnboardSubEntityDocuments.java
@@ -39,4 +39,6 @@ public final class OnboardSubEntityDocuments {
 
     private FinancialVerification financialVerification;
 
+    private FinancialStatements financialStatements;
+
 }

--- a/src/main/java/com/checkout/accounts/ProcessingDetails.java
+++ b/src/main/java/com/checkout/accounts/ProcessingDetails.java
@@ -26,4 +26,8 @@ public final class ProcessingDetails {
 
     private Currency currency;
 
+    private Integer averageOrderFulfillmentTime;
+
+    private ProcessingDetailsPayments payments;
+
 }

--- a/src/main/java/com/checkout/accounts/ProcessingDetailsAch.java
+++ b/src/main/java/com/checkout/accounts/ProcessingDetailsAch.java
@@ -1,0 +1,22 @@
+package com.checkout.accounts;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public final class ProcessingDetailsAch {
+
+    private Integer annualAchVolume;
+
+    private Integer averageAchTransactionSize;
+
+    private Integer estimatedMonthlyCreditVolume;
+
+    private Integer averageCreditAmount;
+
+}

--- a/src/main/java/com/checkout/accounts/ProcessingDetailsPayments.java
+++ b/src/main/java/com/checkout/accounts/ProcessingDetailsPayments.java
@@ -9,12 +9,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public final class DateOfIncorporation {
+public final class ProcessingDetailsPayments {
 
-    private Integer month;
-
-    private Integer year;
-
-    private Integer day;
+    private ProcessingDetailsAch ach;
 
 }

--- a/src/main/java/com/checkout/accounts/Representative.java
+++ b/src/main/java/com/checkout/accounts/Representative.java
@@ -10,24 +10,64 @@ import java.util.List;
 @Builder
 public final class Representative {
 
+    /**
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link #individual} instead.
+     */
+    @Deprecated
     private String firstName;
 
+    /**
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link #individual} instead.
+     */
+    @Deprecated
     private String middleName;
 
+    /**
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link #individual} instead.
+     */
+    @Deprecated
     private String lastName;
 
+    /**
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link #individual} instead.
+     */
+    @Deprecated
     private Address address;
 
+    /**
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link #individual} instead.
+     */
+    @Deprecated
     private Identification identification;
 
+    /**
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link #individual} instead.
+     */
+    @Deprecated
     private AccountPhone phone;
 
+    /**
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link #individual} instead.
+     */
+    @Deprecated
     private DateOfBirth dateOfBirth;
 
+    /**
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link #individual} instead.
+     */
+    @Deprecated
     private PlaceOfBirth placeOfBirth;
 
     private List<EntityRoles> roles;
 
     private OnboardSubEntityDocuments documents;
+
+    private RepresentativeIndividual individual;
+
+    private String id;
+
+    private CompanyPosition companyPosition;
+
+    private Integer ownershipPercentage;
 
 }

--- a/src/main/java/com/checkout/accounts/RepresentativeIndividual.java
+++ b/src/main/java/com/checkout/accounts/RepresentativeIndividual.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -21,6 +23,10 @@ public final class RepresentativeIndividual {
     private DateOfBirth dateOfBirth;
 
     private PlaceOfBirth placeOfBirth;
+
+    private List<Citizenship> citizenships;
+
+    private NationalIdType nationalIdType;
 
     private String nationalIdNumber;
 

--- a/src/main/java/com/checkout/accounts/RepresentativeIndividual.java
+++ b/src/main/java/com/checkout/accounts/RepresentativeIndividual.java
@@ -1,0 +1,33 @@
+package com.checkout.accounts;
+
+import com.checkout.common.Address;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public final class RepresentativeIndividual {
+
+    private String firstName;
+
+    private String middleName;
+
+    private String lastName;
+
+    private DateOfBirth dateOfBirth;
+
+    private PlaceOfBirth placeOfBirth;
+
+    private String nationalIdNumber;
+
+    private String emailAddress;
+
+    private AccountPhone phone;
+
+    private Address address;
+
+}

--- a/src/test/java/com/checkout/accounts/AccountsClientImplTest.java
+++ b/src/test/java/com/checkout/accounts/AccountsClientImplTest.java
@@ -60,6 +60,12 @@ class AccountsClientImplTest {
 
     private AccountsClient accountsClient;
 
+    private static final Headers SCHEMA_V3_HEADERS =
+            Headers.builder().accept("application/json;schema_version=3.0").build();
+
+    private static final Headers SCHEMA_V2_HEADERS =
+            Headers.builder().accept("application/json;schema_version=2.0").build();
+
     @BeforeEach
     void setUp() {
         lenient().when(sdkCredentials.getAuthorization(SdkAuthorizationType.SECRET_KEY_OR_OAUTH)).thenReturn(authorization);
@@ -207,7 +213,7 @@ class AccountsClientImplTest {
         final OnboardEntityRequest request = createOnboardEntityRequest();
         final OnboardEntityResponse expectedResponse = createOnboardEntityResponse();
 
-        when(apiClient.postAsync(eq("accounts/entities"), eq(authorization), eq(OnboardEntityResponse.class), eq(request), isNull()))
+        when(apiClient.postAsync(eq("accounts/entities"), eq(authorization), eq(OnboardEntityResponse.class), eq(request), isNull(), eq(SCHEMA_V3_HEADERS)))
                 .thenReturn(CompletableFuture.completedFuture(expectedResponse));
 
         final CompletableFuture<OnboardEntityResponse> future = accountsClient.createEntity(request);
@@ -219,7 +225,7 @@ class AccountsClientImplTest {
     void shouldGetEntity() throws ExecutionException, InterruptedException {
         final OnboardEntityDetailsResponse expectedResponse = createOnboardEntityDetailsResponse();
 
-        when(apiClient.getAsync("accounts/entities/entity_id", authorization, OnboardEntityDetailsResponse.class))
+        when(apiClient.getAsync("accounts/entities/entity_id", authorization, OnboardEntityDetailsResponse.class, SCHEMA_V3_HEADERS))
                 .thenReturn(CompletableFuture.completedFuture(expectedResponse));
 
         final CompletableFuture<OnboardEntityDetailsResponse> future = accountsClient.getEntity("entity_id");
@@ -232,10 +238,60 @@ class AccountsClientImplTest {
         final OnboardEntityRequest request = createOnboardEntityRequest();
         final OnboardEntityResponse expectedResponse = createOnboardEntityResponse();
 
-        when(apiClient.putAsync(eq("accounts/entities/entity_id"), eq(authorization), eq(OnboardEntityResponse.class), eq(request)))
+        when(apiClient.putAsync(eq("accounts/entities/entity_id"), eq(authorization), eq(OnboardEntityResponse.class), eq(request), eq(SCHEMA_V3_HEADERS)))
                 .thenReturn(CompletableFuture.completedFuture(expectedResponse));
 
         final CompletableFuture<OnboardEntityResponse> future = accountsClient.updateEntity(request, "entity_id");
+
+        validateResponse(expectedResponse, future.get());
+    }
+
+    @Test
+    void shouldCreateEntityWithSchemaVersionOverride() throws ExecutionException, InterruptedException {
+        final OnboardEntityRequest request = createOnboardEntityRequest();
+        final OnboardEntityResponse expectedResponse = createOnboardEntityResponse();
+
+        when(apiClient.postAsync(eq("accounts/entities"), eq(authorization), eq(OnboardEntityResponse.class), eq(request), isNull(), eq(SCHEMA_V2_HEADERS)))
+                .thenReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        final CompletableFuture<OnboardEntityResponse> future = accountsClient.createEntity(request, "2.0");
+
+        validateResponse(expectedResponse, future.get());
+    }
+
+    @Test
+    void shouldGetEntityWithSchemaVersionOverride() throws ExecutionException, InterruptedException {
+        final OnboardEntityDetailsResponse expectedResponse = createOnboardEntityDetailsResponse();
+
+        when(apiClient.getAsync("accounts/entities/entity_id", authorization, OnboardEntityDetailsResponse.class, SCHEMA_V2_HEADERS))
+                .thenReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        final CompletableFuture<OnboardEntityDetailsResponse> future = accountsClient.getEntity("entity_id", "2.0");
+
+        validateResponse(expectedResponse, future.get());
+    }
+
+    @Test
+    void shouldUpdateEntityWithSchemaVersionOverride() throws ExecutionException, InterruptedException {
+        final OnboardEntityRequest request = createOnboardEntityRequest();
+        final OnboardEntityResponse expectedResponse = createOnboardEntityResponse();
+
+        when(apiClient.putAsync(eq("accounts/entities/entity_id"), eq(authorization), eq(OnboardEntityResponse.class), eq(request), eq(SCHEMA_V2_HEADERS)))
+                .thenReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        final CompletableFuture<OnboardEntityResponse> future = accountsClient.updateEntity(request, "entity_id", "2.0");
+
+        validateResponse(expectedResponse, future.get());
+    }
+
+    @Test
+    void shouldGetEntityRequirementsWithSchemaVersionOverride() throws ExecutionException, InterruptedException {
+        final EntityRequirementListResponse expectedResponse = new EntityRequirementListResponse();
+
+        when(apiClient.getAsync("accounts/entities/entity_id/requirements", authorization, EntityRequirementListResponse.class, SCHEMA_V2_HEADERS))
+                .thenReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        final CompletableFuture<EntityRequirementListResponse> future = accountsClient.getEntityRequirements("entity_id", "2.0");
 
         validateResponse(expectedResponse, future.get());
     }
@@ -348,7 +404,7 @@ class AccountsClientImplTest {
         final OnboardEntityRequest request = createOnboardEntityRequest();
         final OnboardEntityResponse expectedResponse = createOnboardEntityResponse();
 
-        when(apiClient.post(eq("accounts/entities"), eq(authorization), eq(OnboardEntityResponse.class), eq(request), isNull()))
+        when(apiClient.post(eq("accounts/entities"), eq(authorization), eq(OnboardEntityResponse.class), eq(request), isNull(), eq(SCHEMA_V3_HEADERS)))
                 .thenReturn(expectedResponse);
 
         final OnboardEntityResponse actualResponse = accountsClient.createEntitySync(request);
@@ -360,7 +416,7 @@ class AccountsClientImplTest {
     void shouldGetEntitySync() {
         final OnboardEntityDetailsResponse expectedResponse = createOnboardEntityDetailsResponse();
 
-        when(apiClient.get("accounts/entities/entity_id", authorization, OnboardEntityDetailsResponse.class))
+        when(apiClient.get("accounts/entities/entity_id", authorization, OnboardEntityDetailsResponse.class, SCHEMA_V3_HEADERS))
                 .thenReturn(expectedResponse);
 
         final OnboardEntityDetailsResponse actualResponse = accountsClient.getEntitySync("entity_id");
@@ -373,7 +429,7 @@ class AccountsClientImplTest {
         final OnboardEntityRequest request = createOnboardEntityRequest();
         final OnboardEntityResponse expectedResponse = createOnboardEntityResponse();
 
-        when(apiClient.put(eq("accounts/entities/entity_id"), eq(authorization), eq(OnboardEntityResponse.class), eq(request)))
+        when(apiClient.put(eq("accounts/entities/entity_id"), eq(authorization), eq(OnboardEntityResponse.class), eq(request), eq(SCHEMA_V3_HEADERS)))
                 .thenReturn(expectedResponse);
 
         final OnboardEntityResponse actualResponse = accountsClient.updateEntitySync(request, "entity_id");
@@ -621,7 +677,7 @@ class AccountsClientImplTest {
     void shouldGetEntityRequirements() throws ExecutionException, InterruptedException {
         final EntityRequirementListResponse expectedResponse = createEntityRequirementListResponse();
 
-        when(apiClient.getAsync("accounts/entities/entity_id/requirements", authorization, EntityRequirementListResponse.class))
+        when(apiClient.getAsync("accounts/entities/entity_id/requirements", authorization, EntityRequirementListResponse.class, SCHEMA_V3_HEADERS))
                 .thenReturn(CompletableFuture.completedFuture(expectedResponse));
 
         final CompletableFuture<EntityRequirementListResponse> future = accountsClient.getEntityRequirements("entity_id");
@@ -733,7 +789,7 @@ class AccountsClientImplTest {
     void shouldGetEntityRequirementsSync() {
         final EntityRequirementListResponse expectedResponse = createEntityRequirementListResponse();
 
-        when(apiClient.get("accounts/entities/entity_id/requirements", authorization, EntityRequirementListResponse.class))
+        when(apiClient.get("accounts/entities/entity_id/requirements", authorization, EntityRequirementListResponse.class, SCHEMA_V3_HEADERS))
                 .thenReturn(expectedResponse);
 
         final EntityRequirementListResponse actualResponse = accountsClient.getEntityRequirementsSync("entity_id");

--- a/src/test/java/com/checkout/accounts/AccountsTestIT.java
+++ b/src/test/java/com/checkout/accounts/AccountsTestIT.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
 
@@ -161,6 +162,86 @@ class AccountsTestIT extends SandboxTestFixture {
 
         final OnboardEntityDetailsResponse entityDetailsResponse = checkoutApi.accountsClient().getEntitySync(entityResponse.getId(), "2.0");
         validateCompanyEntityDetails(entityDetailsResponse, onboardEntityRequest, randomReference);
+    }
+
+    // ===================== Accounts API schema_version 3.0 =====================
+    // v3.0 onboards a sub-entity as a company whose representatives carry nested `individual`
+    // details + `roles`, plus a required `processing_details` object. These mirror the 2.0
+    // onboarding tests above (which pin schema_version to "2.0"); here createEntity/getEntity/
+    // updateEntity use the SDK default (3.0). They run through the accounts-scoped OAuth client,
+    // which is the one provisioned for v3.0 onboarding.
+    @Test
+    void shouldCreateGetAndUpdateOnboardCompanyEntityV3() {
+        final CheckoutApi checkoutApi = getAccountsCheckoutApi();
+        final String randomReference = RandomStringUtils.random(15, true, true);
+        final OnboardEntityRequest onboardEntityRequest = buildCompanyEntityV3(randomReference);
+
+        final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient().createEntity(onboardEntityRequest));
+        validateEntityCreationResponse(entityResponse, randomReference);
+
+        final OnboardEntityDetailsResponse entityDetailsResponse = blocking(() -> checkoutApi.accountsClient().getEntity(entityResponse.getId()));
+        validateCompanyEntityDetails(entityDetailsResponse, onboardEntityRequest, randomReference);
+
+        final OnboardEntityResponse updatedEntityResponse = blocking(() -> checkoutApi.accountsClient().updateEntity(onboardEntityRequest, entityResponse.getId()));
+        assertNotNull(updatedEntityResponse);
+        assertNotNull(updatedEntityResponse.getId());
+    }
+
+    @Test
+    void shouldCreateGetAndUpdateOnboardCompanyEntitySyncV3() {
+        final CheckoutApi checkoutApi = getAccountsCheckoutApi();
+        final String randomReference = RandomStringUtils.random(15, true, true);
+        final OnboardEntityRequest onboardEntityRequest = buildCompanyEntityV3(randomReference);
+
+        final OnboardEntityResponse entityResponse = checkoutApi.accountsClient().createEntitySync(onboardEntityRequest);
+        validateEntityCreationResponse(entityResponse, randomReference);
+
+        final OnboardEntityDetailsResponse entityDetailsResponse = checkoutApi.accountsClient().getEntitySync(entityResponse.getId());
+        validateCompanyEntityDetails(entityDetailsResponse, onboardEntityRequest, randomReference);
+
+        final OnboardEntityResponse updatedEntityResponse = checkoutApi.accountsClient().updateEntitySync(onboardEntityRequest, entityResponse.getId());
+        assertNotNull(updatedEntityResponse);
+        assertNotNull(updatedEntityResponse.getId());
+    }
+
+    @Test
+    void shouldCreateAndRetrievePaymentInstrumentV3() throws URISyntaxException {
+        final CheckoutApi checkoutApi = getAccountsCheckoutApi();
+
+        final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient()
+                .createEntity(buildCompanyEntityV3(RandomStringUtils.random(15, true, true))));
+        assertNotNull(entityResponse);
+        assertNotNull(entityResponse.getId());
+
+        final IdResponse file = uploadFile();
+        final PaymentInstrumentRequest instrumentRequest = buildPaymentInstrumentRequest(file.getId());
+
+        final IdResponse instrumentResponse = blocking(() -> checkoutApi.accountsClient().createPaymentInstrument(entityResponse.getId(), instrumentRequest));
+        assertNotNull(instrumentResponse);
+        assertNotNull(instrumentResponse.getId());
+
+        final PaymentInstrumentDetailsResponse instrumentDetailsResponse = blocking(() -> checkoutApi.accountsClient().retrievePaymentInstrumentDetails(entityResponse.getId(), instrumentResponse.getId()));
+        validatePaymentInstrumentDetailsResponse(instrumentDetailsResponse);
+    }
+
+    @Test
+    void shouldCreateAndRetrievePaymentInstrumentSyncV3() throws URISyntaxException {
+        final CheckoutApi checkoutApi = getAccountsCheckoutApi();
+
+        final OnboardEntityResponse entityResponse = checkoutApi.accountsClient()
+                .createEntitySync(buildCompanyEntityV3(RandomStringUtils.random(15, true, true)));
+        assertNotNull(entityResponse);
+        assertNotNull(entityResponse.getId());
+
+        final IdResponse file = uploadFileSync();
+        final PaymentInstrumentRequest instrumentRequest = buildPaymentInstrumentRequest(file.getId());
+
+        final IdResponse instrumentResponse = checkoutApi.accountsClient().createPaymentInstrumentSync(entityResponse.getId(), instrumentRequest);
+        assertNotNull(instrumentResponse);
+        assertNotNull(instrumentResponse.getId());
+
+        final PaymentInstrumentDetailsResponse instrumentDetailsResponse = checkoutApi.accountsClient().retrievePaymentInstrumentDetailsSync(entityResponse.getId(), instrumentResponse.getId());
+        validatePaymentInstrumentDetailsResponse(instrumentDetailsResponse);
     }
 
     @Test
@@ -611,6 +692,89 @@ class AccountsTestIT extends SandboxTestFixture {
                                 .highestTransactionValue(2500L)
                                 .build())
 
+                        .build())
+                .build();
+    }
+
+    // Builds an onboarding request that conforms to the Accounts API v3.0 schema: the representative
+    // carries nested `individual` details + `roles`, the company has `businessType` +
+    // `dateOfIncorporation`, and `processingDetails` is populated. The holding-currency scope is
+    // configured on the platform (USD here) while `processingDetails.currency` reflects the
+    // sub-entity region (GBP) — the two are independent.
+    private static OnboardEntityRequest buildCompanyEntityV3(final String randomReference) {
+        final Address address = Address.builder()
+                .addressLine1("90 Tottenham Court Road")
+                .city("London")
+                .zip("W1T4TJ")
+                .country(CountryCode.GB)
+                .build();
+
+        return OnboardEntityRequest.builder()
+                .reference(randomReference)
+                .contactDetails(ContactDetails.builder()
+                        .phone(AccountPhone.builder()
+                                .countryCode(CountryCode.GB)
+                                .number("2345678910")
+                                .build())
+                        .emailAddresses(EntityEmailAddresses.builder()
+                                .primary(generateRandomEmail())
+                                .build())
+                        .build())
+                .profile(Profile.builder()
+                        .urls(Collections.singletonList("https://www.superheroexample.com"))
+                        .mccs(Collections.singletonList("0742"))
+                        .defaultHoldingCurrency(Currency.USD)
+                        .holdingCurrencies(Collections.singletonList(Currency.USD))
+                        .build())
+                .company(Company.builder()
+                        .businessRegistrationNumber("01234567")
+                        .businessType(BusinessType.LIMITED_COMPANY)
+                        .legalName("Super Hero Masks Inc.")
+                        .tradingName("Super Hero Masks")
+                        .dateOfIncorporation(DateOfIncorporation.builder()
+                                .day(1)
+                                .month(6)
+                                .year(2010)
+                                .build())
+                        .principalAddress(address)
+                        .registeredAddress(address)
+                        .representatives(Collections.singletonList(Representative.builder()
+                                .individual(RepresentativeIndividual.builder()
+                                        .firstName("John")
+                                        .lastName("Doe")
+                                        .dateOfBirth(DateOfBirth.builder()
+                                                .day(5)
+                                                .month(6)
+                                                .year(1995)
+                                                .build())
+                                        .placeOfBirth(PlaceOfBirth.builder()
+                                                .country(CountryCode.GB)
+                                                .build())
+                                        .address(address)
+                                        .build())
+                                .roles(Arrays.asList(
+                                        EntityRoles.UBO,
+                                        EntityRoles.AUTHORISED_SIGNATORY,
+                                        EntityRoles.DIRECTOR,
+                                        EntityRoles.CONTROL_PERSON))
+                                .build()))
+                        .build())
+                .processingDetails(ProcessingDetails.builder()
+                        .annualProcessingVolume(1000000)
+                        .averageTransactionValue(5000)
+                        .averageOrderFulfillmentTime(3)
+                        .highestTransactionValue(25000)
+                        .currency(Currency.GBP)
+                        .settlementCountry(CountryCode.GB.name())
+                        .targetCountries(Collections.singletonList(CountryCode.GB.name()))
+                        .payments(ProcessingDetailsPayments.builder()
+                                .ach(ProcessingDetailsAch.builder()
+                                        .annualAchVolume(1000000)
+                                        .averageAchTransactionSize(5000)
+                                        .estimatedMonthlyCreditVolume(100000)
+                                        .averageCreditAmount(5000)
+                                        .build())
+                                .build())
                         .build())
                 .build();
     }

--- a/src/test/java/com/checkout/accounts/AccountsTestIT.java
+++ b/src/test/java/com/checkout/accounts/AccountsTestIT.java
@@ -50,17 +50,17 @@ class AccountsTestIT extends SandboxTestFixture {
         final String randomReference = RandomStringUtils.random(15, true, true);
         final OnboardEntityRequest onboardEntityRequest = buildIndividualEntity(randomReference);
 
-        final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient().createEntity(onboardEntityRequest));
+        final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient().createEntity(onboardEntityRequest, "2.0"));
         validateEntityCreationResponse(entityResponse, randomReference);
 
-        final OnboardEntityDetailsResponse entityDetailsResponse = blocking(() -> checkoutApi.accountsClient().getEntity(entityResponse.getId()));
+        final OnboardEntityDetailsResponse entityDetailsResponse = blocking(() -> checkoutApi.accountsClient().getEntity(entityResponse.getId(), "2.0"));
         validateIndividualEntityDetails(entityDetailsResponse, onboardEntityRequest, randomReference);
 
         onboardEntityRequest.getIndividual().setFirstName("Jhon");
-        final OnboardEntityResponse updatedEntityResponse = blocking(() -> checkoutApi.accountsClient().updateEntity(onboardEntityRequest, entityResponse.getId()));
+        final OnboardEntityResponse updatedEntityResponse = blocking(() -> checkoutApi.accountsClient().updateEntity(onboardEntityRequest, entityResponse.getId(), "2.0"));
         assertNotNull(updatedEntityResponse);
 
-        final OnboardEntityDetailsResponse verifyUpdated = blocking(() -> checkoutApi.accountsClient().getEntity(entityResponse.getId()));
+        final OnboardEntityDetailsResponse verifyUpdated = blocking(() -> checkoutApi.accountsClient().getEntity(entityResponse.getId(), "2.0"));
         assertEquals(onboardEntityRequest.getIndividual().getFirstName(), verifyUpdated.getIndividual().getFirstName());
     }
 
@@ -70,10 +70,10 @@ class AccountsTestIT extends SandboxTestFixture {
         final String randomReference = RandomStringUtils.random(15, true, true);
         final OnboardEntityRequest onboardEntityRequest = buildCompanyEntity(randomReference);
 
-        final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient().createEntity(onboardEntityRequest));
+        final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient().createEntity(onboardEntityRequest, "2.0"));
         validateEntityCreationResponse(entityResponse, randomReference);
 
-        final OnboardEntityDetailsResponse entityDetailsResponse = blocking(() -> checkoutApi.accountsClient().getEntity(entityResponse.getId()));
+        final OnboardEntityDetailsResponse entityDetailsResponse = blocking(() -> checkoutApi.accountsClient().getEntity(entityResponse.getId(), "2.0"));
         validateCompanyEntityDetails(entityDetailsResponse, onboardEntityRequest, randomReference);
     }
 
@@ -114,7 +114,7 @@ class AccountsTestIT extends SandboxTestFixture {
         final CheckoutApi checkoutApi = getAccountsCheckoutApi();
 
         final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient()
-                .createEntity(buildCompanyEntity(RandomStringUtils.random(15, true, true))));
+                .createEntity(buildCompanyEntity(RandomStringUtils.random(15, true, true)), "2.0"));
         assertNotNull(entityResponse);
         assertNotNull(entityResponse.getId());
 
@@ -136,17 +136,17 @@ class AccountsTestIT extends SandboxTestFixture {
         final String randomReference = RandomStringUtils.random(15, true, true);
         final OnboardEntityRequest onboardEntityRequest = buildIndividualEntity(randomReference);
 
-        final OnboardEntityResponse entityResponse = checkoutApi.accountsClient().createEntitySync(onboardEntityRequest);
+        final OnboardEntityResponse entityResponse = checkoutApi.accountsClient().createEntitySync(onboardEntityRequest, "2.0");
         validateEntityCreationResponse(entityResponse, randomReference);
 
-        final OnboardEntityDetailsResponse entityDetailsResponse = checkoutApi.accountsClient().getEntitySync(entityResponse.getId());
+        final OnboardEntityDetailsResponse entityDetailsResponse = checkoutApi.accountsClient().getEntitySync(entityResponse.getId(), "2.0");
         validateIndividualEntityDetails(entityDetailsResponse, onboardEntityRequest, randomReference);
 
         onboardEntityRequest.getIndividual().setFirstName("Jhon");
-        final OnboardEntityResponse updatedEntityResponse = checkoutApi.accountsClient().updateEntitySync(onboardEntityRequest, entityResponse.getId());
+        final OnboardEntityResponse updatedEntityResponse = checkoutApi.accountsClient().updateEntitySync(onboardEntityRequest, entityResponse.getId(), "2.0");
         assertNotNull(updatedEntityResponse);
 
-        final OnboardEntityDetailsResponse verifyUpdated = checkoutApi.accountsClient().getEntitySync(entityResponse.getId());
+        final OnboardEntityDetailsResponse verifyUpdated = checkoutApi.accountsClient().getEntitySync(entityResponse.getId(), "2.0");
         assertEquals(onboardEntityRequest.getIndividual().getFirstName(), verifyUpdated.getIndividual().getFirstName());
     }
 
@@ -156,10 +156,10 @@ class AccountsTestIT extends SandboxTestFixture {
         final String randomReference = RandomStringUtils.random(15, true, true);
         final OnboardEntityRequest onboardEntityRequest = buildCompanyEntity(randomReference);
 
-        final OnboardEntityResponse entityResponse = checkoutApi.accountsClient().createEntitySync(onboardEntityRequest);
+        final OnboardEntityResponse entityResponse = checkoutApi.accountsClient().createEntitySync(onboardEntityRequest, "2.0");
         validateEntityCreationResponse(entityResponse, randomReference);
 
-        final OnboardEntityDetailsResponse entityDetailsResponse = checkoutApi.accountsClient().getEntitySync(entityResponse.getId());
+        final OnboardEntityDetailsResponse entityDetailsResponse = checkoutApi.accountsClient().getEntitySync(entityResponse.getId(), "2.0");
         validateCompanyEntityDetails(entityDetailsResponse, onboardEntityRequest, randomReference);
     }
 
@@ -175,7 +175,7 @@ class AccountsTestIT extends SandboxTestFixture {
         final CheckoutApi checkoutApi = getAccountsCheckoutApi();
 
         final OnboardEntityResponse entityResponse = checkoutApi.accountsClient()
-                .createEntitySync(buildCompanyEntity(RandomStringUtils.random(15, true, true)));
+                .createEntitySync(buildCompanyEntity(RandomStringUtils.random(15, true, true)), "2.0");
         assertNotNull(entityResponse);
         assertNotNull(entityResponse.getId());
 
@@ -281,7 +281,7 @@ class AccountsTestIT extends SandboxTestFixture {
     void shouldGetEntityRequirements() {
         final String entityId = Objects.requireNonNull(System.getenv("CHECKOUT_DEFAULT_ENTITY_ID"));
 
-        final EntityRequirementListResponse response = blocking(() -> checkoutApi.accountsClient().getEntityRequirements(entityId));
+        final EntityRequirementListResponse response = blocking(() -> checkoutApi.accountsClient().getEntityRequirements(entityId, "2.0"));
         validateEntityRequirementListResponse(response);
     }
 
@@ -289,7 +289,7 @@ class AccountsTestIT extends SandboxTestFixture {
     @Test
     void shouldGetEntityRequirementDetails() {
         final String entityId = Objects.requireNonNull(System.getenv("CHECKOUT_DEFAULT_ENTITY_ID"));
-        final EntityRequirementListResponse listResponse = blocking(() -> checkoutApi.accountsClient().getEntityRequirements(entityId));
+        final EntityRequirementListResponse listResponse = blocking(() -> checkoutApi.accountsClient().getEntityRequirements(entityId, "2.0"));
         assertNotNull(listResponse.getData());
         assertNotNull(listResponse.getData().get(0));
 
@@ -302,7 +302,7 @@ class AccountsTestIT extends SandboxTestFixture {
     @Test
     void shouldResolveEntityRequirement() {
         final String entityId = Objects.requireNonNull(System.getenv("CHECKOUT_DEFAULT_ENTITY_ID"));
-        final EntityRequirementListResponse listResponse = blocking(() -> checkoutApi.accountsClient().getEntityRequirements(entityId));
+        final EntityRequirementListResponse listResponse = blocking(() -> checkoutApi.accountsClient().getEntityRequirements(entityId, "2.0"));
         assertNotNull(listResponse.getData());
         assertNotNull(listResponse.getData().get(0));
 
@@ -420,7 +420,7 @@ class AccountsTestIT extends SandboxTestFixture {
                         .build())
                 .build();
 
-        final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient().createEntity(entityRequest));
+        final OnboardEntityResponse entityResponse = blocking(() -> checkoutApi.accountsClient().createEntity(entityRequest, "2.0"));
         assertNotNull(entityResponse);
         assertNotNull(entityResponse.getId());
         return entityResponse.getId();

--- a/src/test/java/com/checkout/accounts/AccountsV3SerializationTest.java
+++ b/src/test/java/com/checkout/accounts/AccountsV3SerializationTest.java
@@ -1,6 +1,7 @@
 package com.checkout.accounts;
 
 import com.checkout.GsonSerializer;
+import com.checkout.common.CountryCode;
 import com.checkout.common.Currency;
 import org.junit.jupiter.api.Test;
 
@@ -97,6 +98,11 @@ class AccountsV3SerializationTest {
                 .individual(RepresentativeIndividual.builder()
                         .firstName("John")
                         .lastName("Representative")
+                        .citizenships(Collections.singletonList(Citizenship.builder()
+                                .type("citizenship")
+                                .country(CountryCode.US)
+                                .build()))
+                        .nationalIdType(NationalIdType.SSN)
                         .nationalIdNumber("AB123456C")
                         .emailAddress("john@example.com")
                         .build())
@@ -109,6 +115,10 @@ class AccountsV3SerializationTest {
 
         assertTrue(json.contains("\"individual\""));
         assertTrue(json.contains("\"first_name\""));
+        assertTrue(json.contains("\"citizenships\""));
+        assertTrue(json.contains("\"country\""));
+        assertTrue(json.contains("\"national_id_type\""));
+        assertTrue(json.contains("ssn"));
         assertTrue(json.contains("\"national_id_number\""));
         assertTrue(json.contains("\"email_address\""));
         assertTrue(json.contains("\"company_position\""));

--- a/src/test/java/com/checkout/accounts/AccountsV3SerializationTest.java
+++ b/src/test/java/com/checkout/accounts/AccountsV3SerializationTest.java
@@ -1,0 +1,161 @@
+package com.checkout.accounts;
+
+import com.checkout.GsonSerializer;
+import com.checkout.common.Currency;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AccountsV3SerializationTest {
+
+    private final GsonSerializer serializer = new GsonSerializer();
+
+    @Test
+    void shouldSerializeProcessingDetailsWithPayments() {
+        final ProcessingDetails processingDetails = ProcessingDetails.builder()
+                .annualProcessingVolume(1000000)
+                .averageTransactionValue(5000)
+                .averageOrderFulfillmentTime(3)
+                .highestTransactionValue(25000)
+                .currency(Currency.GBP)
+                .settlementCountry("GB")
+                .targetCountries(Collections.singletonList("GB"))
+                .payments(ProcessingDetailsPayments.builder()
+                        .ach(ProcessingDetailsAch.builder()
+                                .annualAchVolume(1000000)
+                                .averageAchTransactionSize(5000)
+                                .estimatedMonthlyCreditVolume(100000)
+                                .averageCreditAmount(5000)
+                                .build())
+                        .build())
+                .build();
+
+        final String json = serializer.toJson(processingDetails);
+
+        assertTrue(json.contains("\"annual_processing_volume\""));
+        assertTrue(json.contains("\"average_order_fulfillment_time\""));
+        assertTrue(json.contains("\"highest_transaction_value\""));
+        assertTrue(json.contains("\"settlement_country\""));
+        assertTrue(json.contains("\"target_countries\""));
+        assertTrue(json.contains("\"payments\""));
+        assertTrue(json.contains("\"ach\""));
+        assertTrue(json.contains("\"annual_ach_volume\""));
+        assertTrue(json.contains("\"average_ach_transaction_size\""));
+        assertTrue(json.contains("\"estimated_monthly_credit_volume\""));
+        assertTrue(json.contains("\"average_credit_amount\""));
+    }
+
+    @Test
+    void shouldSerializeAgreedTerms() {
+        final AgreedTerms agreedTerms = AgreedTerms.builder()
+                .date("2026-07-20T10:00:00Z")
+                .ipAddress("203.0.113.42")
+                .name("John Representative")
+                .email("john@example.com")
+                .version("1.0")
+                .build();
+
+        final String json = serializer.toJson(agreedTerms);
+
+        assertTrue(json.contains("\"date\""));
+        assertTrue(json.contains("\"ip_address\""));
+        assertTrue(json.contains("\"name\""));
+        assertTrue(json.contains("\"email\""));
+        assertTrue(json.contains("\"version\""));
+    }
+
+    @Test
+    void shouldSerializeCompanyV3Fields() {
+        final Company company = Company.builder()
+                .legalName("Super Hero Masks Inc.")
+                .tradingName("Super Hero Masks")
+                .businessRegistrationNumber("01234567")
+                .businessType(BusinessType.LIMITED_COMPANY)
+                .additionalTradingNames(Collections.singletonList("SHM"))
+                .isRegisteredCompany(true)
+                .dateOfIncorporation(DateOfIncorporation.builder().day(1).month(6).year(2010).build())
+                .build();
+
+        final String json = serializer.toJson(company);
+
+        assertTrue(json.contains("\"additional_trading_names\""));
+        assertTrue(json.contains("\"is_registered_company\""));
+        assertTrue(json.contains("\"business_type\""));
+        assertTrue(json.contains("limited_company"));
+        assertTrue(json.contains("\"date_of_incorporation\""));
+        assertTrue(json.contains("\"day\""));
+    }
+
+    @Test
+    void shouldSerializeRepresentativeV3Fields() {
+        final Representative representative = Representative.builder()
+                .id("rep_00000000000000000000000000")
+                .individual(RepresentativeIndividual.builder()
+                        .firstName("John")
+                        .lastName("Representative")
+                        .nationalIdNumber("AB123456C")
+                        .emailAddress("john@example.com")
+                        .build())
+                .companyPosition(CompanyPosition.CEO)
+                .ownershipPercentage(100)
+                .roles(Arrays.asList(EntityRoles.UBO, EntityRoles.AUTHORISED_SIGNATORY, EntityRoles.DIRECTOR, EntityRoles.CONTROL_PERSON))
+                .build();
+
+        final String json = serializer.toJson(representative);
+
+        assertTrue(json.contains("\"individual\""));
+        assertTrue(json.contains("\"first_name\""));
+        assertTrue(json.contains("\"national_id_number\""));
+        assertTrue(json.contains("\"email_address\""));
+        assertTrue(json.contains("\"company_position\""));
+        assertTrue(json.contains("ceo"));
+        assertTrue(json.contains("\"ownership_percentage\""));
+        assertTrue(json.contains("director"));
+        assertTrue(json.contains("control_person"));
+    }
+
+    @Test
+    void shouldSerializeFinancialStatementsDocument() {
+        final OnboardSubEntityDocuments documents = OnboardSubEntityDocuments.builder()
+                .financialStatements(FinancialStatements.builder()
+                        .type(FinancialStatementsType.FINANCIAL_STATEMENTS)
+                        .front("file_00000000000000000000000000")
+                        .build())
+                .build();
+
+        final String json = serializer.toJson(documents);
+
+        assertTrue(json.contains("\"financial_statements\""));
+        assertTrue(json.contains("financial_statements"));
+        assertTrue(json.contains("\"front\""));
+    }
+
+    @Test
+    void shouldSerializeOnboardEntityRequestWithAgreedTermsAndSellerCategory() {
+        final OnboardEntityRequest request = OnboardEntityRequest.builder()
+                .reference("ref_1")
+                .sellerCategory("cat_electronics")
+                .agreedTerms(AgreedTerms.builder().date("2026-07-20T10:00:00Z").version("1.0").build())
+                .build();
+
+        final String json = serializer.toJson(request);
+
+        assertTrue(json.contains("\"seller_category\""));
+        assertTrue(json.contains("\"agreed_terms\""));
+    }
+
+    @Test
+    void shouldDeserializeNewEnumValuesToExactSwaggerStrings() {
+        assertEquals(EntityRoles.DIRECTOR, serializer.fromJson("\"director\"", EntityRoles.class));
+        assertEquals(EntityRoles.CONTROL_PERSON, serializer.fromJson("\"control_person\"", EntityRoles.class));
+        assertEquals(BusinessType.INDIVIDUAL_OR_SOLE_PROPRIETORSHIP, serializer.fromJson("\"individual_or_sole_proprietorship\"", BusinessType.class));
+        assertEquals(BusinessType.GOVERNMENT_AGENCY, serializer.fromJson("\"government_agency\"", BusinessType.class));
+        assertEquals(BusinessType.SEC_REGISTERED_ENTITY, serializer.fromJson("\"sec_registered_entity\"", BusinessType.class));
+        assertEquals(CompanyPosition.CEO, serializer.fromJson("\"ceo\"", CompanyPosition.class));
+        assertEquals(CompanyPosition.OTHER_NON_EXECUTIVE_NON_SENIOR, serializer.fromJson("\"other_non_executive_non_senior\"", CompanyPosition.class));
+    }
+}


### PR DESCRIPTION
This pull request introduces several enhancements and extensions to the Accounts API client, focusing on improved schema versioning support, expanded entity management, and broader business type and role coverage. The changes add flexible API methods to specify schema versions, introduce new model fields and types, and extend enums to support a wider range of business and company scenarios.

**API client enhancements for schema versioning:**

- Added overloaded methods to `ApiClient` and `AccountsClient` (both async and sync) to accept custom headers, specifically to support specifying a `schemaVersion` for requests. Default schema version is set to `"3.0"` if not provided. (`src/main/java/com/checkout/ApiClient.java`, `src/main/java/com/checkout/ApiClientImpl.java`, `src/main/java/com/checkout/accounts/AccountsClient.java`, `src/main/java/com/checkout/accounts/AccountsClientImpl.java`) [[1]](diffhunk://#diff-c9a2792984abbe85ea8d2f16a7b6af7f1ca55de29c21324ab72ce67d8af65f28R15-R20) [[2]](diffhunk://#diff-c9a2792984abbe85ea8d2f16a7b6af7f1ca55de29c21324ab72ce67d8af65f28R48-R53) [[3]](diffhunk://#diff-17788e6798031a3a75095fb61f03d1a3c404d2b6a6960c446262cfaae5d2688cR62-R70) [[4]](diffhunk://#diff-17788e6798031a3a75095fb61f03d1a3c404d2b6a6960c446262cfaae5d2688cR80-R88) [[5]](diffhunk://#diff-17788e6798031a3a75095fb61f03d1a3c404d2b6a6960c446262cfaae5d2688cR347-R364) [[6]](diffhunk://#diff-cbcb5e828cfdb9bda58ecef6c6763e2ccd51ef014a518b8e88127eb1bc01087fR29-R40) [[7]](diffhunk://#diff-cbcb5e828cfdb9bda58ecef6c6763e2ccd51ef014a518b8e88127eb1bc01087fR80-R81) [[8]](diffhunk://#diff-cbcb5e828cfdb9bda58ecef6c6763e2ccd51ef014a518b8e88127eb1bc01087fR110-R121) [[9]](diffhunk://#diff-cbcb5e828cfdb9bda58ecef6c6763e2ccd51ef014a518b8e88127eb1bc01087fR152-R153) [[10]](diffhunk://#diff-b6f10b5fe05a9035cc59495199733482e9d9cdc97c69b4ee3dee4077d2b6d190R39-R48) [[11]](diffhunk://#diff-b6f10b5fe05a9035cc59495199733482e9d9cdc97c69b4ee3dee4077d2b6d190R88-R100) [[12]](diffhunk://#diff-b6f10b5fe05a9035cc59495199733482e9d9cdc97c69b4ee3dee4077d2b6d190R114-R140) [[13]](diffhunk://#diff-b6f10b5fe05a9035cc59495199733482e9d9cdc97c69b4ee3dee4077d2b6d190R272-R282) [[14]](diffhunk://#diff-b6f10b5fe05a9035cc59495199733482e9d9cdc97c69b4ee3dee4077d2b6d190R337-R349) [[15]](diffhunk://#diff-b6f10b5fe05a9035cc59495199733482e9d9cdc97c69b4ee3dee4077d2b6d190R363-R389) [[16]](diffhunk://#diff-b6f10b5fe05a9035cc59495199733482e9d9cdc97c69b4ee3dee4077d2b6d190R518-R528)

**Model and enum extensions:**

- Added new model classes and fields to support additional business requirements:
    - Introduced `AgreedTerms` model for capturing agreement metadata. (`src/main/java/com/checkout/accounts/AgreedTerms.java`)
    - Added `additionalTradingNames` and `isRegisteredCompany` fields to `Company`. (`src/main/java/com/checkout/accounts/Company.java`)
    - Added `day` field to `DateOfIncorporation`. (`src/main/java/com/checkout/accounts/DateOfIncorporation.java`)
    - Introduced new enum `CompanyPosition` for more granular company role identification. (`src/main/java/com/checkout/accounts/CompanyPosition.java`)

- Expanded supported business types and entity roles:
    - Extended `BusinessType` enum with many new types (e.g., `INDIVIDUAL_OR_SOLE_PROPRIETORSHIP`, `NON_PROFIT_ENTITY`, etc.). (`src/main/java/com/checkout/accounts/BusinessType.java`)
    - Extended `EntityRoles` enum with new roles (`DIRECTOR`, `CONTROL_PERSON`). (`src/main/java/com/checkout/accounts/EntityRoles.java`)

These changes provide greater flexibility for clients to interact with the API using different schema versions, and ensure the models and enums better reflect the diverse range of business entities and roles that may be encountered.