### PR TITLE
fix: send articles_of_association as an object, not a bare string

### DIFF
--- a/src/main/java/com/checkout/accounts/ArticlesOfAssociation.java
+++ b/src/main/java/com/checkout/accounts/ArticlesOfAssociation.java
@@ -1,0 +1,33 @@
+package com.checkout.accounts;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Memorandum or articles of association document, supplied when onboarding a sub-entity.
+ *
+ * <p>Required on the company full onboarding variants. The API expects an object carrying the
+ * document type and the uploaded file ID, which is why this class exists: the field on
+ * {@link OnboardSubEntityDocuments} used to be the {@link ArticlesOfAssociationType} enum, so
+ * the SDK serialized a bare string and the API rejected the request.</p>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public final class ArticlesOfAssociation {
+
+    /**
+     * The type of document being used as the memorandum or articles of association.
+     */
+    private ArticlesOfAssociationType type;
+
+    /**
+     * The ID of the front side of the document as represented within Checkout.com systems,
+     * as returned when the file was uploaded.
+     */
+    private String front;
+
+}

--- a/src/main/java/com/checkout/accounts/OnboardSubEntityDocuments.java
+++ b/src/main/java/com/checkout/accounts/OnboardSubEntityDocuments.java
@@ -16,7 +16,7 @@ public final class OnboardSubEntityDocuments {
 
     private CompanyVerification companyVerification;
 
-    private ArticlesOfAssociationType articlesOfAssociation;
+    private ArticlesOfAssociation articlesOfAssociation;
 
     private BankVerification bankVerification;
 

--- a/src/test/java/com/checkout/accounts/OnboardSubEntityDocumentsSerializationTest.java
+++ b/src/test/java/com/checkout/accounts/OnboardSubEntityDocumentsSerializationTest.java
@@ -1,0 +1,85 @@
+package com.checkout.accounts;
+
+import com.checkout.GsonSerializer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the onboarding documents that carry a type plus a file ID.
+ *
+ * <p>articlesOfAssociation was typed as the ArticlesOfAssociationType enum and there was no
+ * ArticlesOfAssociation class, so the SDK serialized {@code "articles_of_association":
+ * "articles_of_association"} where the API requires an object. That document, which is required
+ * on the company full variants, could not be sent from Java at all.</p>
+ */
+class OnboardSubEntityDocumentsSerializationTest {
+
+    private final GsonSerializer serializer = new GsonSerializer();
+
+    @Test
+    void shouldSerializeArticlesOfAssociationAsAnObject() {
+        final OnboardSubEntityDocuments documents = OnboardSubEntityDocuments.builder()
+                .articlesOfAssociation(ArticlesOfAssociation.builder()
+                        .type(ArticlesOfAssociationType.ARTICLES_OF_ASSOCIATION)
+                        .front("file_6lbss42ezvoufcb2beo76rvwly")
+                        .build())
+                .build();
+
+        final String json = serializer.toJson(documents);
+
+        assertTrue(json.contains("\"articles_of_association\":{"), json);
+        assertTrue(json.contains("\"type\":\"articles_of_association\""), json);
+        assertTrue(json.contains("\"front\":\"file_6lbss42ezvoufcb2beo76rvwly\""), json);
+        // The old shape. If this ever comes back, the API rejects the request.
+        assertFalse(json.contains("\"articles_of_association\":\"articles_of_association\""), json);
+    }
+
+    @Test
+    void shouldSerializeMemorandumOfAssociation() {
+        final OnboardSubEntityDocuments documents = OnboardSubEntityDocuments.builder()
+                .articlesOfAssociation(ArticlesOfAssociation.builder()
+                        .type(ArticlesOfAssociationType.MEMORANDUM_OF_ASSOCIATION)
+                        .front("file_6lbss42ezvoufcb2beo76rvwly")
+                        .build())
+                .build();
+
+        assertTrue(serializer.toJson(documents).contains("\"type\":\"memorandum_of_association\""));
+    }
+
+    /**
+     * The sibling documents were already objects. Asserted here so the three stay consistent:
+     * they are the same shape in the API and a future edit should not split them apart again.
+     */
+    @Test
+    void shouldSerializeBankVerificationAndShareholderStructureAsObjects() {
+        final OnboardSubEntityDocuments documents = OnboardSubEntityDocuments.builder()
+                .bankVerification(BankVerification.builder()
+                        .type(BankVerificationType.BANK_STATEMENT)
+                        .front("file_bank")
+                        .build())
+                .shareholderStructure(ShareholderStructure.builder()
+                        .type(ShareholderStructureType.CERTIFIED_SHAREHOLDER_STRUCTURE)
+                        .front("file_shareholder")
+                        .build())
+                .build();
+
+        final String json = serializer.toJson(documents);
+
+        assertTrue(json.contains("\"bank_verification\":{\"type\":\"bank_statement\""), json);
+        assertTrue(json.contains("\"shareholder_structure\":{\"type\":\"certified_shareholder_structure\""), json);
+    }
+
+    @Test
+    void shouldDeserializeArticlesOfAssociation() {
+        final String json = "{\"articles_of_association\":{\"type\":\"articles_of_association\","
+                + "\"front\":\"file_6lbss42ezvoufcb2beo76rvwly\"}}";
+
+        final OnboardSubEntityDocuments documents = serializer.fromJson(json, OnboardSubEntityDocuments.class);
+
+        assertEquals(ArticlesOfAssociationType.ARTICLES_OF_ASSOCIATION, documents.getArticlesOfAssociation().getType());
+        assertEquals("file_6lbss42ezvoufcb2beo76rvwly", documents.getArticlesOfAssociation().getFront());
+    }
+}


### PR DESCRIPTION
## What

`articles_of_association` was being serialized as a bare string instead of an object, so the API rejected it. That document is **required** on the company full onboarding variants, which means it could not be sent from Java at all.

## The bug

`OnboardSubEntityDocuments.articlesOfAssociation` was typed as the enum `ArticlesOfAssociationType`, and no `ArticlesOfAssociation` class existed. The result:

```json
{"articles_of_association": "articles_of_association"}
```

The spec requires an object:

```json
{"articles_of_association": {"type": "articles_of_association", "front": "file_..."}}
```

Its siblings `BankVerification` and `ShareholderStructure` were modelled correctly as objects all along. Only this one was wrong.

Found while verifying an internal report about the `bank_verification` document type, which Java already models correctly.

## Breaking, and why it is still a minor

The field type changes, so this is source-breaking for anyone assigning the enum directly to it. Nobody could have been sending a valid request that way, since the API rejected the old shape, so nothing that worked stops working.

Breaking because the API demands it, not by our choice, so a minor per the release rules. Worth calling out in the release notes.

## Tests

Four tests, including one that asserts the **old string shape is gone**, not merely that the new one is present.

Suite: 2014 tests, 1 failure unrelated to this change — `RefundPaymentsTestIT.shouldRefundTokenPaymentSync` fails with `no_capture_balance_available_to_refund`, a sandbox balance condition in payments.

Refs INT-1691.