### PR TITLE
feat(payments): add fallback_source_used to PaymentProcessing and complete ProcessingData JavaDoc

### DIFF
--- a/src/main/java/com/checkout/payments/PaymentProcessing.java
+++ b/src/main/java/com/checkout/payments/PaymentProcessing.java
@@ -142,6 +142,12 @@ public final class PaymentProcessing {
     private Long surchargeAmount;
 
     /**
+     * Indicates whether the {@code fallback_source} field was used for the payment.
+     * [Optional]
+     */
+    private Boolean fallbackSourceUsed;
+
+    /**
      * Indicates whether a Checkout.com Network Token was available for the payment.
      * [Optional]
      */

--- a/src/main/java/com/checkout/payments/response/ProcessingData.java
+++ b/src/main/java/com/checkout/payments/response/ProcessingData.java
@@ -12,50 +12,157 @@ import java.util.List;
 @Data
 public final class ProcessingData {
 
+    /**
+     * The preferred scheme for co-badged card payment processing. If performing 3DS via a third party,
+     * this is the scheme that processed 3DS. Does not support PINless debit schemes in the US
+     * (STAR, PULSE, NYCE, ACCEL, SHAZAM).
+     * [Optional]
+     */
     private PreferredSchema preferredScheme;
 
+    /**
+     * The customer's application identifier.
+     * [Optional]
+     */
     private String appId;
 
+    /**
+     * The customer's ID on the partner platform.
+     * [Optional]
+     */
     private String partnerCustomerId;
 
+    /**
+     * The partner-originated unique payment identifier.
+     * [Optional]
+     */
     private String partnerPaymentId;
 
+    /**
+     * Total tax amount of the order.
+     * [Optional]
+     */
     private Long taxAmount;
 
+    /**
+     * The country where the purchase was made. ISO 3166-1 alpha-2 country code.
+     * Not documented in the public spec for this response, kept for backward compatibility.
+     * [Optional]
+     */
     private CountryCode purchaseCountry;
 
+    /**
+     * The language and region of the customer. ISO 639-2 language code, its value consists of
+     * language-country.
+     * [Optional]
+     * Pattern: ^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}))?$
+     * min 2 characters, max 10 characters
+     */
     private String locale;
 
+    /**
+     * A unique identifier for the authorization provided by partner.
+     * [Optional]
+     */
     private String retrievalReferenceNumber;
 
+    /**
+     * The Klarna order ID associated with the payment.
+     * [Optional]
+     */
     private String partnerOrderId;
 
+    /**
+     * Status of a payment provided by partner.
+     * [Optional]
+     */
     private String partnerStatus;
 
+    /**
+     * Unique transaction identification provided by partner.
+     * [Optional]
+     */
     private String partnerTransactionId;
 
+    /**
+     * The list of error codes that led the payment to fail or be declined, as given by the
+     * payment provider.
+     * [Optional]
+     */
     private List<String> partnerErrorCodes;
 
+    /**
+     * Error description provided by partner.
+     * [Optional]
+     */
     private String partnerErrorMessage;
 
+    /**
+     * Authorization code provided by partner.
+     * [Optional]
+     */
     private String partnerAuthorizationCode;
 
+    /**
+     * Authorization response code provided by partner.
+     * [Optional]
+     */
     private String partnerAuthorizationResponseCode;
 
+    /**
+     * Fraud status of the payment.
+     * Not documented in the public spec for this response, kept for backward compatibility.
+     * Prefer {@code partnerFraudStatus}.
+     * [Optional]
+     */
     private String fraudStatus;
 
+    /**
+     * The payment method authorized by the provider.
+     * Not documented in the public spec for this response, kept for backward compatibility.
+     * [Optional]
+     */
     private ProviderAuthorizedPaymentMethod providerAuthorizedPaymentMethod;
 
+    /**
+     * An array defining which of the configured payment options within a payment category
+     * (for example, {@code pay_later} or {@code pay_over_time}) should be displayed for this purchase.
+     * [Optional]
+     */
     private List<String> customPaymentMethodIds;
 
+    /**
+     * Indicates whether the payment is an Account Funding Transaction.
+     * [Optional]
+     */
     private Boolean aft;
 
+    /**
+     * Four-digit code for retail financial services expressed in ISO 18245 format, classifying
+     * the types of goods or services you provide.
+     * [Optional]
+     */
     private String merchantCategoryCode;
 
+    /**
+     * The merchant identifier that was configured with the scheme and used for the payment.
+     * [Optional]
+     */
     private String schemeMerchantId;
 
+    /**
+     * The type of Primary Account Number (PAN) used for the payment. DPAN indicates a network
+     * token was used, FPAN indicates the full card was used.
+     * [Optional]
+     * Enum: "fpan" "dpan"
+     */
     private PanProcessedType panTypeProcessed;
 
+    /**
+     * Indicates whether a Checkout.com Network Token was available for the payment.
+     * Not documented in the public spec for this response, kept for backward compatibility.
+     * [Optional]
+     */
     private Boolean ckoNetworkTokenAvailable;
 
     /**

--- a/src/test/java/com/checkout/payments/PaymentProcessingSerializationTest.java
+++ b/src/test/java/com/checkout/payments/PaymentProcessingSerializationTest.java
@@ -195,6 +195,7 @@ class PaymentProcessingSerializationTest {
                 + "\"recommendation_code\":\"R001\","
                 + "\"scheme\":\"Mastercard\","
                 + "\"pan_type_processed\":\"fpan\","
+                + "\"fallback_source_used\":true,"
                 + "\"cko_network_token_available\":false,"
                 + "\"purchase_country\":\"GB\","
                 + "\"scheme_merchant_id\":\"SMI001\","
@@ -215,6 +216,7 @@ class PaymentProcessingSerializationTest {
         assertEquals("Acquirer Bank", processing.getAcquirerName());
         assertEquals(CountryCode.GB, processing.getAcquirerCountryCode());
         assertEquals(PanProcessedType.FPAN, processing.getPanTypeProcessed());
+        assertEquals(Boolean.TRUE, processing.getFallbackSourceUsed());
         assertEquals(Boolean.FALSE, processing.getCkoNetworkTokenAvailable());
         assertEquals(CountryCode.GB, processing.getPurchaseCountry());
         assertEquals("SMI001", processing.getSchemeMerchantId());
@@ -222,6 +224,28 @@ class PaymentProcessingSerializationTest {
         assertEquals("biz_001", processing.getBizumPaymentId());
         assertEquals("rec_001", processing.getReconciliationId());
         assertEquals("MTL-XYZ-789", processing.getSchemeTransactionLinkId());
+    }
+
+    @Test
+    void shouldDeserializeFallbackSourceUsed() {
+        final String json = "{\"fallback_source_used\":true}";
+
+        final PaymentProcessing processing = serializer.fromJson(json, PaymentProcessing.class);
+
+        assertNotNull(processing);
+        assertEquals(Boolean.TRUE, processing.getFallbackSourceUsed());
+    }
+
+    @Test
+    void shouldRoundTripFallbackSourceUsed() {
+        final PaymentProcessing processing = new PaymentProcessing();
+        processing.setFallbackSourceUsed(false);
+
+        final String json = serializer.toJson(processing);
+        final PaymentProcessing deserialized = serializer.fromJson(json, PaymentProcessing.class);
+
+        assertTrue(json.contains("\"fallback_source_used\":false"));
+        assertEquals(Boolean.FALSE, deserialized.getFallbackSourceUsed());
     }
 
     @Test


### PR DESCRIPTION
**Summary**

`POST /payments` returns `PaymentResponse.processing`, an inline schema distinct from the `ProcessingData` schema returned by `GET /payments/{id}`. The Java model for the former (`PaymentProcessing`) was complete except for `fallback_source_used`, which this PR adds (INT-1685).

While auditing both models, `ProcessingData` turned out to have JavaDoc on only its last nine properties. The other 23 are documented here from the swagger, so the class is complete per the review-integrity doc-comment rule.

**Changes**
- `src/main/java/com/checkout/payments/PaymentProcessing.java` — added `fallbackSourceUsed`
- `src/main/java/com/checkout/payments/response/ProcessingData.java` — JavaDoc for the 23 previously undocumented properties, including descriptions, constraints (`locale` pattern and length, `pan_type_processed` enum values) and a note on the properties that are not in the public spec but are kept for backward compatibility
- `src/test/java/com/checkout/payments/PaymentProcessingSerializationTest.java` — `fallback_source_used` added to the full swagger-example test, plus a dedicated deserialization test and a round-trip test

**API Reference**
- `POST /payments` — `PaymentResponse.processing` (inline schema)
- `GET /payments/{id}` — `PaymentDetails.processing` (`ProcessingData` schema, documentation only)

**Breaking changes**

None. One new optional response property, plus documentation.

**README**

No impact. The README does not document individual response fields.