### PR TITLE
feat(identities): add Address Document Verification (Adv) endpoints

### DIFF
--- a/src/main/java/com/checkout/CheckoutApi.java
+++ b/src/main/java/com/checkout/CheckoutApi.java
@@ -17,6 +17,7 @@ import com.checkout.identities.faceauthentications.FaceAuthenticationClient;
 import com.checkout.identities.applicants.ApplicantClient;
 import com.checkout.identities.identityverification.IdentityVerificationClient;
 import com.checkout.identities.iddocumentverification.IdDocumentVerificationClient;
+import com.checkout.identities.addressdocumentverification.AddressDocumentVerificationClient;
 import com.checkout.identities.amlscreening.AmlScreeningClient;
 import com.checkout.instruments.InstrumentsClient;
 import com.checkout.issuing.IssuingClient;
@@ -97,6 +98,8 @@ public interface CheckoutApi extends CheckoutApmApi {
     IdentityVerificationClient identityVerificationClient();
 
     IdDocumentVerificationClient idDocumentVerificationClient();
+
+    AddressDocumentVerificationClient addressDocumentVerificationClient();
 
     AmlScreeningClient amlScreeningClient();
 

--- a/src/main/java/com/checkout/CheckoutApiImpl.java
+++ b/src/main/java/com/checkout/CheckoutApiImpl.java
@@ -34,6 +34,8 @@ import com.checkout.identities.identityverification.IdentityVerificationClient;
 import com.checkout.identities.identityverification.IdentityVerificationClientImpl;
 import com.checkout.identities.iddocumentverification.IdDocumentVerificationClient;
 import com.checkout.identities.iddocumentverification.IdDocumentVerificationClientImpl;
+import com.checkout.identities.addressdocumentverification.AddressDocumentVerificationClient;
+import com.checkout.identities.addressdocumentverification.AddressDocumentVerificationClientImpl;
 import com.checkout.identities.amlscreening.AmlScreeningClient;
 import com.checkout.identities.amlscreening.AmlScreeningClientImpl;
 import com.checkout.instruments.InstrumentsClient;
@@ -105,6 +107,7 @@ public class CheckoutApiImpl extends AbstractCheckoutApmApi implements CheckoutA
     private final ApplicantClient applicantClient;
     private final IdentityVerificationClient identityVerificationClient;
     private final IdDocumentVerificationClient idDocumentVerificationClient;
+    private final AddressDocumentVerificationClient addressDocumentVerificationClient;
     private final AmlScreeningClient amlScreeningClient;
     private final NetworkTokensClient networkTokensClient;
     private final StandaloneAccountUpdaterClient standaloneAccountUpdaterClient;
@@ -146,6 +149,7 @@ public class CheckoutApiImpl extends AbstractCheckoutApmApi implements CheckoutA
         this.applicantClient = new ApplicantClientImpl(identityApiClient, configuration);
         this.identityVerificationClient = new IdentityVerificationClientImpl(identityApiClient, configuration);
         this.idDocumentVerificationClient = new IdDocumentVerificationClientImpl(identityApiClient, configuration);
+        this.addressDocumentVerificationClient = new AddressDocumentVerificationClientImpl(identityApiClient, configuration);
         this.amlScreeningClient = new AmlScreeningClientImpl(identityApiClient, configuration);
         this.networkTokensClient = new NetworkTokensClientImpl(this.apiClient, configuration);
         this.standaloneAccountUpdaterClient = new StandaloneAccountUpdaterClientImpl(this.apiClient, configuration);
@@ -276,6 +280,9 @@ public class CheckoutApiImpl extends AbstractCheckoutApmApi implements CheckoutA
 
     @Override
     public IdDocumentVerificationClient idDocumentVerificationClient() { return idDocumentVerificationClient; }
+
+    @Override
+    public AddressDocumentVerificationClient addressDocumentVerificationClient() { return addressDocumentVerificationClient; }
 
     @Override
     public AmlScreeningClient amlScreeningClient() { return amlScreeningClient; }

--- a/src/main/java/com/checkout/identities/addressdocumentverification/AddressDocumentVerificationClient.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/AddressDocumentVerificationClient.java
@@ -1,0 +1,134 @@
+package com.checkout.identities.addressdocumentverification;
+
+import com.checkout.identities.addressdocumentverification.requests.AddressDocumentVerificationAttemptRequest;
+import com.checkout.identities.addressdocumentverification.requests.AddressDocumentVerificationRequest;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationAttemptResponse;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationAttemptsResponse;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationReportResponse;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Client for address document verification operations
+ */
+public interface AddressDocumentVerificationClient {
+
+    /**
+     * Create an address document verification
+     *
+     * @param addressDocumentVerificationRequest the address document verification request
+     * @return a {@link CompletableFuture} containing the {@link AddressDocumentVerificationResponse}
+     */
+    CompletableFuture<AddressDocumentVerificationResponse> createAddressDocumentVerification(AddressDocumentVerificationRequest addressDocumentVerificationRequest);
+
+    /**
+     * Retrieve an address document verification
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @return a {@link CompletableFuture} containing the {@link AddressDocumentVerificationResponse}
+     */
+    CompletableFuture<AddressDocumentVerificationResponse> getAddressDocumentVerification(String addressDocumentVerificationId);
+
+    /**
+     * Anonymize an address document verification
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @return a {@link CompletableFuture} containing the {@link AddressDocumentVerificationResponse}
+     */
+    CompletableFuture<AddressDocumentVerificationResponse> anonymizeAddressDocumentVerification(String addressDocumentVerificationId);
+
+    /**
+     * Create an address document verification attempt
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @param addressDocumentVerificationAttemptRequest the attempt request
+     * @return a {@link CompletableFuture} containing the {@link AddressDocumentVerificationAttemptResponse}
+     */
+    CompletableFuture<AddressDocumentVerificationAttemptResponse> createAddressDocumentVerificationAttempt(String addressDocumentVerificationId, AddressDocumentVerificationAttemptRequest addressDocumentVerificationAttemptRequest);
+
+    /**
+     * Retrieve all address document verification attempts
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @return a {@link CompletableFuture} containing the {@link AddressDocumentVerificationAttemptsResponse}
+     */
+    CompletableFuture<AddressDocumentVerificationAttemptsResponse> getAddressDocumentVerificationAttempts(String addressDocumentVerificationId);
+
+    /**
+     * Retrieve a specific address document verification attempt
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @param attemptId the attempt ID
+     * @return a {@link CompletableFuture} containing the {@link AddressDocumentVerificationAttemptResponse}
+     */
+    CompletableFuture<AddressDocumentVerificationAttemptResponse> getAddressDocumentVerificationAttempt(String addressDocumentVerificationId, String attemptId);
+
+    /**
+     * Generate and download a PDF report
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @return a {@link CompletableFuture} containing the {@link AddressDocumentVerificationReportResponse}
+     */
+    CompletableFuture<AddressDocumentVerificationReportResponse> getAddressDocumentVerificationReport(String addressDocumentVerificationId);
+
+    // Synchronous methods
+
+    /**
+     * Create an address document verification
+     *
+     * @param addressDocumentVerificationRequest the address document verification request
+     * @return the {@link AddressDocumentVerificationResponse}
+     */
+    AddressDocumentVerificationResponse createAddressDocumentVerificationSync(AddressDocumentVerificationRequest addressDocumentVerificationRequest);
+
+    /**
+     * Retrieve an address document verification
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @return the {@link AddressDocumentVerificationResponse}
+     */
+    AddressDocumentVerificationResponse getAddressDocumentVerificationSync(String addressDocumentVerificationId);
+
+    /**
+     * Anonymize an address document verification
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @return the {@link AddressDocumentVerificationResponse}
+     */
+    AddressDocumentVerificationResponse anonymizeAddressDocumentVerificationSync(String addressDocumentVerificationId);
+
+    /**
+     * Create an address document verification attempt
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @param addressDocumentVerificationAttemptRequest the attempt request
+     * @return the {@link AddressDocumentVerificationAttemptResponse}
+     */
+    AddressDocumentVerificationAttemptResponse createAddressDocumentVerificationAttemptSync(String addressDocumentVerificationId, AddressDocumentVerificationAttemptRequest addressDocumentVerificationAttemptRequest);
+
+    /**
+     * Retrieve all address document verification attempts
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @return the {@link AddressDocumentVerificationAttemptsResponse}
+     */
+    AddressDocumentVerificationAttemptsResponse getAddressDocumentVerificationAttemptsSync(String addressDocumentVerificationId);
+
+    /**
+     * Retrieve a specific address document verification attempt
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @param attemptId the attempt ID
+     * @return the {@link AddressDocumentVerificationAttemptResponse}
+     */
+    AddressDocumentVerificationAttemptResponse getAddressDocumentVerificationAttemptSync(String addressDocumentVerificationId, String attemptId);
+
+    /**
+     * Generate and download a PDF report
+     *
+     * @param addressDocumentVerificationId the address document verification ID
+     * @return the {@link AddressDocumentVerificationReportResponse}
+     */
+    AddressDocumentVerificationReportResponse getAddressDocumentVerificationReportSync(String addressDocumentVerificationId);
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/AddressDocumentVerificationClientImpl.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/AddressDocumentVerificationClientImpl.java
@@ -1,0 +1,147 @@
+package com.checkout.identities.addressdocumentverification;
+
+import com.checkout.AbstractClient;
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SdkAuthorizationType;
+import com.checkout.identities.addressdocumentverification.requests.AddressDocumentVerificationAttemptRequest;
+import com.checkout.identities.addressdocumentverification.requests.AddressDocumentVerificationRequest;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationAttemptResponse;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationAttemptsResponse;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationReportResponse;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.checkout.common.CheckoutUtils.validateParams;
+
+/**
+ * Implementation of the Address Document Verification client.
+ */
+public class AddressDocumentVerificationClientImpl extends AbstractClient implements AddressDocumentVerificationClient {
+
+    private static final String ADDRESS_DOCUMENT_VERIFICATIONS_PATH = "address-document-verifications";
+    private static final String ANONYMIZE_PATH = "anonymize";
+    private static final String ATTEMPTS_PATH = "attempts";
+    private static final String PDF_REPORT_PATH = "pdf-report";
+
+    public AddressDocumentVerificationClientImpl(final ApiClient apiClient, final CheckoutConfiguration configuration) {
+        super(apiClient, configuration, SdkAuthorizationType.SECRET_KEY_OR_OAUTH);
+    }
+
+    @Override
+    public CompletableFuture<AddressDocumentVerificationResponse> createAddressDocumentVerification(
+            final AddressDocumentVerificationRequest addressDocumentVerificationRequest) {
+        validateParams("addressDocumentVerificationRequest", addressDocumentVerificationRequest);
+        return apiClient.postAsync(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, sdkAuthorization(),
+                AddressDocumentVerificationResponse.class, addressDocumentVerificationRequest, null);
+    }
+
+    @Override
+    public CompletableFuture<AddressDocumentVerificationResponse> getAddressDocumentVerification(
+            final String addressDocumentVerificationId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+        return apiClient.getAsync(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId),
+                sdkAuthorization(), AddressDocumentVerificationResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<AddressDocumentVerificationResponse> anonymizeAddressDocumentVerification(
+            final String addressDocumentVerificationId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+        return apiClient.postAsync(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, ANONYMIZE_PATH),
+                sdkAuthorization(), AddressDocumentVerificationResponse.class, null, null);
+    }
+
+    @Override
+    public CompletableFuture<AddressDocumentVerificationAttemptResponse> createAddressDocumentVerificationAttempt(
+            final String addressDocumentVerificationId,
+            final AddressDocumentVerificationAttemptRequest addressDocumentVerificationAttemptRequest) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId,
+                "addressDocumentVerificationAttemptRequest", addressDocumentVerificationAttemptRequest);
+        return apiClient.postAsync(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, ATTEMPTS_PATH),
+                sdkAuthorization(), AddressDocumentVerificationAttemptResponse.class, addressDocumentVerificationAttemptRequest,
+                null);
+    }
+
+    @Override
+    public CompletableFuture<AddressDocumentVerificationAttemptsResponse> getAddressDocumentVerificationAttempts(
+            final String addressDocumentVerificationId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+        return apiClient.getAsync(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, ATTEMPTS_PATH),
+                sdkAuthorization(), AddressDocumentVerificationAttemptsResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<AddressDocumentVerificationAttemptResponse> getAddressDocumentVerificationAttempt(
+            final String addressDocumentVerificationId, final String attemptId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId, "attemptId", attemptId);
+        return apiClient.getAsync(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, ATTEMPTS_PATH, attemptId),
+                sdkAuthorization(), AddressDocumentVerificationAttemptResponse.class);
+    }
+
+    @Override
+    public CompletableFuture<AddressDocumentVerificationReportResponse> getAddressDocumentVerificationReport(
+            final String addressDocumentVerificationId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+        return apiClient.getAsync(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, PDF_REPORT_PATH),
+                sdkAuthorization(), AddressDocumentVerificationReportResponse.class);
+    }
+
+    // Synchronous methods
+
+    @Override
+    public AddressDocumentVerificationResponse createAddressDocumentVerificationSync(
+            final AddressDocumentVerificationRequest addressDocumentVerificationRequest) {
+        validateParams("addressDocumentVerificationRequest", addressDocumentVerificationRequest);
+        return apiClient.post(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, sdkAuthorization(),
+                AddressDocumentVerificationResponse.class, addressDocumentVerificationRequest, null);
+    }
+
+    @Override
+    public AddressDocumentVerificationResponse getAddressDocumentVerificationSync(final String addressDocumentVerificationId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+        return apiClient.get(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId),
+                sdkAuthorization(), AddressDocumentVerificationResponse.class);
+    }
+
+    @Override
+    public AddressDocumentVerificationResponse anonymizeAddressDocumentVerificationSync(final String addressDocumentVerificationId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+        return apiClient.post(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, ANONYMIZE_PATH),
+                sdkAuthorization(), AddressDocumentVerificationResponse.class, null, null);
+    }
+
+    @Override
+    public AddressDocumentVerificationAttemptResponse createAddressDocumentVerificationAttemptSync(
+            final String addressDocumentVerificationId,
+            final AddressDocumentVerificationAttemptRequest addressDocumentVerificationAttemptRequest) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId,
+                "addressDocumentVerificationAttemptRequest", addressDocumentVerificationAttemptRequest);
+        return apiClient.post(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, ATTEMPTS_PATH),
+                sdkAuthorization(), AddressDocumentVerificationAttemptResponse.class, addressDocumentVerificationAttemptRequest,
+                null);
+    }
+
+    @Override
+    public AddressDocumentVerificationAttemptsResponse getAddressDocumentVerificationAttemptsSync(final String addressDocumentVerificationId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+        return apiClient.get(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, ATTEMPTS_PATH),
+                sdkAuthorization(), AddressDocumentVerificationAttemptsResponse.class);
+    }
+
+    @Override
+    public AddressDocumentVerificationAttemptResponse getAddressDocumentVerificationAttemptSync(
+            final String addressDocumentVerificationId, final String attemptId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId, "attemptId", attemptId);
+        return apiClient.get(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, ATTEMPTS_PATH, attemptId),
+                sdkAuthorization(), AddressDocumentVerificationAttemptResponse.class);
+    }
+
+    @Override
+    public AddressDocumentVerificationReportResponse getAddressDocumentVerificationReportSync(final String addressDocumentVerificationId) {
+        validateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+        return apiClient.get(buildPath(ADDRESS_DOCUMENT_VERIFICATIONS_PATH, addressDocumentVerificationId, PDF_REPORT_PATH),
+                sdkAuthorization(), AddressDocumentVerificationReportResponse.class);
+    }
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/requests/AddressDocumentVerificationAttemptRequest.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/requests/AddressDocumentVerificationAttemptRequest.java
@@ -1,0 +1,23 @@
+package com.checkout.identities.addressdocumentverification.requests;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Address document verification attempt request
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public final class AddressDocumentVerificationAttemptRequest {
+
+    /**
+     * The address document image to upload.
+     * [Required]
+     * Format: binary
+     */
+    private String document;
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/requests/AddressDocumentVerificationRequest.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/requests/AddressDocumentVerificationRequest.java
@@ -1,0 +1,37 @@
+package com.checkout.identities.addressdocumentverification.requests;
+
+import com.checkout.identities.entities.DeclaredData;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Address document verification request
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public final class AddressDocumentVerificationRequest {
+
+    /**
+     * The applicant's unique identifier.
+     * [Required]
+     * Pattern: ^aplt_\w+$
+     */
+    private String applicantId;
+
+    /**
+     * Your configuration ID.
+     * [Required]
+     * Pattern: ^usj_[a-z2-7]{26}$
+     */
+    private String userJourneyId;
+
+    /**
+     * The personal details provided by the applicant.
+     * [Optional]
+     */
+    private DeclaredData declaredData;
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/responses/Address.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/responses/Address.java
@@ -1,0 +1,46 @@
+package com.checkout.identities.addressdocumentverification.responses;
+
+import lombok.Data;
+
+/**
+ * The address extracted from the document.
+ */
+@Data
+public final class Address {
+
+    /**
+     * The first line of the address.
+     * max 250 characters
+     */
+    private String addressLine1;
+
+    /**
+     * The second line of the address.
+     * max 250 characters
+     */
+    private String addressLine2;
+
+    /**
+     * The city or town.
+     * max 50 characters
+     */
+    private String city;
+
+    /**
+     * The state, county, or province.
+     * max 50 characters
+     */
+    private String state;
+
+    /**
+     * The postal or ZIP code.
+     * max 50 characters
+     */
+    private String zip;
+
+    /**
+     * The two-letter ISO country code of the address.
+     * max 2 characters
+     */
+    private String country;
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentResult.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentResult.java
@@ -1,0 +1,38 @@
+package com.checkout.identities.addressdocumentverification.responses;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * The result of the address document check.
+ */
+@Data
+public final class AddressDocumentResult {
+
+    /**
+     * The type of address document submitted.
+     */
+    private String documentType;
+
+    /**
+     * The issuer of the address document.
+     */
+    private String issuer;
+
+    /**
+     * The full names of the people named on the document.
+     */
+    private List<String> fullNames;
+
+    /**
+     * The date the document was issued.
+     * Format: date (yyyy-MM-dd)
+     */
+    private String issueDate;
+
+    /**
+     * The address extracted from the document.
+     */
+    private Address address;
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationAttemptResponse.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationAttemptResponse.java
@@ -1,0 +1,14 @@
+package com.checkout.identities.addressdocumentverification.responses;
+
+import com.checkout.identities.entities.BaseIdentityResponseStatus;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Response for address document verification attempt operations
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public final class AddressDocumentVerificationAttemptResponse extends BaseIdentityResponseStatus<AddressDocumentVerificationAttemptStatus> {
+    // id, created_on, modified_on, status and response_codes are inherited
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationAttemptStatus.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationAttemptStatus.java
@@ -1,0 +1,45 @@
+package com.checkout.identities.addressdocumentverification.responses;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Enumeration of address document verification attempt statuses
+ */
+public enum AddressDocumentVerificationAttemptStatus {
+
+    /**
+     * Checks in progress
+     */
+    @SerializedName("checks_in_progress")
+    CHECKS_IN_PROGRESS,
+
+    /**
+     * Checks inconclusive
+     */
+    @SerializedName("checks_inconclusive")
+    CHECKS_INCONCLUSIVE,
+
+    /**
+     * Attempt completed
+     */
+    @SerializedName("completed")
+    COMPLETED,
+
+    /**
+     * Quality checks aborted
+     */
+    @SerializedName("quality_checks_aborted")
+    QUALITY_CHECKS_ABORTED,
+
+    /**
+     * Quality checks in progress
+     */
+    @SerializedName("quality_checks_in_progress")
+    QUALITY_CHECKS_IN_PROGRESS,
+
+    /**
+     * Attempt terminated
+     */
+    @SerializedName("terminated")
+    TERMINATED
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationAttemptsResponse.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationAttemptsResponse.java
@@ -1,0 +1,23 @@
+package com.checkout.identities.addressdocumentverification.responses;
+
+import com.checkout.common.Resource;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+/**
+ * Response for address document verification attempts listing operations
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public final class AddressDocumentVerificationAttemptsResponse extends Resource {
+
+    private Integer totalCount;
+
+    private Integer skip;
+
+    private Integer limit;
+
+    private List<AddressDocumentVerificationAttemptResponse> data;
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationReportResponse.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationReportResponse.java
@@ -1,0 +1,15 @@
+package com.checkout.identities.addressdocumentverification.responses;
+
+import com.checkout.common.Resource;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Response for address document verification report operations
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public final class AddressDocumentVerificationReportResponse extends Resource {
+
+    private String signedUrl;
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationResponse.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationResponse.java
@@ -1,0 +1,22 @@
+package com.checkout.identities.addressdocumentverification.responses;
+
+import com.checkout.identities.entities.BaseIdentityResponseStatus;
+import com.checkout.identities.entities.DeclaredData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Response for address document verification operations
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public final class AddressDocumentVerificationResponse extends BaseIdentityResponseStatus<AddressDocumentVerificationStatus> {
+
+    private String userJourneyId;
+
+    private String applicantId;
+
+    private DeclaredData declaredData;
+
+    private AddressDocumentResult addressDocument;
+}

--- a/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationStatus.java
+++ b/src/main/java/com/checkout/identities/addressdocumentverification/responses/AddressDocumentVerificationStatus.java
@@ -1,0 +1,51 @@
+package com.checkout.identities.addressdocumentverification.responses;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Enumeration of address document verification statuses
+ */
+public enum AddressDocumentVerificationStatus {
+
+    /**
+     * Address document verification created
+     */
+    @SerializedName("created")
+    CREATED,
+
+    /**
+     * Quality checks in progress
+     */
+    @SerializedName("quality_checks_in_progress")
+    QUALITY_CHECKS_IN_PROGRESS,
+
+    /**
+     * Checks in progress
+     */
+    @SerializedName("checks_in_progress")
+    CHECKS_IN_PROGRESS,
+
+    /**
+     * Address document verification approved
+     */
+    @SerializedName("approved")
+    APPROVED,
+
+    /**
+     * Address document verification declined
+     */
+    @SerializedName("declined")
+    DECLINED,
+
+    /**
+     * Retry required
+     */
+    @SerializedName("retry_required")
+    RETRY_REQUIRED,
+
+    /**
+     * Address document verification inconclusive
+     */
+    @SerializedName("inconclusive")
+    INCONCLUSIVE
+}

--- a/src/test/java/com/checkout/identities/addressdocumentverification/AddressDocumentVerificationClientImplTest.java
+++ b/src/test/java/com/checkout/identities/addressdocumentverification/AddressDocumentVerificationClientImplTest.java
@@ -1,0 +1,146 @@
+package com.checkout.identities.addressdocumentverification;
+
+import com.checkout.ApiClient;
+import com.checkout.CheckoutConfiguration;
+import com.checkout.SdkAuthorization;
+import com.checkout.SdkAuthorizationType;
+import com.checkout.SdkCredentials;
+import com.checkout.identities.addressdocumentverification.requests.AddressDocumentVerificationAttemptRequest;
+import com.checkout.identities.addressdocumentverification.requests.AddressDocumentVerificationRequest;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationAttemptResponse;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationAttemptsResponse;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationReportResponse;
+import com.checkout.identities.addressdocumentverification.responses.AddressDocumentVerificationResponse;
+import com.checkout.identities.entities.DeclaredData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddressDocumentVerificationClientImplTest {
+
+    private static final String ADV_ID = "adv_tkoi5db4hryu5cei5vwoabr7we";
+    private static final String ATTEMPT_ID = "adva_tkoi5db4hryu5cei5vwoabr7we";
+
+    private AddressDocumentVerificationClient client;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private CheckoutConfiguration configuration;
+
+    @Mock
+    private SdkCredentials sdkCredentials;
+
+    @Mock
+    private SdkAuthorization authorization;
+
+    @BeforeEach
+    void setUp() {
+        when(sdkCredentials.getAuthorization(SdkAuthorizationType.SECRET_KEY_OR_OAUTH)).thenReturn(authorization);
+        when(configuration.getSdkCredentials()).thenReturn(sdkCredentials);
+        client = new AddressDocumentVerificationClientImpl(apiClient, configuration);
+    }
+
+    @Test
+    void shouldCreateAddressDocumentVerification() throws ExecutionException, InterruptedException {
+        final AddressDocumentVerificationRequest request = createRequest();
+        final AddressDocumentVerificationResponse response = new AddressDocumentVerificationResponse();
+
+        when(apiClient.postAsync("address-document-verifications", authorization,
+                AddressDocumentVerificationResponse.class, request, null))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        final CompletableFuture<AddressDocumentVerificationResponse> future =
+                client.createAddressDocumentVerification(request);
+
+        assertNotNull(future.get());
+        assertEquals(response, future.get());
+    }
+
+    @Test
+    void shouldGetAddressDocumentVerification() throws ExecutionException, InterruptedException {
+        final AddressDocumentVerificationResponse response = new AddressDocumentVerificationResponse();
+
+        when(apiClient.getAsync("address-document-verifications/" + ADV_ID, authorization,
+                AddressDocumentVerificationResponse.class))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        assertEquals(response, client.getAddressDocumentVerification(ADV_ID).get());
+    }
+
+    @Test
+    void shouldAnonymizeAddressDocumentVerification() throws ExecutionException, InterruptedException {
+        final AddressDocumentVerificationResponse response = new AddressDocumentVerificationResponse();
+
+        when(apiClient.postAsync("address-document-verifications/" + ADV_ID + "/anonymize", authorization,
+                AddressDocumentVerificationResponse.class, null, null))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        assertEquals(response, client.anonymizeAddressDocumentVerification(ADV_ID).get());
+    }
+
+    @Test
+    void shouldCreateAttempt() throws ExecutionException, InterruptedException {
+        final AddressDocumentVerificationAttemptRequest request =
+                AddressDocumentVerificationAttemptRequest.builder().document("base64-data").build();
+        final AddressDocumentVerificationAttemptResponse response = new AddressDocumentVerificationAttemptResponse();
+
+        when(apiClient.postAsync("address-document-verifications/" + ADV_ID + "/attempts", authorization,
+                AddressDocumentVerificationAttemptResponse.class, request, null))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        assertEquals(response, client.createAddressDocumentVerificationAttempt(ADV_ID, request).get());
+    }
+
+    @Test
+    void shouldGetAttempts() throws ExecutionException, InterruptedException {
+        final AddressDocumentVerificationAttemptsResponse response = new AddressDocumentVerificationAttemptsResponse();
+
+        when(apiClient.getAsync("address-document-verifications/" + ADV_ID + "/attempts", authorization,
+                AddressDocumentVerificationAttemptsResponse.class))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        assertEquals(response, client.getAddressDocumentVerificationAttempts(ADV_ID).get());
+    }
+
+    @Test
+    void shouldGetAttempt() throws ExecutionException, InterruptedException {
+        final AddressDocumentVerificationAttemptResponse response = new AddressDocumentVerificationAttemptResponse();
+
+        when(apiClient.getAsync("address-document-verifications/" + ADV_ID + "/attempts/" + ATTEMPT_ID, authorization,
+                AddressDocumentVerificationAttemptResponse.class))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        assertEquals(response, client.getAddressDocumentVerificationAttempt(ADV_ID, ATTEMPT_ID).get());
+    }
+
+    @Test
+    void shouldGetReport() throws ExecutionException, InterruptedException {
+        final AddressDocumentVerificationReportResponse response = new AddressDocumentVerificationReportResponse();
+
+        when(apiClient.getAsync("address-document-verifications/" + ADV_ID + "/pdf-report", authorization,
+                AddressDocumentVerificationReportResponse.class))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        assertEquals(response, client.getAddressDocumentVerificationReport(ADV_ID).get());
+    }
+
+    private AddressDocumentVerificationRequest createRequest() {
+        return AddressDocumentVerificationRequest.builder()
+                .applicantId("aplt_tkoi5db4hryu5cei5vwoabr7we")
+                .userJourneyId("usj_tkoi5db4hryu5cei5vwoabr7we")
+                .declaredData(DeclaredData.builder().name("Hannah Bret").build())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the new **Address Document Verification (Adv)** API family introduced in the Checkout.com swagger on 2026-07-16 (INT-1665). This mirrors the existing ID Document Verification client and reuses the `identity-verification` OAuth scope (no new scope).

## Changes

New `AddressDocumentVerification` client exposing the 7 endpoints, plus request/response models and status enums, wired into the SDK entry point next to `IdDocumentVerification`:

- `POST /address-document-verifications` — create
- `GET  /address-document-verifications/{id}` — retrieve
- `POST /address-document-verifications/{id}/anonymize` — anonymize
- `POST /address-document-verifications/{id}/attempts` — create attempt
- `GET  /address-document-verifications/{id}/attempts` — list attempts
- `GET  /address-document-verifications/{id}/attempts/{attemptId}` — get attempt
- `GET  /address-document-verifications/{id}/pdf-report` — PDF report

Request model: `applicant_id`, `user_journey_id`, `declared_data`. Attempt request: `document`. Responses cover `AdvVerificationStatuses` / `AdvAttemptStates`, `response_codes`, `_links` and the extracted `address_document` result.

## API Reference

Swagger schemas: `AdvAddressDocumentVerification*`, `AdvAttempt*`, `AdvAddress`, `AdvAddressDocumentResult`, `AdvVerificationStatuses`, `AdvAttemptStates`.

## Tests

Unit tests covering all 7 endpoints; integration tests scaffolded (skipped, require sandbox entitlement). Build + tests green locally.
