### PR TITLE
feature/INT-1693 - Payment sessions default values defect fix

### DIFF
--- a/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionBase.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionBase.java
@@ -1,12 +1,10 @@
 package com.checkout.handlepaymentsandpayouts.flow.requests;
 
 import com.checkout.payments.ProductRequest;
-import com.checkout.payments.PaymentType;
 import com.checkout.payments.ThreeDSRequest;
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -51,12 +49,4 @@ public abstract class PaymentSessionBase {
      */
     @SerializedName("3ds")
     private ThreeDSRequest threeDS;
-
-    /**
-     * Must be specified for card-not-present (CNP) payments. Default: "Regular"
-     * [Optional]
-     * Enum: "Regular" "Recurring" "MOTO" "Installment" "PayLater" "Unscheduled"
-     */
-    @Builder.Default
-    private PaymentType paymentType = PaymentType.REGULAR;
 }

--- a/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionCompleteRequest.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionCompleteRequest.java
@@ -1,8 +1,6 @@
 package com.checkout.handlepaymentsandpayouts.flow.requests;
 
-import com.checkout.payments.LocaleType;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -16,20 +14,13 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public final class PaymentSessionCompleteRequest extends PaymentSessionInfo {
-
-    /**
-     * Creates a translated version of the page in the specified language. Default: "en-GB"
-     * [Optional]
-     */
-    @Builder.Default
-    private LocaleType locale = LocaleType.EN_GB;
+public final class PaymentSessionCompleteRequest extends PaymentSessionCreateBase {
 
     /**
      * A unique token representing the additional customer data captured by Flow,
      * as received from the handleSubmit callback.
      * Do not log or store this value.
-     * [Optional]
+     * [Required]
      */
     private String sessionData;
 }

--- a/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionCreateBase.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionCreateBase.java
@@ -1,0 +1,89 @@
+package com.checkout.handlepaymentsandpayouts.flow.requests;
+
+import com.checkout.payments.AuthorizationType;
+import com.checkout.payments.LocaleType;
+import com.checkout.payments.PaymentPlan;
+import com.checkout.payments.PaymentType;
+import com.checkout.payments.RiskRequest;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Base class for the payment session requests that create a session.
+ *
+ * The fields declared here are accepted only when a payment session is created, either by
+ * Request a Payment Session (POST /payment-sessions) or by Request a Payment Session with
+ * Payment (POST /payment-sessions/complete). They are not accepted by Submit a Payment
+ * Session (POST /payment-sessions/{id}/submit), which is why PaymentSessionSubmitRequest
+ * does not extend this class.
+ *
+ * The defaults declared here mirror the API defaults, so a request that omits them behaves
+ * the same whether or not the SDK sends them.
+ */
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public abstract class PaymentSessionCreateBase extends PaymentSessionInfo {
+
+    /**
+     * Specifies whether to capture the payment, if applicable. Default: true
+     * [Optional]
+     */
+    @Builder.Default
+    private Boolean capture = true;
+
+    /**
+     * Must be specified for card-not-present (CNP) payments. Default: "Regular"
+     * [Optional]
+     * Enum: "Regular" "Recurring" "MOTO" "Installment" "Unscheduled"
+     */
+    @Builder.Default
+    private PaymentType paymentType = PaymentType.REGULAR;
+
+    /**
+     * Creates a translated version of the page in the specified language. Default: "en-GB"
+     * [Optional]
+     */
+    @Builder.Default
+    private LocaleType locale = LocaleType.EN_GB;
+
+    /**
+     * The authorization type.
+     * [Optional]
+     * Enum: "Final" "Estimated"
+     * Default: "Final"
+     */
+    private AuthorizationType authorizationType;
+
+    /**
+     * A description for the payment.
+     * [Optional]
+     * max 100 characters
+     */
+    private String description;
+
+    /**
+     * The merchant's display name.
+     * [Optional]
+     * max 255 characters
+     */
+    private String displayName;
+
+    /**
+     * The information to process a recurring payment request. To be used when the payment_type is Recurring.
+     * [Optional]
+     */
+    private PaymentPlan paymentPlan;
+
+    /**
+     * Configures the risk assessment performed during payment processing.
+     * [Optional]
+     */
+    private RiskRequest risk;
+}

--- a/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionCreateRequest.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionCreateRequest.java
@@ -3,9 +3,7 @@ package com.checkout.handlepaymentsandpayouts.flow.requests;
 import com.checkout.common.PaymentMethodType;
 import com.checkout.handlepaymentsandpayouts.flow.entities.CustomerRetry;
 import com.checkout.handlepaymentsandpayouts.flow.entities.PaymentMethodConfiguration;
-import com.checkout.payments.LocaleType;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -22,14 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public final class PaymentSessionCreateRequest extends PaymentSessionInfo {
-
-    /**
-     * Creates a translated version of the page in the specified language. Default: "en-GB"
-     * [Optional]
-     */
-    @Builder.Default
-    private LocaleType locale = LocaleType.EN_GB;
+public final class PaymentSessionCreateRequest extends PaymentSessionCreateBase {
 
     /**
      * A timestamp specifying when the PaymentSession should expire, as an ISO 8601 code.

--- a/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionInfo.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionInfo.java
@@ -2,19 +2,15 @@ package com.checkout.handlepaymentsandpayouts.flow.requests;
 
 import com.checkout.common.Currency;
 import com.checkout.handlepaymentsandpayouts.flow.entities.Customer;
-import com.checkout.payments.AuthorizationType;
 import com.checkout.payments.BillingInformation;
 import com.checkout.payments.ShippingDetails;
 import com.checkout.payments.BillingDescriptor;
-import com.checkout.payments.PaymentPlan;
 import com.checkout.payments.PaymentRecipient;
 import com.checkout.payments.ProcessingSettings;
 import com.checkout.payments.PaymentInstruction;
 import com.checkout.common.AmountAllocations;
-import com.checkout.payments.RiskRequest;
 import com.checkout.payments.sender.PaymentSender;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -25,7 +21,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Extended base class for payment session requests that include full payment details
+ * Extended base class for payment session requests that include full payment details.
+ *
+ * This class holds only the fields that every payment session request accepts, whether it
+ * creates a session or submits a payment attempt for an existing one. Fields that only the
+ * session creation endpoints accept live in PaymentSessionCreateBase.
  */
 @Data
 @SuperBuilder
@@ -70,12 +70,6 @@ public abstract class PaymentSessionInfo extends PaymentSessionBase {
     private BillingDescriptor billingDescriptor;
 
     /**
-     * A description for the payment.
-     * [Optional]
-     */
-    private String description;
-
-    /**
      * The customer's details. Required if source.type is tamara.
      * [Optional]
      */
@@ -115,20 +109,9 @@ public abstract class PaymentSessionInfo extends PaymentSessionBase {
     /**
      * The sub-entities that the payment is being processed on behalf of.
      * [Optional]
+     * min 1 max 50 items
      */
     private List<AmountAllocations> amountAllocations;
-
-    /**
-     * Configures the risk assessment performed during payment processing.
-     * [Optional]
-     */
-    private RiskRequest risk;
-
-    /**
-     * The merchant's display name.
-     * [Optional]
-     */
-    private String displayName;
 
     /**
      * Allows you to store additional information about a transaction with custom fields.
@@ -143,31 +126,10 @@ public abstract class PaymentSessionInfo extends PaymentSessionBase {
     private PaymentSender sender;
 
     /**
-     * Specifies whether to capture the payment, if applicable. Default: true
-     * [Optional]
-     */
-    @Builder.Default
-    private Boolean capture = true;
-
-    /**
      * A timestamp specifying when to capture the payment, as an ISO 8601 code.
-     * If a value is provided, capture is automatically set to true.
+     * If a value is provided, capture is automatically set to true by the API.
      * [Optional]
      * Format: date-time (ISO 8601)
      */
     private Instant captureOn;
-
-    /**
-     * The authorization type.
-     * [Optional]
-     * Enum: "Final" "Estimated"
-     * Default: "Final"
-     */
-    private AuthorizationType authorizationType;
-
-    /**
-     * The information to process a recurring payment request. To be used when the payment_type is Recurring.
-     * [Optional]
-     */
-    private PaymentPlan paymentPlan;
 }

--- a/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionSubmitRequest.java
+++ b/src/main/java/com/checkout/handlepaymentsandpayouts/flow/requests/PaymentSessionSubmitRequest.java
@@ -1,6 +1,7 @@
 package com.checkout.handlepaymentsandpayouts.flow.requests;
 
 import com.checkout.handlepaymentsandpayouts.flow.entities.PaymentMethodConfiguration;
+import com.checkout.payments.PaymentType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,6 +13,10 @@ import lombok.experimental.SuperBuilder;
  *
  * This request works with the Flow handleSubmit callback, where you can perform a customized payment submission.
  * You must send the unmodified response body as the response of the handleSubmit callback.
+ *
+ * Every field is optional except sessionData. A field you do not set is omitted from the request
+ * body, which leaves the value provided when the payment session was created untouched. This is
+ * why capture and paymentType carry no default here, unlike on the session creation requests.
  */
 @Data
 @SuperBuilder
@@ -24,9 +29,26 @@ public final class PaymentSessionSubmitRequest extends PaymentSessionInfo {
      * A unique token representing the additional customer data captured by Flow,
      * as received from the handleSubmit callback.
      * Do not log or store this value.
-     * [Optional]
+     * [Required]
      */
     private String sessionData;
+
+    /**
+     * Specifies whether to capture the payment, if applicable.
+     * Leave this field unset to keep the value provided when the payment session was created.
+     * If it was not provided then either, the API applies its default of true.
+     * [Optional]
+     */
+    private Boolean capture;
+
+    /**
+     * Must be specified for card-not-present (CNP) payments.
+     * Leave this field unset to keep the value provided when the payment session was created.
+     * If it was not provided then either, the API applies its default of "Regular".
+     * [Optional]
+     * Enum: "Regular" "Recurring" "MOTO" "Installment" "Unscheduled"
+     */
+    private PaymentType paymentType;
 
     /**
      * Configurations for payment method-specific settings.

--- a/src/test/java/com/checkout/handlepaymentsandpayouts/flow/FlowLocaleAndStatusDeserializationTest.java
+++ b/src/test/java/com/checkout/handlepaymentsandpayouts/flow/FlowLocaleAndStatusDeserializationTest.java
@@ -54,7 +54,7 @@ class FlowLocaleAndStatusDeserializationTest {
                 .reference("order-002")
                 .sessionData("sd_tok_xyz789")
                 .capture(true)
-                .description("Full submit request")
+                .processingChannelId("pc_abcdefghijklmnopqrstuvwxyz")
                 .build();
 
         String json = serializer.toJson(request);

--- a/src/test/java/com/checkout/handlepaymentsandpayouts/flow/PaymentSessionCaptureDefaultsTest.java
+++ b/src/test/java/com/checkout/handlepaymentsandpayouts/flow/PaymentSessionCaptureDefaultsTest.java
@@ -1,0 +1,242 @@
+package com.checkout.handlepaymentsandpayouts.flow;
+
+import com.checkout.GsonSerializer;
+import com.checkout.common.Currency;
+import com.checkout.handlepaymentsandpayouts.flow.requests.PaymentSessionCompleteRequest;
+import com.checkout.handlepaymentsandpayouts.flow.requests.PaymentSessionCreateRequest;
+import com.checkout.handlepaymentsandpayouts.flow.requests.PaymentSessionSubmitRequest;
+import com.checkout.payments.AmountVariabilityType;
+import com.checkout.payments.AuthorizationType;
+import com.checkout.payments.LocaleType;
+import com.checkout.payments.PaymentPlan;
+import com.checkout.payments.PaymentType;
+import com.checkout.payments.RiskRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the capture and payment_type defaults on the Flow payment session requests.
+ *
+ * The session creation requests (POST /payment-sessions and POST /payment-sessions/complete) must
+ * keep sending the API defaults, because the caller is supplying the payment's values in that same
+ * call. The submit request (POST /payment-sessions/{id}/submit) must send neither field unless the
+ * caller sets it, because any value present in the submit body is applied to the payment attempt
+ * and would overwrite the value provided when the payment session was created.
+ */
+class PaymentSessionCaptureDefaultsTest {
+
+    private final GsonSerializer serializer = new GsonSerializer();
+
+    // ---------------------------------------------------------------
+    //  Submit: nothing is sent unless the caller sets it
+    // ---------------------------------------------------------------
+
+    @Test
+    void submitRequestBuiltWithBuilderShouldOnlySerializeSessionData() {
+        PaymentSessionSubmitRequest request = PaymentSessionSubmitRequest.builder()
+                .sessionData("SD")
+                .build();
+
+        assertEquals("{\"session_data\":\"SD\"}", serializer.toJson(request));
+    }
+
+    @Test
+    void submitRequestBuiltWithNoArgsConstructorShouldOnlySerializeSessionData() {
+        PaymentSessionSubmitRequest request = new PaymentSessionSubmitRequest();
+        request.setSessionData("SD");
+
+        assertEquals("{\"session_data\":\"SD\"}", serializer.toJson(request));
+    }
+
+    @Test
+    void submitRequestShouldLeaveCaptureAndPaymentTypeNullWhenNotSet() {
+        PaymentSessionSubmitRequest fromBuilder = PaymentSessionSubmitRequest.builder()
+                .sessionData("SD")
+                .build();
+        PaymentSessionSubmitRequest fromConstructor = new PaymentSessionSubmitRequest();
+
+        assertNull(fromBuilder.getCapture(), "capture must not be defaulted on the submit request");
+        assertNull(fromBuilder.getPaymentType(), "payment_type must not be defaulted on the submit request");
+        assertNull(fromConstructor.getCapture(), "capture must not be defaulted by the no-args constructor");
+        assertNull(fromConstructor.getPaymentType(), "payment_type must not be defaulted by the no-args constructor");
+    }
+
+    // ---------------------------------------------------------------
+    //  Submit: both fields remain usable when the caller wants them
+    // ---------------------------------------------------------------
+
+    @Test
+    void submitRequestShouldSerializeCaptureFalseWhenExplicitlySet() {
+        PaymentSessionSubmitRequest request = PaymentSessionSubmitRequest.builder()
+                .sessionData("SD")
+                .capture(false)
+                .build();
+
+        String json = serializer.toJson(request);
+
+        assertTrue(json.contains("\"capture\":false"), "an explicit capture of false must be sent");
+    }
+
+    @Test
+    void submitRequestShouldSerializeCaptureTrueAndPaymentTypeWhenExplicitlySet() {
+        PaymentSessionSubmitRequest request = PaymentSessionSubmitRequest.builder()
+                .sessionData("SD")
+                .capture(true)
+                .paymentType(PaymentType.RECURRING)
+                .build();
+
+        String json = serializer.toJson(request);
+
+        assertTrue(json.contains("\"capture\":true"), "an explicit capture of true must be sent");
+        assertTrue(json.contains("\"payment_type\":\"Recurring\""), "an explicit payment_type must be sent");
+    }
+
+    @Test
+    void submitRequestShouldRoundTripEveryLocalField() {
+        PaymentSessionSubmitRequest original = PaymentSessionSubmitRequest.builder()
+                .sessionData("SD")
+                .capture(false)
+                .paymentType(PaymentType.MOTO)
+                .amount(2500L)
+                .currency(Currency.USD)
+                .reference("ORD-456")
+                .processingChannelId("pc_abcdefghijklmnopqrstuvwxyz")
+                .build();
+
+        PaymentSessionSubmitRequest roundTripped =
+                serializer.fromJson(serializer.toJson(original), PaymentSessionSubmitRequest.class);
+
+        assertEquals("SD", roundTripped.getSessionData());
+        assertEquals(false, roundTripped.getCapture());
+        assertEquals(PaymentType.MOTO, roundTripped.getPaymentType());
+        assertEquals(2500L, roundTripped.getAmount());
+        assertEquals(Currency.USD, roundTripped.getCurrency());
+        assertEquals("ORD-456", roundTripped.getReference());
+        assertEquals("pc_abcdefghijklmnopqrstuvwxyz", roundTripped.getProcessingChannelId());
+    }
+
+    @Test
+    void submitRequestShouldNotSerializeSessionCreationOnlyFields() {
+        PaymentSessionSubmitRequest request = PaymentSessionSubmitRequest.builder()
+                .sessionData("SD")
+                .amount(1000L)
+                .currency(Currency.GBP)
+                .capture(true)
+                .paymentType(PaymentType.REGULAR)
+                .build();
+
+        String json = serializer.toJson(request);
+
+        assertFalse(json.contains("\"locale\""), "locale is not accepted by the submit endpoint");
+        assertFalse(json.contains("\"description\""), "description is not accepted by the submit endpoint");
+        assertFalse(json.contains("\"display_name\""), "display_name is not accepted by the submit endpoint");
+        assertFalse(json.contains("\"authorization_type\""), "authorization_type is not accepted by the submit endpoint");
+        assertFalse(json.contains("\"payment_plan\""), "payment_plan is not accepted by the submit endpoint");
+        assertFalse(json.contains("\"risk\""), "risk is not accepted by the submit endpoint");
+    }
+
+    // ---------------------------------------------------------------
+    //  Create: the defaults are kept
+    // ---------------------------------------------------------------
+
+    @Test
+    void createRequestShouldSerializeTheApiDefaults() {
+        PaymentSessionCreateRequest request = PaymentSessionCreateRequest.builder()
+                .amount(1000L)
+                .currency(Currency.GBP)
+                .build();
+
+        String json = serializer.toJson(request);
+
+        assertTrue(json.contains("\"capture\":true"), "create must keep the capture default");
+        assertTrue(json.contains("\"payment_type\":\"Regular\""), "create must keep the payment_type default");
+        assertTrue(json.contains("\"locale\":\"en-GB\""), "create must keep the locale default");
+    }
+
+    @Test
+    void completeRequestShouldSerializeTheApiDefaults() {
+        PaymentSessionCompleteRequest request = PaymentSessionCompleteRequest.builder()
+                .sessionData("SD")
+                .amount(2000L)
+                .currency(Currency.USD)
+                .build();
+
+        String json = serializer.toJson(request);
+
+        assertTrue(json.contains("\"capture\":true"), "complete must keep the capture default");
+        assertTrue(json.contains("\"payment_type\":\"Regular\""), "complete must keep the payment_type default");
+        assertTrue(json.contains("\"locale\":\"en-GB\""), "complete must keep the locale default");
+    }
+
+    @Test
+    void createRequestShouldStillAllowOverridingTheDefaults() {
+        PaymentSessionCreateRequest request = PaymentSessionCreateRequest.builder()
+                .amount(1000L)
+                .currency(Currency.GBP)
+                .capture(false)
+                .paymentType(PaymentType.UNSCHEDULED)
+                .locale(LocaleType.FR_FR)
+                .build();
+
+        String json = serializer.toJson(request);
+
+        assertTrue(json.contains("\"capture\":false"));
+        assertTrue(json.contains("\"payment_type\":\"Unscheduled\""));
+        assertTrue(json.contains("\"locale\":\"fr-FR\""));
+    }
+
+    @Test
+    void createRequestShouldRoundTripEverySessionCreationOnlyField() {
+        PaymentSessionCreateRequest original = PaymentSessionCreateRequest.builder()
+                .capture(false)
+                .paymentType(PaymentType.INSTALLMENT)
+                .locale(LocaleType.DE_DE)
+                .authorizationType(AuthorizationType.ESTIMATED)
+                .description("Payment for gold necklace")
+                .displayName("Example Store")
+                .paymentPlan(PaymentPlan.builder()
+                        .amountVariabilityType(AmountVariabilityType.FIXED)
+                        .daysBetweenPayments(28)
+                        .build())
+                .risk(RiskRequest.builder()
+                        .enabled(false)
+                        .build())
+                .build();
+
+        PaymentSessionCreateRequest roundTripped =
+                serializer.fromJson(serializer.toJson(original), PaymentSessionCreateRequest.class);
+
+        assertEquals(false, roundTripped.getCapture());
+        assertEquals(PaymentType.INSTALLMENT, roundTripped.getPaymentType());
+        assertEquals(LocaleType.DE_DE, roundTripped.getLocale());
+        assertEquals(AuthorizationType.ESTIMATED, roundTripped.getAuthorizationType());
+        assertEquals("Payment for gold necklace", roundTripped.getDescription());
+        assertEquals("Example Store", roundTripped.getDisplayName());
+        assertEquals(AmountVariabilityType.FIXED, roundTripped.getPaymentPlan().getAmountVariabilityType());
+        assertEquals(28, roundTripped.getPaymentPlan().getDaysBetweenPayments());
+        assertEquals(false, roundTripped.getRisk().getEnabled());
+    }
+
+    // ---------------------------------------------------------------
+    //  The documented submit example from the API reference
+    // ---------------------------------------------------------------
+
+    @Test
+    void shouldDeserializeTheDocumentedSubmitExample() {
+        String json = "{"
+                + "\"session_data\":\"{SESSION_DATA_FROM_FLOW}\","
+                + "\"3ds\":{\"enabled\":true}"
+                + "}";
+
+        PaymentSessionSubmitRequest request = serializer.fromJson(json, PaymentSessionSubmitRequest.class);
+
+        assertEquals("{SESSION_DATA_FROM_FLOW}", request.getSessionData());
+        assertTrue(request.getThreeDS().getEnabled());
+        assertNull(request.getCapture(), "the documented example does not carry capture");
+        assertNull(request.getPaymentType(), "the documented example does not carry payment_type");
+    }
+}


### PR DESCRIPTION
This pull request fixes a defect in the payment sessions default values, refactors and clarifies the structure of payment session request classes, separating fields that are specific to session creation from those shared by all requests. It introduces a new base class, `PaymentSessionCreateBase`, to hold fields relevant only to session creation endpoints, and moves or removes several fields from other classes for better organization and alignment with API behavior. The changes also improve documentation and clarify which fields are required or optional in each context.

**Class hierarchy and structure refactoring:**

* Introduced a new abstract base class, `PaymentSessionCreateBase`, which contains fields that are only accepted when creating a payment session (e.g., `capture`, `paymentType`, `locale`, `authorizationType`, `description`, `displayName`, `paymentPlan`, `risk`). This class is now the parent for both `PaymentSessionCreateRequest` and `PaymentSessionCompleteRequest`, ensuring these fields are only present where appropriate.
* Updated `PaymentSessionInfo` to remove fields that are now in `PaymentSessionCreateBase`, and clarified its role as holding only fields shared by all payment session requests. Improved class-level documentation to reflect this separation. [[1]](diffhunk://#diff-0fe60fb620a42c06b6064c12ab6cd10f92e5516a58d63288966dd90b4e78fccbL28-R28) [[2]](diffhunk://#diff-0fe60fb620a42c06b6064c12ab6cd10f92e5516a58d63288966dd90b4e78fccbL72-L77) [[3]](diffhunk://#diff-0fe60fb620a42c06b6064c12ab6cd10f92e5516a58d63288966dd90b4e78fccbR112-L132) [[4]](diffhunk://#diff-0fe60fb620a42c06b6064c12ab6cd10f92e5516a58d63288966dd90b4e78fccbL145-L172)

**Request class adjustments:**

* Changed `PaymentSessionCreateRequest` and `PaymentSessionCompleteRequest` to extend the new `PaymentSessionCreateBase` instead of `PaymentSessionInfo`, and removed duplicated fields now inherited from the new base class. [[1]](diffhunk://#diff-61ad0790471bea4c725dff7d4b0de0689a14e39b3392dc1a78c7726ac98bf1c6L25-R23) [[2]](diffhunk://#diff-ab9930e4f1af6784ab8b2cfd54239645847ac508ecbf7f5b24e32a9959f0fa10L19-R23)
* Updated `PaymentSessionSubmitRequest` to allow optional overriding of `capture` and `paymentType`, with clear documentation that leaving these fields unset preserves the values from session creation (or defaults). Also clarified that only `sessionData` is required. [[1]](diffhunk://#diff-462798be46d92649c7cbfaa6437a1d0ed387622126e158f4595f4294dbe13ed6R16-R19) [[2]](diffhunk://#diff-462798be46d92649c7cbfaa6437a1d0ed387622126e158f4595f4294dbe13ed6L27-R52)

**Documentation and code cleanup:**

* Improved and clarified Javadoc comments throughout the affected classes, specifying field requirements, default behaviors, and the intended use of each class. [[1]](diffhunk://#diff-d6f5d99bd176e3903e7ee1341a57935dfcf6fca892a9b19525d02442336b09b7R1-R89) [[2]](diffhunk://#diff-0fe60fb620a42c06b6064c12ab6cd10f92e5516a58d63288966dd90b4e78fccbL28-R28) [[3]](diffhunk://#diff-462798be46d92649c7cbfaa6437a1d0ed387622126e158f4595f4294dbe13ed6R16-R19)
* Removed unused imports and redundant annotations from affected files for code clarity. [[1]](diffhunk://#diff-78db8b59f0dbc7931b0e84c4d2093728a855b4ed9f7bb363625d260753c0ddb7L4-L9) [[2]](diffhunk://#diff-ab9930e4f1af6784ab8b2cfd54239645847ac508ecbf7f5b24e32a9959f0fa10L3-L5) [[3]](diffhunk://#diff-61ad0790471bea4c725dff7d4b0de0689a14e39b3392dc1a78c7726ac98bf1c6L6-L8) [[4]](diffhunk://#diff-0fe60fb620a42c06b6064c12ab6cd10f92e5516a58d63288966dd90b4e78fccbL5-L17)

**Test updates:**

* Updated a test in `FlowLocaleAndStatusDeserializationTest` to reflect the refactored request structure, ensuring correct serialization after the changes.