### PR TITLE
fix: add merchant_id to the Google Pay enrollment response

### DIFF
--- a/src/main/java/com/checkout/handlepaymentsandpayouts/googlepay/responses/GooglePayEnrollmentResponse.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/googlepay/responses/GooglePayEnrollmentResponse.java
@@ -9,11 +9,23 @@ import java.time.Instant;
 
 /**
  * Response returned when enrolling an entity in Google Pay.
+ *
+ * <p>The real 201 body carries merchant_id, tos_accepted_time and state. The spec declares only
+ * {@code tosAcceptedTime} and {@code state}, with {@code additionalProperties false}, so
+ * {@code merchant_id} was missing here: this class was generated faithfully from a wrong schema.
+ * Reported by a merchant. The spec is being fixed separately; until then this class follows the
+ * live API.</p>
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public final class GooglePayEnrollmentResponse extends HttpMetadata {
+
+    /**
+     * The Google Pay merchant identifier assigned to the entity, needed to initialise Google Pay
+     * on the client. Returned by the API but absent from the spec.
+     */
+    private String merchantId;
 
     /**
      * When the Google terms of service were accepted.

--- a/src/test/java/com/checkout/handlepaymentsandpayouts/googlepay/GooglePaySerializationTest.java
+++ b/src/test/java/com/checkout/handlepaymentsandpayouts/googlepay/GooglePaySerializationTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -146,6 +147,65 @@ class GooglePaySerializationTest {
         assertNotNull(deserialized);
         assertEquals(original.getTosAcceptedTime(), deserialized.getTosAcceptedTime());
         assertEquals(original.getState(), deserialized.getState());
+    }
+
+    /**
+     * The body a real POST /googlepay/enrollments returns in sandbox, which is not what the
+     * swagger example below says: it also carries merchant_id, and the spec omits it while
+     * setting additionalProperties false. A merchant reported the field as missing.
+     */
+    @Test
+    void shouldDeserializeTheRealGooglePayEnrollmentResponse() {
+        String json = "{"
+                + "\"merchant_id\":\"12345678901234567890\","
+                + "\"tos_accepted_time\":\"2026-08-13T09:12:41Z\","
+                + "\"state\":\"ACTIVE\""
+                + "}";
+
+        GooglePayEnrollmentResponse response = serializer.fromJson(json, GooglePayEnrollmentResponse.class);
+
+        assertNotNull(response);
+        assertEquals("12345678901234567890", response.getMerchantId());
+        assertEquals(Instant.parse("2026-08-13T09:12:41Z"), response.getTosAcceptedTime());
+        assertEquals(GooglePayEnrollmentState.ACTIVE, response.getState());
+    }
+
+    /**
+     * merchant_id is what the caller needs to initialise Google Pay on the client, so losing it
+     * is the whole defect. Asserted on its own to make that unmissable.
+     */
+    @Test
+    void shouldNotSilentlyDropMerchantId() {
+        String json = "{"
+                + "\"merchant_id\":\"12345678901234567890\","
+                + "\"tos_accepted_time\":\"2026-08-13T09:12:41Z\","
+                + "\"state\":\"ACTIVE\""
+                + "}";
+
+        assertNotNull(serializer.fromJson(json, GooglePayEnrollmentResponse.class).getMerchantId());
+    }
+
+    /**
+     * A missing merchant_id has to come back null rather than empty: a caller must be able to
+     * tell "not returned" from "returned blank".
+     */
+    @Test
+    void shouldLeaveMerchantIdNullWhenAbsent() {
+        String json = "{\"tos_accepted_time\":\"2026-08-13T09:12:41Z\",\"state\":\"ACTIVE\"}";
+
+        GooglePayEnrollmentResponse response = serializer.fromJson(json, GooglePayEnrollmentResponse.class);
+
+        assertNull(response.getMerchantId());
+        assertEquals(GooglePayEnrollmentState.ACTIVE, response.getState());
+    }
+
+    @Test
+    void shouldSerializeMerchantIdAsSnakeCase() {
+        GooglePayEnrollmentResponse response = new GooglePayEnrollmentResponse();
+        response.setMerchantId("12345678901234567890");
+        response.setState(GooglePayEnrollmentState.ACTIVE);
+
+        assertTrue(serializer.toJson(response).contains("\"merchant_id\":\"12345678901234567890\""));
     }
 
     @Test


### PR DESCRIPTION
## What

Adds `merchant_id` to the Google Pay enrollment response.

Reported internally on behalf of a merchant. `merchant_id` is what the caller needs to initialise Google Pay on the client, so without it the enrollment response is not usable for its purpose.

## The root cause is the spec, not this SDK

`GooglePayEnrollmentResponse` in the spec declares only `tosAcceptedTime` and `state`, both required, omits `merchant_id`, and sets `additionalProperties: false`.

The real 201 from `POST /googlepay/enrollments` returns:

```json
{
  "merchant_id": "12345678901234567890",
  "tos_accepted_time": "2026-08-13T09:12:41Z",
  "state": "ACTIVE"
}
```

The model was generated faithfully from a wrong schema. **The spec fix is being raised separately and is the actual fix**: until it lands, the next regeneration reintroduces this.

## Tests

They deserialize the real sandbox body, not the swagger example, because the swagger example is the thing that was wrong. One test asserts `merchant_id` survives on its own, since losing it is the entire defect, and another asserts an absent `merchant_id` comes back null rather than blank, so a caller can tell "not returned" from "returned empty".

## Not breaking

Purely additive on a response model.

Refs INT-1690.

## Note on the timestamp

`tosAcceptedTime` already worked here: `GsonSerializer` applies `FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES`, so the field matches `tos_accepted_time` on the wire without a `@SerializedName`. Only the missing field needed fixing.

Four new tests, the whole Google Pay serialization suite green.