### PR TITLE
feature/INT-1671 - PaymentSourceType blik

### DIFF
--- a/src/main/java/com/checkout/common/PaymentSourceType.java
+++ b/src/main/java/com/checkout/common/PaymentSourceType.java
@@ -30,6 +30,8 @@ public enum PaymentSourceType {
     BENEFITPAY,
     @SerializedName("bizum")
     BIZUM,
+    @SerializedName("blik")
+    BLIK,
     @SerializedName("boleto")
     BOLETO,
     @SerializedName("card")

--- a/src/main/java/com/checkout/payments/request/source/apm/RequestBlikSource.java
+++ b/src/main/java/com/checkout/payments/request/source/apm/RequestBlikSource.java
@@ -1,0 +1,47 @@
+package com.checkout.payments.request.source.apm;
+
+import com.checkout.common.PaymentSourceType;
+import com.checkout.payments.request.source.AbstractRequestSource;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Blik source. Use this to process Blik payments in Poland.
+ * <p>
+ * When {@code source.type} is {@code blik}: {@code currency} must be {@code PLN}, {@code amount}
+ * must not exceed 5,000,000 (minor currency unit), and {@code reference} is limited to 35 characters.
+ * <p>
+ * For customer-initiated payments ({@code merchant_initiated: false}), provide the customer's
+ * 6-digit Blik code in {@code processing.partner_code}. For merchant-initiated recurring payments
+ * ({@code merchant_initiated: true}), use either {@code source.type: id} with a previous
+ * {@code source.id}, or {@code source.type: blik} with {@code partnerAgreementId}.
+ */
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class RequestBlikSource extends AbstractRequestSource {
+
+    /**
+     * The Blik PAYID identifying an external partner agreement created with another PSP.
+     * Only used when processing merchant-initiated recurring payments
+     * ({@code merchant_initiated: true}) without a stored Checkout.com source.
+     * [Optional]
+     * max 64 characters
+     */
+    private String partnerAgreementId;
+
+    @Builder
+    private RequestBlikSource(final String partnerAgreementId) {
+        super(PaymentSourceType.BLIK);
+        this.partnerAgreementId = partnerAgreementId;
+    }
+
+    public RequestBlikSource() {
+        super(PaymentSourceType.BLIK);
+    }
+
+}

--- a/src/test/java/com/checkout/payments/AbstractPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/AbstractPaymentsTestIT.java
@@ -33,7 +33,9 @@ public abstract class AbstractPaymentsTestIT extends SandboxTestFixture {
     public static final String APM_SERVICE_UNAVAILABLE = "apm_service_unavailable";
     public static final String PAYMENT_METHOD_NOT_SUPPORTED = "payment_method_not_supported";
     public static final String APM_CURRENCY_NOT_SUPPORTED = "currency_not_supported";
-
+    public static final String MERCHANT_CATEGORY_CODE_REQUIRED = "merchant_category_code_required";
+    public static final String MERCHANT_DATA_DELEGATED_AUTHENTICATION_FAILED = "merchant_data_delegated_authentication_failed";
+    
     public AbstractPaymentsTestIT() {
         super(PlatformType.DEFAULT);
         this.paymentsClient = checkoutApi.paymentsClient();

--- a/src/test/java/com/checkout/payments/RequestApmPaymentsIT.java
+++ b/src/test/java/com/checkout/payments/RequestApmPaymentsIT.java
@@ -44,6 +44,7 @@ import com.checkout.payments.request.source.apm.RequestAlmaSource;
 import com.checkout.payments.request.source.apm.RequestBancontactSource;
 import com.checkout.payments.request.source.apm.RequestBenefitSource;
 import com.checkout.payments.request.source.apm.RequestBizumSource;
+import com.checkout.payments.request.source.apm.RequestBlikSource;
 import com.checkout.payments.request.source.apm.RequestCvConnectSource;
 import com.checkout.payments.request.source.apm.RequestEpsSource;
 import com.checkout.payments.request.source.apm.RequestFawrySource;
@@ -199,6 +200,12 @@ class RequestApmPaymentsIT extends AbstractPaymentsTestIT {
     }
 
     @Test
+    void shouldMakeBlikPayment() throws ExecutionException, InterruptedException {
+        final PaymentRequest paymentRequest = createBlikPaymentRequest();
+        checkErrorItem(() -> paymentsClient.requestPayment(paymentRequest), MERCHANT_CATEGORY_CODE_REQUIRED);
+    }
+
+    @Test
     void shouldMakeMultiBancoPayment() throws ExecutionException, InterruptedException {
         final PaymentRequest paymentRequest = createMultiBancoPaymentRequest();
         checkErrorItem(() -> paymentsClient.requestPayment(paymentRequest), PAYEE_NOT_ONBOARDED);
@@ -215,7 +222,7 @@ class RequestApmPaymentsIT extends AbstractPaymentsTestIT {
     @Test
     void shouldMakeStcPayPayment() throws ExecutionException, InterruptedException {
         final PaymentRequest paymentRequest = createStcPayPaymentRequest();
-        checkErrorItem(() -> paymentsClient.requestPayment(paymentRequest), "merchant_data_delegated_authentication_failed");
+        checkErrorItem(() -> paymentsClient.requestPayment(paymentRequest), MERCHANT_DATA_DELEGATED_AUTHENTICATION_FAILED);
     }
 
     @Test
@@ -426,7 +433,7 @@ class RequestApmPaymentsIT extends AbstractPaymentsTestIT {
     @Test
     void shouldMakeStcPayPaymentSync() {
         final PaymentRequest paymentRequest = createStcPayPaymentRequest();
-        checkErrorItemSync(() -> paymentsClient.requestPaymentSync(paymentRequest), "merchant_data_delegated_authentication_failed");
+        checkErrorItemSync(() -> paymentsClient.requestPaymentSync(paymentRequest), MERCHANT_DATA_DELEGATED_AUTHENTICATION_FAILED);
     }
 
     @Test
@@ -556,6 +563,14 @@ class RequestApmPaymentsIT extends AbstractPaymentsTestIT {
         return createBasePaymentRequest(createBancontactSource(), Currency.EUR, 100L).build();
     }
 
+    private PaymentRequest createBlikPaymentRequest() {
+        // Blik limits reference to 35 characters; a dashed UUID is 36, so strip the dashes to get 32.
+        return createBasePaymentRequest(new RequestBlikSource(), Currency.PLN, 100L)
+                .reference(UUID.randomUUID().toString().replace("-", ""))
+                .processing(ProcessingSettings.builder().partnerCode("123456").build())
+                .build();
+    }
+
     private PaymentRequest createMultiBancoPaymentRequest() {
         return createBasePaymentRequest(createMultiBancoSource(), Currency.EUR, 10L).build();
     }
@@ -637,7 +652,7 @@ class RequestApmPaymentsIT extends AbstractPaymentsTestIT {
                 .currency(Currency.SAR)
                 .amount(10000L)
                 .capture(true)
-                .successUrl("https://testing.checkout.com/sucess")
+                .successUrl("https://testing.checkout.com/success")
                 .failureUrl("https://testing.checkout.com/failure")
                 .reference("ORD-5023-4E89")
                 .processing(ProcessingSettings.builder().taxAmount(500L).shippingAmount(1000L).build())
@@ -653,7 +668,7 @@ class RequestApmPaymentsIT extends AbstractPaymentsTestIT {
                 .currency(currency)
                 .amount(amount)
                 .capture(true)
-                .successUrl("https://testing.checkout.com/sucess")
+                .successUrl("https://testing.checkout.com/success")
                 .failureUrl("https://testing.checkout.com/failure");
     }
 

--- a/src/test/java/com/checkout/payments/RequestPaymentsTestIT.java
+++ b/src/test/java/com/checkout/payments/RequestPaymentsTestIT.java
@@ -382,7 +382,7 @@ class RequestPaymentsTestIT extends AbstractPaymentsTestIT {
                 .currency(Currency.GBP)
                 .amount(10L)
                 .capture(true)
-                .successUrl("https://testing.checkout.com/sucess")
+                .successUrl("https://testing.checkout.com/success")
                 .failureUrl("https://testing.checkout.com/failure")
                 .build();
     }

--- a/src/test/java/com/checkout/payments/request/source/apm/RequestBlikSourceSerializationTest.java
+++ b/src/test/java/com/checkout/payments/request/source/apm/RequestBlikSourceSerializationTest.java
@@ -1,0 +1,79 @@
+package com.checkout.payments.request.source.apm;
+
+import com.checkout.GsonSerializer;
+import com.checkout.common.PaymentSourceType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RequestBlikSourceSerializationTest {
+
+    private final GsonSerializer serializer = new GsonSerializer();
+
+    @Test
+    void shouldSerializeWithRequiredFieldsOnly() {
+        final RequestBlikSource source = new RequestBlikSource();
+
+        final String json = serializer.toJson(source);
+
+        assertTrue(json.contains("\"type\":\"blik\""),
+                "type should serialize as 'blik'. Got: " + json);
+        assertEquals(PaymentSourceType.BLIK, source.getType());
+    }
+
+    @Test
+    void shouldSerializePartnerAgreementId() {
+        final RequestBlikSource source = RequestBlikSource.builder()
+                .partnerAgreementId("blik_payid_123456789")
+                .build();
+
+        final String json = serializer.toJson(source);
+
+        assertTrue(json.contains("\"partner_agreement_id\":\"blik_payid_123456789\""),
+                "partner_agreement_id should serialize in snake_case. Got: " + json);
+        assertDoesNotThrow(() -> serializer.toJson(source));
+    }
+
+    @Test
+    void shouldRoundTripSerialize() {
+        final RequestBlikSource original = RequestBlikSource.builder()
+                .partnerAgreementId("blik_payid_123456789")
+                .build();
+
+        final String json = serializer.toJson(original);
+        final RequestBlikSource deserialized = serializer.fromJson(json, RequestBlikSource.class);
+
+        assertNotNull(deserialized);
+        assertEquals(PaymentSourceType.BLIK, deserialized.getType());
+        assertEquals("blik_payid_123456789", deserialized.getPartnerAgreementId());
+    }
+
+    @Test
+    void shouldDeserializeSwaggerExample() {
+        final String swaggerJson = "{"
+                + "\"type\":\"blik\","
+                + "\"partner_agreement_id\":\"blik_payid_123456789\""
+                + "}";
+
+        final RequestBlikSource source = serializer.fromJson(swaggerJson, RequestBlikSource.class);
+
+        assertNotNull(source);
+        assertEquals(PaymentSourceType.BLIK, source.getType());
+        assertEquals("blik_payid_123456789", source.getPartnerAgreementId());
+    }
+
+    @Test
+    void shouldDeserializeCustomerInitiatedSource() {
+        final String swaggerJson = "{\"type\":\"blik\"}";
+
+        final RequestBlikSource source = serializer.fromJson(swaggerJson, RequestBlikSource.class);
+
+        assertNotNull(source);
+        assertEquals(PaymentSourceType.BLIK, source.getType());
+        assertNull(source.getPartnerAgreementId());
+    }
+}


### PR DESCRIPTION
This pull request adds support for Blik as a payment source, allowing the processing of Blik payments. It introduces a new class to represent Blik payment sources, updates the payment source type enumeration, and adds comprehensive tests to ensure correct serialization and deserialization of Blik payment data.

**Blik payment source support:**

* Added the `RequestBlikSource` class to represent Blik payment sources, including handling for the optional `partnerAgreementId` field used in merchant-initiated recurring payments.
* Updated the `PaymentSourceType` enum to include a new `BLIK` value, mapped to the serialized name `"blik"`.

**Testing and validation:**

* Introduced `RequestBlikSourceSerializationTest` to verify serialization and deserialization of the new Blik source, including coverage for required fields, optional fields, and round-trip conversion.