### PR TITLE
feat(payments): add optional amount to VoidRequest for partial voids

### DIFF
--- a/src/main/java/com/checkout/payments/VoidRequest.java
+++ b/src/main/java/com/checkout/payments/VoidRequest.java
@@ -14,6 +14,12 @@ import java.util.Map;
 @AllArgsConstructor
 public final class VoidRequest {
 
+    /**
+     * The amount to void. If not specified, the full payment amount is voided.
+     * Integer, min 0, max 9999999999.
+     */
+    private Long amount;
+
     private String reference;
 
     @Builder.Default

--- a/src/test/java/com/checkout/payments/VoidRequestSchemaTest.java
+++ b/src/test/java/com/checkout/payments/VoidRequestSchemaTest.java
@@ -1,0 +1,100 @@
+package com.checkout.payments;
+
+import com.checkout.GsonSerializer;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Schema validation tests for VoidRequest.
+ * Validates serialization and field completeness against swagger, in
+ * particular the optional amount field (partial voids, swagger 2026-08-13):
+ * when amount is not set it must be absent from the JSON body, because a
+ * null or zero amount leaking in would turn a full void into a zero-amount void.
+ */
+class VoidRequestSchemaTest {
+
+    private final GsonSerializer serializer = new GsonSerializer();
+
+    @Test
+    void shouldSerializeWithAllFields() {
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put("coupon_code", "NY2018");
+
+        final VoidRequest request = VoidRequest.builder()
+                .amount(6540L)
+                .reference("ORD-5023-4E89")
+                .metadata(metadata)
+                .build();
+
+        assertDoesNotThrow(() -> {
+            final String json = serializer.toJson(request);
+            assertNotNull(json);
+            assertTrue(json.contains("\"amount\":6540"));
+            assertTrue(json.contains("\"reference\":\"ORD-5023-4E89\""));
+            assertTrue(json.contains("\"coupon_code\":\"NY2018\""));
+        });
+    }
+
+    @Test
+    void shouldOmitAmountWhenNotSet() {
+        final VoidRequest request = VoidRequest.builder()
+                .reference("ORD-5023-4E89")
+                .build();
+
+        final String json = serializer.toJson(request);
+        assertNotNull(json);
+        assertFalse(json.contains("amount"));
+    }
+
+    @Test
+    void shouldDeserializeFromSwaggerExample() {
+        final String json = "{\"amount\":6540,\"reference\":\"ORD-5023-4E89\",\"metadata\":{\"coupon_code\":\"NY2018\"}}";
+
+        final VoidRequest request = serializer.fromJson(json, VoidRequest.class);
+        assertNotNull(request);
+        assertEquals(Long.valueOf(6540L), request.getAmount());
+        assertEquals("ORD-5023-4E89", request.getReference());
+        assertEquals("NY2018", request.getMetadata().get("coupon_code"));
+    }
+
+    @Test
+    void shouldRoundTripSerialize() {
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put("partner_id", "123989");
+
+        final VoidRequest original = VoidRequest.builder()
+                .amount(1L)
+                .reference("REF-1")
+                .metadata(metadata)
+                .build();
+
+        final String json = serializer.toJson(original);
+        final VoidRequest deserialized = serializer.fromJson(json, VoidRequest.class);
+
+        assertEquals(original.getAmount(), deserialized.getAmount());
+        assertEquals(original.getReference(), deserialized.getReference());
+        assertEquals(original.getMetadata(), deserialized.getMetadata());
+    }
+
+    @Test
+    void shouldRoundTripWithoutAmountAsFullVoid() {
+        final VoidRequest original = VoidRequest.builder()
+                .reference("REF-FULL-VOID")
+                .build();
+
+        final String json = serializer.toJson(original);
+        final VoidRequest deserialized = serializer.fromJson(json, VoidRequest.class);
+
+        assertNull(deserialized.getAmount());
+        assertEquals("REF-FULL-VOID", deserialized.getReference());
+    }
+}


### PR DESCRIPTION
**Summary**
Adds the optional `amount` field to the payment void request, introduced in the API spec on 2026-08-13. When set, only that amount is voided; when omitted, the full payment amount is voided, exactly as before.

**Changes**
- Void request model: new optional `amount` (integer, min 0, max 9999999999) with doc comment
- Serialization tests: amount present when set, and absent from the body when unset, so existing full-void callers keep sending an identical payload

**API Reference**
- `POST /payments/{id}/voids` (`VoidRequest.amount`)

**Breaking changes**
None.

**README**
No README impact.