### PR TITLE
fix/SOC2-908 - Dependabot vulnerabilities fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,17 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily" 
+      interval: "daily"
+    groups:
+      test-deps:
+        patterns:
+          - "org.junit*"
+          - "org.mockito*"
+          - "org.apache.logging.log4j*"
+          - "org.hamcrest*"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'maven-publish'
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
     id 'io.freefair.lombok' version '8.14.4'
-    id "org.sonarqube" version "7.0.1.6134"
+    id "org.sonarqube" version "7.3.1.8318"
     id 'jacoco'
 }
 
@@ -42,9 +42,9 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest:3.0'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
-    testImplementation 'org.apache.logging.log4j:log4j-api:2.25.3'
-    testImplementation 'org.apache.logging.log4j:log4j-core:2.25.3'
-    testImplementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.25.3'
+    testImplementation 'org.apache.logging.log4j:log4j-api:2.25.5'
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.25.5'
+    testImplementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.25.5'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }
 


### PR DESCRIPTION
This pull request updates the sonarcube and log4j dependencies and modifies the `.github/dependabot.yml` configuration to improve dependency management by grouping related dependencies and adding support for GitHub Actions. The main changes are:

Dependency updates:
- sonarcube to 7.3.1.8318
- log4j to log4j:log4j-api:2.25.5, log4j-core:2.25.5, log4j-slf4j2-impl:2.25.5

Dependency grouping:

* Added a `test-deps` group to combine updates for testing-related dependencies (`org.junit*`, `org.mockito*`, `org.apache.logging.log4j*`, `org.hamcrest*`) into single pull requests, reducing noise and making test dependency updates easier to manage.

Dependabot configuration enhancements:

* Increased the `open-pull-requests-limit` to 10 for the main package ecosystem, allowing more concurrent dependency update PRs.
* Added a new configuration for the `github-actions` ecosystem with a weekly update schedule, enabling automated updates for GitHub Actions workflows.