### PR TITLE
feature/INT-1670 - CardType and CardCategory enum fixes

### DIFF
--- a/src/main/java/com/checkout/common/CardCategory.java
+++ b/src/main/java/com/checkout/common/CardCategory.java
@@ -4,15 +4,11 @@ import com.google.gson.annotations.SerializedName;
 
 public enum CardCategory {
 
-    @SerializedName(value = "All", alternate = {"ALL", "all"})
-    ALL,
     @SerializedName(value = "Commercial", alternate = {"COMMERCIAL", "commercial"})
     COMMERCIAL,
     @SerializedName(value = "Consumer", alternate = {"CONSUMER", "consumer"})
     CONSUMER,
-    @SerializedName(value = "NotSet", alternate = {"NOTSET", "NOT_SET", "Not_Set", "notset", "not_set"})
-    NOT_SET,
-    @SerializedName(value = "Other", alternate = {"OTHER", "other"})
-    OTHER
+    @SerializedName(value = "Unknown", alternate = {"UNKNOWN", "unknown"})
+    UNKNOWN
 
 }

--- a/src/main/java/com/checkout/common/CardType.java
+++ b/src/main/java/com/checkout/common/CardType.java
@@ -12,7 +12,14 @@ public enum CardType {
     PREPAID,
     @SerializedName(value = "Charge", alternate = {"CHARGE", "charge"})
     CHARGE,
-    @SerializedName(value = "Deferred Debit", alternate = {"DEFERRED DEBIT", "deferred_debit"})
+    @SerializedName(value = "Deferred Debit", alternate = {"DEFERRED DEBIT", "deferred debit"})
     DEFERRED_DEBIT,
+
+    // NetworkToken is returned only by the card metadata endpoint.
+    @SerializedName(value = "Network Token", alternate = {"NETWORK TOKEN", "network token"})
+    NETWORK_TOKEN,
+    // Unknown is returned only on card payout destinations.
+    @SerializedName(value = "Unknown", alternate = {"UNKNOWN", "unknown"})
+    UNKNOWN
 
 }

--- a/src/test/java/com/checkout/metadata/CardMetadataSerializationTest.java
+++ b/src/test/java/com/checkout/metadata/CardMetadataSerializationTest.java
@@ -24,6 +24,8 @@ import com.checkout.metadata.card.source.CardMetadataTokenSource;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -299,6 +301,72 @@ class CardMetadataSerializationTest {
         assertTrue(response.getLocalSchemes().contains(SchemeLocalType.SHAZAM));
         assertTrue(response.getLocalSchemes().contains(SchemeLocalType.PAYPAK));
         assertTrue(response.getLocalSchemes().contains(SchemeLocalType.MAESTRO));
+    }
+
+    @Test
+    void shouldDeserializeEveryCardTypeValue() {
+        final Map<String, CardType> expected = new LinkedHashMap<>();
+        // Spellings returned by the API on the current platform.
+        expected.put("CREDIT", CardType.CREDIT);
+        expected.put("DEBIT", CardType.DEBIT);
+        expected.put("PREPAID", CardType.PREPAID);
+        expected.put("CHARGE", CardType.CHARGE);
+        expected.put("DEFERRED DEBIT", CardType.DEFERRED_DEBIT);
+        expected.put("NETWORK TOKEN", CardType.NETWORK_TOKEN);
+        expected.put("UNKNOWN", CardType.UNKNOWN);
+        // Spellings returned by the API on the previous platform, plus the values Gson writes.
+        expected.put("Credit", CardType.CREDIT);
+        expected.put("Debit", CardType.DEBIT);
+        expected.put("Prepaid", CardType.PREPAID);
+        expected.put("Charge", CardType.CHARGE);
+        expected.put("Deferred Debit", CardType.DEFERRED_DEBIT);
+        expected.put("Network Token", CardType.NETWORK_TOKEN);
+        expected.put("Unknown", CardType.UNKNOWN);
+
+        for (final Map.Entry<String, CardType> entry : expected.entrySet()) {
+            final String json = "{\"bin\":\"45434720\",\"card_type\":\"" + entry.getKey() + "\"}";
+
+            final CardMetadataResponse response = serializer.fromJson(json, CardMetadataResponse.class);
+
+            assertNotNull(response);
+            assertEquals(entry.getValue(), response.getCardType(),
+                    "card_type '" + entry.getKey() + "' did not deserialize");
+        }
+    }
+
+    @Test
+    void shouldDeserializeEveryCardCategoryValue() {
+        final Map<String, CardCategory> expected = new LinkedHashMap<>();
+        // Spellings returned by the API on the current platform.
+        expected.put("CONSUMER", CardCategory.CONSUMER);
+        expected.put("COMMERCIAL", CardCategory.COMMERCIAL);
+        expected.put("UNKNOWN", CardCategory.UNKNOWN);
+        // Spellings returned by the API on the previous platform, plus the values Gson writes.
+        expected.put("Consumer", CardCategory.CONSUMER);
+        expected.put("Commercial", CardCategory.COMMERCIAL);
+        expected.put("Unknown", CardCategory.UNKNOWN);
+
+        for (final Map.Entry<String, CardCategory> entry : expected.entrySet()) {
+            final String json = "{\"bin\":\"45434720\",\"card_category\":\"" + entry.getKey() + "\"}";
+
+            final CardMetadataResponse response = serializer.fromJson(json, CardMetadataResponse.class);
+
+            assertNotNull(response);
+            assertEquals(entry.getValue(), response.getCardCategory(),
+                    "card_category '" + entry.getKey() + "' did not deserialize");
+        }
+    }
+
+    @Test
+    void shouldReturnNullForUnrecognizedCardTypeAndCardCategory() {
+        final String json = "{\"bin\":\"45434720\",\"card_type\":\"NOT_A_CARD_TYPE\","
+                + "\"card_category\":\"NOT_A_CARD_CATEGORY\"}";
+
+        final CardMetadataResponse response = serializer.fromJson(json, CardMetadataResponse.class);
+
+        assertNotNull(response);
+        assertNull(response.getCardType());
+        assertNull(response.getCardCategory());
     }
 
     @Test


### PR DESCRIPTION
This pull request updates the `CardCategory` and `CardType` enums to better align with API responses and adds comprehensive test coverage for deserialization of all supported and unknown values. The changes improve consistency, future-proof the code against new values, and ensure robust handling of unexpected input.

**Enum changes and alignment with API:**
- Updated `CardCategory` enum: Removed `ALL`, `NOT_SET`, and `OTHER` values, and replaced them with a single `UNKNOWN` value to match API responses. (`src/main/java/com/checkout/common/CardCategory.java`)
- Updated `CardType` enum: Added `NETWORK_TOKEN` and `UNKNOWN` values, and adjusted alternate spellings for `DEFERRED_DEBIT` to include a space instead of an underscore. (`src/main/java/com/checkout/common/CardType.java`)

**Test coverage improvements:**
- Added tests to ensure all supported `CardType` and `CardCategory` values (including alternate spellings and new values) are correctly deserialized from JSON. (`src/test/java/com/checkout/metadata/CardMetadataSerializationTest.java`)
- Added tests to verify that unrecognized `card_type` and `card_category` strings are deserialized as `null`, ensuring resilience to future API changes. (`src/test/java/com/checkout/metadata/CardMetadataSerializationTest.java`)

**Test infrastructure:**
- Added imports for `LinkedHashMap` and `Map` to support new test cases. (`src/test/java/com/checkout/metadata/CardMetadataSerializationTest.java`)