### PR TITLE
Release 8.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.checkout
-version=7.16.2
+version=8.0.0
 
 project_name=Checkout SDK Java
 project_description=Checkout SDK for Java https://checkout.com


### PR DESCRIPTION
- The merchant-specific subdomain (environmentSubdomain) is now required. Set it, or call the deprecated useLegacyDomain() to keep using the shared checkout.com hosts (#649)
- An invalid subdomain now throws instead of being silently ignored (#649)
- Add optional amount to VoidRequest to support partial voids (#658)
- Add the ISV (SaaS seller) payout schedule fields balanceMinimum, carryForwardEnabled and paymentInstrumentId (#653)