### PR TITLE
Release 7.16.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.checkout
-version=7.15.0
+version=7.16.0
 
 project_name=Checkout SDK Java
 project_description=Checkout SDK for Java https://checkout.com


### PR DESCRIPTION
- Add merchant_id to the Google Pay enrollment response (#651)
- Send articles_of_association as an object with type and front, instead of a bare string the API rejected, so the document can be sent at all (#650)
- Add fallback_source_used to PaymentProcessing and document ProcessingData (#646)

Note for the release notes: #650 changes the type of `OnboardSubEntityDocuments.articlesOfAssociation` from the `ArticlesOfAssociationType` enum to the new `ArticlesOfAssociation` object. That is source-breaking for anyone assigning the enum directly, but the old shape was rejected by the API, so nothing that worked stops working. Minor, per the rule that an API-forced break is not a major.